### PR TITLE
Remove theme command line argument from override and page commands.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -39,14 +39,14 @@ const options = yargs
     })
   .command(
     'override',
-    'override a theme or path within a theme',
+    'override a path within the theme',
     yargs => {
       return yargs
-        .option('theme', { description: 'theme to override', demandOption: true })
         .option('path', { description: 'path in the theme to override' })
     },
     argv => {
-      const shadowConfiguration = new overrideCommand.ShadowConfiguration(argv);
+      const shadowConfiguration = 
+        new overrideCommand.ShadowConfiguration(addThemeToArgs(argv));
       const themeShadower = new overrideCommand.ThemeShadower(jamboConfig);
       themeShadower.createShadow(shadowConfiguration);
     })
@@ -57,11 +57,11 @@ const options = yargs
       return yargs
         .option('name', { description: 'name for the new files', demandOption: true })
         .option('layout', { description: 'layout to use with page' })
-        .option('theme', { description: 'theme to use with page' })
         .option('template', { description: 'template to use within theme' });
     },
     argv => {
-      const pageConfiguration = new addPageCommand.PageConfiguration(argv);
+      const pageConfiguration = 
+        new addPageCommand.PageConfiguration(addThemeToArgs(argv));
       const pageScaffolder = new addPageCommand.PageScaffolder(jamboConfig);
       pageScaffolder.create(pageConfiguration);
     })
@@ -86,3 +86,14 @@ const options = yargs
       sitesGenerator.generate();
     })
   .argv;
+
+  /**
+   * Augments command line options with the defaultTheme from
+   * Jambo.
+   * 
+   * @param {Object} argv An object containing the command line
+   *                      options and the Jambo defaultTheme.
+   */
+  function addThemeToArgs(argv) {
+    return { ...argv, theme: jamboConfig.defaultTheme };
+  }

--- a/src/commands/override/themeshadower.js
+++ b/src/commands/override/themeshadower.js
@@ -8,6 +8,10 @@ const fs = require('fs-extra');
  */
 exports.ShadowConfiguration = class {
   constructor({ theme, path }) {
+    if (!theme) {
+      throw new Error('Theme must be specified when shadowing');
+    }
+
     this._theme = theme;
     this._path = path;
   }


### PR DESCRIPTION
These arguments were redundant given that a Jambo repo can have only one theme
and that theme is listed in the Jambo config.

J=SPR-1992
TEST=manual

Manually tested the following:

- Added a page with a name and template. Made sure it correctly inferred the
  Theme.
- Added a page with just a name. Made sure that generated a blank config and
  a blank html.hbs, as expected.
- Attempted an override before importing a theme in the repo. Saw the expected
  error.
- Called the override command with a path and without a path. Saw the correct
  shadows were generated.