### PR TITLE
Create a 'card' command to add new, custom cards.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,7 @@ const buildCommand = require('./commands/build/sitesgenerator');
 const addPageCommand = require('./commands/page/add/pagescaffolder');
 const overrideCommand = require('./commands/override/themeshadower');
 const themeCommand = require('./commands/import/themeimporter');
+const addCardCommand = require('./commands/card/cardcreator');
 const configParser = require('./utils/jamboconfigparser');
 const yargs = require('yargs');
 const fs = require('file-system');
@@ -63,6 +64,18 @@ const options = yargs
       const pageConfiguration = new addPageCommand.PageConfiguration(argv);
       const pageScaffolder = new addPageCommand.PageScaffolder(jamboConfig);
       pageScaffolder.create(pageConfiguration);
+    })
+  .command(
+    'card',
+    'add a new card for use in the site',
+    yargs => {
+      return yargs
+        .option('name', { description: 'name for the new card', demandOption: true })
+        .option('templateCardFolder', { description: 'folder of card to fork', demandOption: true })
+    },
+    argv => {
+      const cardCreator = new addCardCommand.CardCreator(jamboConfig);
+      cardCreator.create(argv.name, argv.templateCardFolder);
     })
 	.command(
     'build',

--- a/src/commands/card/cardcreator.js
+++ b/src/commands/card/cardcreator.js
@@ -1,0 +1,42 @@
+const fs = require('fs-extra');
+
+exports.CardCreator = class {
+  constructor(jamboConfig) {
+    this.config = jamboConfig;
+  }
+
+  /**
+   * Creates a new, custom card in the top-level 'Cards' directory. This card
+   * will be based off either an existing custom card or one supplied by the
+   * Theme.
+   * 
+   * @param {string} cardName           The name of the new card. A folder with a
+   *                                    lowercased version of this name will be
+   *                                    created.
+   * @param {string} templateCardFolder The folder of the existing card on which
+   *                                    the new one will be based.
+   */
+  create(cardName, templateCardFolder) {
+    const defaultTheme = this.config.defaultTheme;
+    const themeCardsDir = 
+        `${this.config.dirs.themes}/${defaultTheme}/cards`;
+    const customCardsDir = this.config.dirs.cards;
+
+    const cardFolderName = cardName.toLowerCase();
+    const isFolderInUse = 
+        fs.existsSync(`${themeCardsDir}/${cardFolderName}`) ||
+        fs.existsSync(`${customCardsDir}/${cardFolderName}`);
+    if (isFolderInUse) {
+        console.error(`A folder with name ${cardFolderName} already exists`);
+        return;
+    }
+
+    const cardFolder = `${customCardsDir}/${cardFolderName}`;
+    if (fs.existsSync(templateCardFolder)) {
+        fs.copySync(templateCardFolder, cardFolder);
+    } else {
+        console.error(`The folder ${templateCardFolder} does not exist`);
+        return;
+    }
+  }
+}

--- a/src/utils/jamboconfigparser.js
+++ b/src/utils/jamboconfigparser.js
@@ -10,7 +10,8 @@ exports.computeJamboConfig = function() {
         overrides: 'overrides',
         output: 'public',
         pages: 'pages',
-        partials: 'partials'
+        partials: 'partials',
+        cards: 'cards'
       }
     },
     JSON.parse(fs.readFileSync('config.json'))


### PR DESCRIPTION
This PR adds a 'card' command to Jambo. This lets a user create a new, custom
card for their site. This card will be based off an existing custom card or
one provided by the Theme. The new command has validation to make sure the
new card's folder name is not a duplicate. It also has validation ensuring the
forked card exists.

J=SPR-1895
TEST=manual

Tested the following scenarios:

- Tried to add a new card with the same folder name as one in the theme. Saw a
  validation error.
- Tried to add a new card with the same folder name as an existing custom card.
  Saw a validation error.
- Tried to add a new card with a templateCardFolder that did not exist. Saw a
  validation error.
- Added a new card based on an existing custom card.
- Added a new card based on one in the Theme.