### PR TITLE
Create localized instance of Translator in SitesGenerator.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -118,7 +118,7 @@ const options = yargs
     },
     argv => {
       const sitesGenerator = new buildCommand.SitesGenerator(jamboConfig);
-      sitesGenerator.generate(argv.jsonEnvVars);
+      sitesGenerator.generate(argv.jsonEnvVars).catch(console.log);
     })
   .command(
     'extract-i18n',

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -95,7 +95,7 @@ exports.RepositoryScaffolder = class {
       }
     };
     if (includeTranslations) {
-      jamboConfig.dirs.translsations = 'translations';
+      jamboConfig.dirs.translations = 'translations';
     }
 
     fs.writeFileSync('jambo.json', JSON.stringify(jamboConfig, null, 2));

--- a/src/i18n/translationfetchers/localfileparser.js
+++ b/src/i18n/translationfetchers/localfileparser.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { readFileSync } = require('fs');
+const { readFileSync, existsSync } = require('fs');
 const { gettextToI18next } = require('i18next-conv');
 
 /**
@@ -20,7 +20,8 @@ class LocalFileParser {
   }
 
   /**
-   * Parses a locale's translations in the local filesystem.
+   * Extracts a locale's translations from the local filesystem. If no such
+   * translations exist, an empty object is returned.
    * 
    * @param {string} locale The desired locale.
    * @returns {Promise<Object>} A Promise containing the parsed translations in
@@ -28,9 +29,14 @@ class LocalFileParser {
   */
   async fetch(locale) {
     const translationFile = path.join(this._translationsDir, `${locale}.po`);
-    const localeTranslations =
-      gettextToI18next(locale, readFileSync(translationFile), this._options);
-    return localeTranslations.then(data => JSON.parse(data));
+
+    if (existsSync(translationFile)) {
+      const localeTranslations =
+        gettextToI18next(locale, readFileSync(translationFile), this._options);
+      return localeTranslations.then(data => JSON.parse(data));
+    }
+
+    return {};
   }
 }
 module.exports = LocalFileParser;

--- a/tests/i18n/translationfetchers/localfileparser.js
+++ b/tests/i18n/translationfetchers/localfileparser.js
@@ -2,10 +2,10 @@ const path = require('path');
 const LocalFileParser = require('../../../src/i18n/translationfetchers/localfileparser');
 
 describe('LocalFileParser works correctly', () => {
-  it('translations are parsed and converted into i18next format', () => {
-    const translationsPath = path.join(__dirname, '../../fixtures/translations');
-    const localFileParser = new LocalFileParser(translationsPath);
+  const translationsPath = path.join(__dirname, '../../fixtures/translations');
+  const localFileParser = new LocalFileParser(translationsPath);
 
+  it('translations are parsed and converted into i18next format', () => {
     const expectedTranslations = {
       Item: 'Article',
       Item_plural: 'Articles',
@@ -18,4 +18,10 @@ describe('LocalFileParser works correctly', () => {
       expect(translations).toStrictEqual(expectedTranslations);
     })
   });
+
+  it('works correctly when no translation file exists for the locale', () => {
+    return localFileParser.fetch('es').then(translations => {
+      expect(translations).toEqual({});
+    })
+  })
 });


### PR DESCRIPTION
This PR has SitesGenerator creating a Translator instance per locale. This
instance is used to create the localized HBS helpers needed to build the locale's
pages.

A couple other small changes were included in this PR. The RepositoryScaffolder
had a bug where it generated a Jambo config with a dirs.translsations attribute.
This should be dirs.translations. The LocalFileParser was changed to gracefully
handle the case when translation files don't exist for a locale.

TEST=auto, manual

Added unit tests for the new LocalFileParser behavior. Locally, I created a Jambo
site with a French locale. I provided some French translations. One of my custom
partials used the new translate helper with interpolation. Confirmed that the
text was translated correctly. I also verified that if I tried translating a
string for which there were no translations, it simply returned the string.

I made sure that I could still build pages for a Jambo site that did not have
any local translations.