### PR TITLE
Add webpack folder to themeimporter

### DIFF
--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -74,6 +74,7 @@ exports.ThemeImporter = class {
       copyFileIfExists(`${staticAssetsPath}/scss/answers.scss`, `${siteStaticDir}/scss/answers.scss`);
       copyFileIfExists(`${staticAssetsPath}/scss/answers-variables.scss`, `${siteStaticDir}/scss/answers-variables.scss`);
       copyFileIfExists(`${staticAssetsPath}/scss/fonts.scss`, `${siteStaticDir}/scss/fonts.scss`);
+      copyFileIfExists(`${staticAssetsPath}/webpack/html-image-loader.js`, `${siteStaticDir}/webpack/html-image-loader.js`);
 
       copyFileIfExists(`${staticAssetsPath}/Gruntfile.js`, 'Gruntfile.js');
       copyFileIfExists(`${staticAssetsPath}/webpack-config.js`, 'webpack-config.js');


### PR DESCRIPTION
Include the static/webpack/html-image-loader.js in the theme on import.
This is to include the loader file for Webpack to load custom images in
the JSON configuration.

J=SPR-2456
TEST=manual

Import local HH theme, check to see html-image-loader.js is included in
repo-level static folder.