### PR TITLE
Create a local copy of layouts when importing a new theme.

### DIFF
--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -27,6 +27,11 @@ exports.ThemeImporter = class {
         `${this.config.dirs.config}/global_config.json`);
       this._copyStaticAssets(localPath);
 
+      const layoutsPath = `${localPath}/layouts`;
+      if (fs.existsSync(layoutsPath)) {
+        fs.copySync(layoutsPath, `${this.config.dirs.partials}/layouts`);
+      }
+      
       return localPath;
     } catch (error) {
       return Promise.reject(error.toString());


### PR DESCRIPTION
This PR updates ThemeImporter to create a copy of the theme's layouts, if they exist, in the root-level partials directory. From here, client's can alter the local copy of the layouts if they wish.

TEST=manual