### PR TITLE
Do not copy layout templates to 'partials' on Theme import.

### DIFF
--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -41,11 +41,6 @@ exports.ThemeImporter = class {
         `${this.config.dirs.config}/global_config.json`);
       this._copyStaticAssets(localPath);
       this._updateDefaultTheme(themeName);
-
-      const layoutsPath = `${localPath}/layouts`;
-      if (fs.existsSync(layoutsPath)) {
-        fs.copySync(layoutsPath, `${this.config.dirs.partials}/layouts`);
-      }
       
       return localPath;
     } catch (error) {


### PR DESCRIPTION
This PR stops ThemeImporter from copying layout templates to the 'partials'
directory on Theme import. This was done to make upgrading a Theme easier in a
site repo. Now, the layout templates are overridden in the same way as any
other Theme template.

J=SPR-2931
TEST=manual

In a local site repo, I imported the HH Theme. Ensured that nothing was added
to the 'partials' directory. Used the override command with the Theme's
layouts/html.hbs file. A top-level 'layouts' directory was created with a
shadow of html.hbs.