### PR TITLE
Allow Theme to be imported via Git clone as well as Git submodule.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,6 +20,14 @@ const options = yargs
     yargs => {
       return yargs
         .option('theme', { description: 'a starter theme' })
+        .option(
+          'addThemeAsSubmodule', 
+          { 
+            description: 'if starter theme should be imported as submodule', 
+            default: true,
+            type: 'boolean' 
+          }
+        );
     },
     argv => {
       const repositorySettings = new initCommand.RepositorySettings(argv);
@@ -32,10 +40,13 @@ const options = yargs
     yargs => {
       return yargs
         .option('theme', { description: 'theme to import', demandOption: true })
+        .option(
+          'addAsSubmodule', 
+          { description: 'import the theme as a submodule', default: true, type: 'boolean' });
     },
     argv => {
       const themeImporter = new themeCommand.ThemeImporter(jamboConfig);
-      themeImporter.import(argv.theme).then(console.log).catch(console.log);
+      themeImporter.import(argv.theme, argv.addAsSubmodule).then(console.log).catch(console.log);
     })
   .command(
     'override',

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -12,14 +12,16 @@ exports.ThemeImporter = class {
   }
 
   /**
-   * Imports the requested theme as a Git submodule in Jambo's Themes directory.
+   * Imports the requested theme into Jambo's Themes directory. Note that the theme can either
+   * be cloned directly into this directory or added there as a submodule.
    *
    * @param {string} themeName The name of the theme
+   * @param {boolean} addAsSubmodule If the theme should be imported as a submodule.
    * @returns {Promise<string>} If the addition of the submodule was successful, a Promise
    *                            containing the new submodule's local path. If the addition failed,
    *                            a Promise containing the error.
    */
-  async import(themeName) {
+  async import(themeName, addAsSubmodule) {
     if (!this.config) {
       console.warn('No jambo.json found. Did you `jambo init` yet?')
       return;
@@ -28,7 +30,11 @@ exports.ThemeImporter = class {
       const themeRepo = this._getRepoForTheme(themeName);
       const localPath = `${this.config.dirs.themes}/${themeName}`;
 
-      await git.submoduleAdd(themeRepo, localPath);
+      if (addAsSubmodule) {
+        await git.submoduleAdd(themeRepo, localPath);
+      } else {
+        await git.clone(themeRepo, localPath);
+      }
 
       fs.copyFileSync(
         `${localPath}/global_config.json`,

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -6,15 +6,21 @@ const git = simpleGit();
 
 /**
  * RepositorySettings contains the information needed by Jambo to scaffold a new site repository.
- * Currently, these settings include an optional theme.
+ * Currently, these settings include an optional theme and whether or not the theme should be
+ * imported as a submodule.
  */
 exports.RepositorySettings = class {
-  constructor({ theme }) {
+  constructor({ theme, addThemeAsSubmodule }) {
     this._theme = theme;
+    this._addThemeAsSubmodule = addThemeAsSubmodule;
   }
 
   getTheme() {
     return this._theme;
+  }
+
+  shouldAddThemeAsSubmodule() {
+    return this._addThemeAsSubmodule;
   }
 }
 
@@ -37,7 +43,9 @@ exports.RepositoryScaffolder = class {
       const theme = repositorySettings.getTheme();
       if (theme) {
         const themeImporter = new themeCommand.ThemeImporter(jamboConfig);
-        await themeImporter.import(theme);
+        await themeImporter.import(
+          theme, 
+          repositorySettings.shouldAddThemeAsSubmodule());
       }
     } catch (error) {
       return Promise.reject(error.toString());


### PR DESCRIPTION
This PR updates the Jambo init and import commands to support importing a Theme
via direct clone or submodule. The default is still to import a Theme as a Git
submodule.

J=SPR-2163
TEST=manual

Verified that:
- I could import the Theme as a submodule on Jambo's init.
- I could import the Theme as a normal repo on Jambo's init.
- I could import the Theme as a submodule on Jambo's import.
- I could import the Theme as a normal repo on Jambo's import.
- All defaults worked as expected.