### PR TITLE
Error Handling: Error if global config file not found

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -19,6 +19,13 @@ exports.SitesGenerator = class {
       }
     })
 
+    const globalConfigName = 'global_config';
+
+    if (!pagesConfig[globalConfigName]) {
+      console.error(`Error: Cannot find ${globalConfigName} file in '` + config.dirs.config + '/\' directory, exiting.');
+      return;
+    }
+
     // Register needed Handlebars helpers.
     this._registerHelpers();
 
@@ -26,7 +33,7 @@ exports.SitesGenerator = class {
     this._registerAllPartials(config);
 
     const verticalConfigs = Object.keys(pagesConfig).reduce((object, key) => {
-      if (key !== 'global_config') {
+      if (key !== globalConfigName) {
         object[key] = pagesConfig[key];
       }
       return object;
@@ -39,7 +46,7 @@ exports.SitesGenerator = class {
           pagesConfig[pageId],
           {
             verticalConfigs,
-            global_config: pagesConfig['global_config'],
+            global_config: pagesConfig[globalConfigName],
             relativePath: this._calculateRelativePath(path)
           });
       const pageLayout = pageConfig.layout;


### PR DESCRIPTION
Prints this error message: `Error: Cannot find global_config file in 'config/' directory, exiting.`