### PR TITLE
Import Theme: Reduce the amount of static files copied

### DIFF
--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -73,7 +73,6 @@ exports.ThemeImporter = class {
         }
       };
 
-      copyFileIfExists(`${staticAssetsPath}/entry.js`, `${siteStaticDir}/entry.js`);
       copyFileIfExists(`${staticAssetsPath}/scss/answers.scss`, `${siteStaticDir}/scss/answers.scss`);
       copyFileIfExists(`${staticAssetsPath}/scss/answers-variables.scss`, `${siteStaticDir}/scss/answers-variables.scss`);
       copyFileIfExists(`${staticAssetsPath}/scss/fonts.scss`, `${siteStaticDir}/scss/fonts.scss`);
@@ -81,6 +80,7 @@ exports.ThemeImporter = class {
       copyFileIfExists(`${staticAssetsPath}/Gruntfile.js`, 'Gruntfile.js');
       copyFileIfExists(`${staticAssetsPath}/webpack-config.js`, 'webpack-config.js');
       copyFileIfExists(`${staticAssetsPath}/package.json`, 'package.json');
+      copyFileIfExists(`${staticAssetsPath}/package-lock.json`, 'package-lock.json');
     }
   }
 


### PR DESCRIPTION
The build command is changing to copy static files over on build,
this means that only select theme files need to be in the site's
static directory. This commit changes the import theme command
to copy only specific SCSS and config files from within the theme's
static directory.

TEST=manual

Test using the following bash script, then inspecting the output files:
  command cd $REPO
  command rm -rf testImportThemeDir
  command mkdir testImportThemeDir
  command cd testImportThemeDir
  command jambo init
  command jambo import --theme answers-hitchhiker-theme
  command code .