### PR TITLE
Add handlebars concat helper

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -31,7 +31,7 @@ exports.SitesGenerator = class {
     const envVarParser = EnvironmentVariableParser.create();
     const env = envVarParser.parse(['JAMBO_INJECTED_DATA'].concat(jsonEnvVars));
     console.log('Jambo Injected Data:', env);
-    console.log('testing');
+
     console.log('Reading config files');
     const pagesConfig = {};
     fs.recurseSync(config.dirs.config, (path, relative, filename) => {


### PR DESCRIPTION
Add concat handlebars helper to sitesgenerator.js. For the universal section templates item, we need the concat helper to specify the path to the template that needs to be read ( {{{read (concat 'universalsectiontemplates/' {{universalSectionTemplate}} )}}} ).

J = SLAP-526

TEST=manual

Tested on local jambo site to ensure that concat helper correctly concatenates the path to the template.