### PR TITLE
Add console log statement to output jambo injected data json object

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -27,10 +27,9 @@ exports.SitesGenerator = class {
     }
     
     // Pull all data from environment variables.
-    console.log('Printing Jambo Injected Data:');
     const envVarParser = EnvironmentVariableParser.create();
     const env = envVarParser.parse(['JAMBO_INJECTED_DATA'].concat(jsonEnvVars));
-    console.log(env);
+    console.log('Jambo Injected Data:', env);
 
     console.log('Reading config files');
     const pagesConfig = {};


### PR DESCRIPTION
Add console log statement to print out the JAMBO_INJECTED_DATA json object at the beginning of jambo build to help identify any issues when building.

J=SPR-2490

TEST=manual

Added console log statement in local jambo repo and ran npx jambo build on test site to make sure JAMBO_INJECTED_DATA json object is printed.