### PR TITLE
Update the partial naming scheme to no longer be snake casing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,48 +23,10 @@
         "color-convert": "^2.0.1"
       }
     },
-    "camel-case": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.1.tgz",
-      "integrity": "sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==",
-      "requires": {
-        "pascal-case": "^3.1.1",
-        "tslib": "^1.10.0"
-      }
-    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-    },
-    "capital-case": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.3.tgz",
-      "integrity": "sha512-OlUSJpUr7SY0uZFOxcwnDOU7/MpHlKTZx2mqnDYQFrDudXLFm0JJ9wr/l4csB+rh2Ug0OPuoSO53PqiZBqno9A==",
-      "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0",
-        "upper-case-first": "^2.0.1"
-      }
-    },
-    "change-case": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.1.tgz",
-      "integrity": "sha512-qRlUWn/hXnX1R1LBDF/RelJLiqNjKjUqlmuBVSEIyye8kq49CXqkZWKmi8XeUAdDXWFOcGLUMZ+aHn3Q5lzUXw==",
-      "requires": {
-        "camel-case": "^4.1.1",
-        "capital-case": "^1.0.3",
-        "constant-case": "^3.0.3",
-        "dot-case": "^3.0.3",
-        "header-case": "^2.0.3",
-        "no-case": "^3.0.3",
-        "param-case": "^3.0.3",
-        "pascal-case": "^3.1.1",
-        "path-case": "^3.0.3",
-        "sentence-case": "^3.0.3",
-        "snake-case": "^3.0.3",
-        "tslib": "^1.10.0"
-      }
     },
     "cliui": {
       "version": "6.0.0",
@@ -95,16 +57,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "optional": true
     },
-    "constant-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.3.tgz",
-      "integrity": "sha512-FXtsSnnrFYpzDmvwDGQW+l8XK3GV1coLyBN0eBz16ZUzGaZcT2ANVCJmLeuw2GQgxKHQIe9e0w2dzkSfaRlUmA==",
-      "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0",
-        "upper-case": "^2.0.1"
-      }
-    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -117,15 +69,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
-    "dot-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
-      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
-      "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
-      }
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -189,15 +132,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "header-case": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.3.tgz",
-      "integrity": "sha512-LChe/V32mnUQnTwTxd3aAlNMk8ia9tjCDb/LjYtoMrdAPApxLB+azejUk5ERZIZdIqvinwv6BAUuFXH/tQPdZA==",
-      "requires": {
-        "capital-case": "^1.0.3",
-        "tslib": "^1.10.0"
-      }
-    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -229,14 +163,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lower-case": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.1.tgz",
-      "integrity": "sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==",
-      "requires": {
-        "tslib": "^1.10.0"
-      }
-    },
     "merge-options": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-2.0.0.tgz",
@@ -259,15 +185,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
-    },
-    "no-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
-      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
-      "requires": {
-        "lower-case": "^2.0.1",
-        "tslib": "^1.10.0"
-      }
     },
     "optimist": {
       "version": "0.6.1",
@@ -299,33 +216,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
-    "param-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
-      "integrity": "sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==",
-      "requires": {
-        "dot-case": "^3.0.3",
-        "tslib": "^1.10.0"
-      }
-    },
-    "pascal-case": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.1.tgz",
-      "integrity": "sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==",
-      "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0"
-      }
-    },
-    "path-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.3.tgz",
-      "integrity": "sha512-UMFU6UETFpCNWbIWNczshPrnK/7JAXBP2NYw80ojElbQ2+JYxdqWDBkvvqM93u4u6oLmuJ/tPOf2tM8KtXv4eg==",
-      "requires": {
-        "dot-case": "^3.0.3",
-        "tslib": "^1.10.0"
-      }
-    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -350,16 +240,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
-    "sentence-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.3.tgz",
-      "integrity": "sha512-ZPr4dgTcNkEfcGOMFQyDdJrTU9uQO1nb1cjf+nuzb6FxgMDgKddZOM29qEsB7jvsZSMruLRcL2KfM4ypKpa0LA==",
-      "requires": {
-        "no-case": "^3.0.3",
-        "tslib": "^1.10.0",
-        "upper-case-first": "^2.0.1"
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -377,15 +257,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
       "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig=="
-    },
-    "snake-case": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.3.tgz",
-      "integrity": "sha512-WM1sIXEO+rsAHBKjGf/6R1HBBcgbncKS08d2Aqec/mrDSpU80SiOU41hO7ny6DToHSyrlwTYzQBIK1FPSx4Y3Q==",
-      "requires": {
-        "dot-case": "^3.0.3",
-        "tslib": "^1.10.0"
-      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -410,11 +281,6 @@
         "ansi-regex": "^5.0.0"
       }
     },
-    "tslib": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
-    },
     "uglify-js": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
@@ -429,22 +295,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-    },
-    "upper-case": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.1.tgz",
-      "integrity": "sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==",
-      "requires": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "upper-case-first": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.1.tgz",
-      "integrity": "sha512-105J8XqQ+9RxW3l9gHZtgve5oaiR9TIwvmZAMAIZWRHe00T21cdvewKORTlOJf/zXW6VukuTshM+HXZNWz7N5w==",
-      "requires": {
-        "tslib": "^1.10.0"
-      }
     },
     "utils-extend": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "homepage": "https://github.com/yext/jamboree#readme",
   "dependencies": {
-    "change-case": "^4.1.1",
     "file-system": "^2.2.2",
     "fs-extra": "^8.1.0",
     "handlebars": "^4.7.3",

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -1,5 +1,4 @@
 const fs = require('file-system');
-const { snakeCase } = require('change-case');
 const hbs = require('handlebars');
 const path = require('path');
 
@@ -15,7 +14,7 @@ exports.SitesGenerator = class {
     const pagesConfig = {};
     fs.recurseSync(config.dirs.config, (path, relative, filename) => {
       if (this._isValidFile(filename)) {
-        let pageId = snakeCase(this._stripExtension(relative));
+        let pageId = this._stripExtension(relative);
         try {
           pagesConfig[pageId] = JSON.parse(fs.readFileSync(path));
         } catch (e) {
@@ -95,7 +94,7 @@ exports.SitesGenerator = class {
       fs.recurseSync(directory, (path, relative, filename) => {
         if (this._isValidFile(filename)) {
           const relativeNoExtension = this._stripExtension(relative);
-          hbs.registerPartial(snakeCase(relativeNoExtension), fs.readFileSync(path).toString());
+          hbs.registerPartial(relativeNoExtension, fs.readFileSync(path).toString());
         }
       });
     }


### PR DESCRIPTION
This PR updates the conventions Jambo uses to name partials. Previously, the
names were all snake cased. Now, we adopt a more intuitive naming convention.
A partial's name is it's relative path, with the file extension removed. This
should make it easier for a HH to trace where in the Jambo repo a particular
Partial is defined.

I also updated the id we compute for each page's config in the configuration
object. That no longer uses snake casing either. This ensures consistency
with the page config id computed via the page's html.hbs file.

J=SPR-1988
TEST=manual

Updated the HH Theme to use this new Partial naming scheme. Then, using Jambo
and the modified HH Theme, made a simple test site locally. Made sure this site
could be built by Jambo and that it looked as expected when served.