### PR TITLE
Added built-in 'translate' HBS helper to Jambo.

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -270,7 +270,7 @@ exports.SitesGenerator = class {
     }
   }
 
-  _registerHelpers() {
+  _registerHelpers(translator) {
     hbs.registerHelper('json', function(context) {
       return JSON.stringify(context || {});
     });
@@ -308,6 +308,15 @@ exports.SitesGenerator = class {
      */
     hbs.registerHelper('deepMerge', function (...args) {
       return _.merge({}, ...args.slice(0, args.length - 1));
+    });
+
+    /**
+     * Performs a simple translation of the provided phrase. Interpolation is
+     * supported as well.
+     */
+    hbs.registerHelper('translate', function (phrase, options) {
+      const interpValues = options.hash;
+      return translator.translate(phrase, interpValues);
     });
   }
 


### PR DESCRIPTION
This helper translates the provided string. It can also perform interpolation.
It is backed by an instance of the 'Translator' class. A future PR will create
the 'Translator' instance and pass it into '_registerHelpers'.

J=SLAP-521
TEST=manual

Injected a sample 'Translator' instance into '_registerHelpers' and tried using
the 'translate' helper on a sample site that had local .PO files. Ensured
that translations were correctly provided during HBS compilation.