### PR TITLE
Add 'all' and 'any' handlebars helpers

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -168,12 +168,12 @@ exports.SitesGenerator = class {
       return (arg1 === arg2) ? options.fn(this) : options.inverse(this);
     });
 
-    hbs.registerHelper('and', function () {
-      return Array.prototype.every.call(arguments, Boolean);
+    hbs.registerHelper('all', function (...args) {
+      return args.filter(item =>item).length === args.length;
     });
 
-    hbs.registerHelper('or', function () {
-      return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
+    hbs.registerHelper('any', function (...args) {
+      return args.filter(item =>item).length > 0;
     });
 
     hbs.registerHelper('read', function (fileName) {


### PR DESCRIPTION
Add 'all' and 'any' handlebars helpers that take in a variable amount of arguments. Adding these handlebars helpers allows multiple conditions in 'if' statements. Usage for that would look like this: 

`{{#if (any A B) }}` 

TEST=manual

On local site, test compilation of handlebars templates using both 'all' and 'any'. Set A to true, B to false; A false, B false; A true, B true. Verify that for 'all' and 'any' that the statements evaluate properly.