### PR TITLE
Support the execution of custom shell scripts specified by a Theme.

### DIFF
--- a/src/utils/customcommands/command.js
+++ b/src/utils/customcommands/command.js
@@ -3,39 +3,10 @@
  * of a built-in Jambo command. These shell commands are supplied by Themes.
  */
 exports.CustomCommand = class {
-    constructor({ file, args, cwd }) {
-        this._file = file;
-        this._fileType = file.split('.').pop();
+    constructor({ executable, args, cwd }) {
+        this._executable = executable;
         this._args = args || [];
         this._cwd = cwd;
-    }
-
-    /**
-     * Returns the {@link CustomCommand} as a string. The string matches exactly
-     * what someone would type into the shell to run the command.
-     * 
-     * @returns {string} The stringified {@link CustomCommand}.
-     */
-    toString() {
-        const argReducer = (argsString, currentArgs) => {
-            const [name, value] = currentArgs;
-            return argsString.concat(` ${name}=${value}`);
-        };
-        const parsedArgs = this._args.reduce(argReducer, '');
-
-        let commandPrefix;
-        switch (this._fileType) {
-            case 'js':
-                commandPrefix = `node ${this._file}`;
-                break;
-            case 'sh':
-                commandPrefix = `./${this._file}`;
-                break;
-            default:
-                throw 'Unsupported file type';
-        }
-
-        return `${commandPrefix} ${parsedArgs}`;
     }
 
     /**
@@ -58,12 +29,12 @@ exports.CustomCommand = class {
     }
 
     /**
-     * Returns the file name of the executable.
+     * Returns the executable to be invoked.
      * 
-     * @returns {string} The name of the executable.
+     * @returns {string} The executable.
      */
-    getFile() {
-        return this._file;
+    getExecutable() {
+        return this._executable;
     }
 
     /**


### PR DESCRIPTION
This PR allows themes to specify a custom shell script to execute as part of
a Jambo command. Currently, the convention is that the Theme must keep these
scripts in a top-level directory called 'scripts'. Each script must have one
of the following names: addPage.sh, build.sh, override.sh, import.sh, or
init.sh. The names indicate to Jambo which script to run as part of which
command.

Jambo will make available certain variables to these scripts. Almost all of the
Jambo directories can be referenced as variables in a script. Jambo will also
make the arguments provided to a command available to the corresponding script
as variables (i.e. $PAGE_NAME in addPage.sh).

As part of this PR, I've updated only the add page command to support running
a custom shell script. Once this PR is merged, I will update the other commands
as well. Once all the commands can execute a Theme's custom script, I will
migrate a lot of the ThemeImporter logic into an import.sh for the HH Theme.

TEST=manual

Tested with a simple script that I added to the HH Theme to be run when Jambo
creates a new page.