### PR TITLE
Fix bug in the SitesGenerator#_registerAllPartials method.

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -81,7 +81,7 @@ exports.SitesGenerator = class {
     const { partials, themes, overrides, cards } = dirs;
     // If a theme is specified, register partials and overrides from it.
     if (defaultTheme) {
-      for (const dir in [themes, overrides]) {
+      for (const dir of [themes, overrides]) {
         this._registerPartials(path.resolve(dir, defaultTheme));
       }
       this._registerPartials(cards);


### PR DESCRIPTION
This fixes a bug in the SitesGenerator's _registerAllPartials method. The for loop was using 'in', instead of 'of', and this resulted in an attempt to register partials from the incorrect directories.

TEST=manual

Made sure Jambo build worked after an init and page command.