### PR TITLE
Rename Jambo's config.json to be jambo.json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npx jambo build
 
 The build command builds all pages reigstered within Jambo, and places them inside the 'public' directory.
 
-The build command uses the 'theme' attribute in the config.json in Jambo's root directory, which must be added to config.json manually. Here is an example config.json.
+The build command uses the 'defaultTheme' attribute in the jambo.json in Jambo's root directory, which must be added to jambo.json manually. Here is an example jambo.json.
 
 ```json
 {
@@ -109,7 +109,7 @@ The build command uses the 'theme' attribute in the config.json in Jambo's root 
     "pages":"pages",
     "layouts":"layouts"
   },
-  "theme": "answers-hitchhiker-theme"
+  "defaultTheme": "answers-hitchhiker-theme"
 }
 ```
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,7 +10,7 @@ const configParser = require('./utils/jamboconfigparser');
 const yargs = require('yargs');
 const fs = require('file-system');
 
-const jamboConfig = fs.existsSync('config.json') && configParser.computeJamboConfig();
+const jamboConfig = fs.existsSync('jambo.json') && configParser.computeJamboConfig();
 
 const options = yargs
 	.usage('Usage: $0 <cmd> <operation> [options]')

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -17,7 +17,7 @@ exports.ThemeImporter = class {
    */
   async import(themeName) {
     if (!this.config) {
-      console.warn('No config.json found. Did you `jambo init` yet?')
+      console.warn('No jambo.json found. Did you `jambo init` yet?')
       return;
     }
     try {
@@ -71,7 +71,7 @@ exports.ThemeImporter = class {
   _updateDefaultTheme(themeName) {
     if (this.config.defaultTheme !== themeName) {
       const updatedConfig = Object.assign({}, this.config, { defaultTheme: themeName });
-      fs.writeFileSync('config.json', JSON.stringify(updatedConfig, null, 2));
+      fs.writeFileSync('jambo.json', JSON.stringify(updatedConfig, null, 2));
     }
   }
 

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -75,7 +75,7 @@ exports.RepositoryScaffolder = class {
         cards: 'cards'
       }
     };
-    fs.writeFileSync('config.json', JSON.stringify(jamboConfig, null, 2));
+    fs.writeFileSync('jambo.json', JSON.stringify(jamboConfig, null, 2));
 
     return jamboConfig;
   }

--- a/src/utils/jamboconfigparser.js
+++ b/src/utils/jamboconfigparser.js
@@ -14,7 +14,7 @@ exports.computeJamboConfig = function() {
         cards: 'cards'
       }
     },
-    JSON.parse(fs.readFileSync('config.json'))
+    JSON.parse(fs.readFileSync('jambo.json'))
   );
 
   return config;


### PR DESCRIPTION
The name config.json is quite generic, which could lead to potential naming
conflicts down the line. We now update Jambo's configuration file to be called
jambo.json as this should eliminate the possibility of a naming conflict.

TEST=manual

Created a new repository, imported a Theme, added a page, and built. All those
commands still worked as expected.