### PR TITLE
Jambo: Allow for and retain comments in json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,22 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "optional": true
     },
+    "comment-json": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-3.0.2.tgz",
+      "integrity": "sha512-ysJasbJ671+8mPEmwLOfLFqxoGtSmjyoep+lKRVH4J1/hsGu79fwetMDQWk8de8mVgqDZ43D7JuJAlACqjI1pg==",
+      "requires": {
+        "core-util-is": "^1.0.2",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -74,6 +90,11 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "file-match": {
       "version": "1.0.2",
@@ -131,6 +152,11 @@
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
       }
+    },
+    "has-own-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -229,6 +255,11 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
       }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/yext/jamboree#readme",
   "dependencies": {
+    "comment-json": "^3.0.2",
     "file-system": "^2.2.2",
     "fs-extra": "^8.1.0",
     "handlebars": "^4.7.3",

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -1,6 +1,7 @@
 const fs = require('file-system');
 const hbs = require('handlebars');
 const path = require('path');
+const { parse } = require('comment-json');
 
 exports.SitesGenerator = class {
   constructor(jamboConfig) {
@@ -19,7 +20,7 @@ exports.SitesGenerator = class {
       if (this._isValidFile(filename)) {
         let pageId = this._stripExtension(relative);
         try {
-          pagesConfig[pageId] = JSON.parse(fs.readFileSync(path));
+          pagesConfig[pageId] = parse(fs.readFileSync(path, 'utf8'), null, true);
         } catch (e) {
           if (e instanceof SyntaxError) {
             console.error('JSON SyntaxError: could not parse ' + path);

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -1,6 +1,10 @@
 const fs = require('fs-extra');
 const simpleGit = require('simple-git/promise');
 const git = simpleGit();
+const {
+  stringify,
+  assign 
+} = require('comment-json');
 
 exports.ThemeImporter = class {
   constructor(jamboConfig) {
@@ -70,8 +74,8 @@ exports.ThemeImporter = class {
 
   _updateDefaultTheme(themeName) {
     if (this.config.defaultTheme !== themeName) {
-      const updatedConfig = Object.assign({}, this.config, { defaultTheme: themeName });
-      fs.writeFileSync('jambo.json', JSON.stringify(updatedConfig, null, 2));
+      const updatedConfig = assign({ defaultTheme: themeName }, this.config);
+      fs.writeFileSync('jambo.json', stringify(updatedConfig, null, 2));
     }
   }
 

--- a/src/commands/page/add/pagescaffolder.js
+++ b/src/commands/page/add/pagescaffolder.js
@@ -1,4 +1,9 @@
 const fs = require('file-system');
+const {
+  parse,
+  stringify,
+  assign 
+} = require('comment-json');
 
 exports.PageConfiguration = class {
   constructor({ name, layout, theme, template }) {
@@ -44,13 +49,12 @@ exports.PageScaffolder = class {
       const rootTemplatePath = `${this.config.dirs.themes}/${theme}/templates/${template}`;
       fs.copyFileSync(`${rootTemplatePath}/page.html.hbs`, htmlFilePath);
 
-      configContents = Object.assign(
-        {},
-        JSON.parse(fs.readFileSync(`${rootTemplatePath}/page-config.json`)),
+      configContents = assign(
+        parse(fs.readFileSync(`${rootTemplatePath}/page-config.json`, 'utf8')),
         configContents);
     } else {
       fs.writeFileSync(htmlFilePath, '');
     }
-    fs.writeFileSync(configFilePath, JSON.stringify(configContents, null, 2));
+    fs.writeFileSync(configFilePath, stringify(configContents, null, 2));
   }
 }

--- a/src/utils/jamboconfigutils.js
+++ b/src/utils/jamboconfigutils.js
@@ -1,6 +1,10 @@
 const fs = require('file-system');
 const path = require('path');
 const mergeOptions = require('merge-options');
+const {
+  parse,
+  stringify
+} = require('comment-json');
 
 /**
  * Parses the repository's Jambo config file. If certain attributes are not
@@ -19,7 +23,7 @@ parseJamboConfig = function() {
         partials: ['partials'],
       }
     },
-    JSON.parse(fs.readFileSync('jambo.json'))
+    parse(fs.readFileSync('jambo.json', 'utf8'))
   );
   return config;
 }
@@ -42,6 +46,6 @@ exports.addToPartials = function(partialsPath) {
   
   if (shouldAddNewPartialsPath) {
     existingPartials.push(partialsPath);
-    fs.writeFileSync('jambo.json', JSON.stringify(jamboConfig, null, 2));
+    fs.writeFileSync('jambo.json', stringify(jamboConfig, null, 2));
   }
 }


### PR DESCRIPTION
In order to help users understand the configuration values, what can
be specified what cannot, and what they mean, it's important for us to
be able to put in comments directly in-line with the JSON data.

This update uses the comment-json node module to read in JSON
configuration files with comments, retain the comments and then write
them back out. We considered using the smaller, simpler library,
called strip-json-comments, but there are times where we need to read
in an existing configuration file, add a property to it, and then
write it back out again, if we just stripped out the comments, they
would be lost in that transformation.

The main caveat that we need to be aware of here, is that now when you
read in the jambo.json file using the parseJamboConfig() method in
jamboconfigutils.js, it is a more complex object than just a JSON
file, so all manipulations to it must be done using the functions that
accompany comment-json - parse, stringify, and assign.

Additionally, the comment-json parse method cannot handle Buffers,
only strings, so we have to specify that each config file should be
read-in as UTF-8 encoded. This is less than ideal, but it should work
seamlessly for most developers.

TEST=manual

I initialized a site, added a page, and built the site. I verified
these were all working as intended.