### PR TITLE
Change extractor unit tests to use double braces

### DIFF
--- a/tests/fixtures/extract/expectedjson.js
+++ b/tests/fixtures/extract/expectedjson.js
@@ -1,27 +1,27 @@
 exports.hbs = {
   'Regular translation in hbs': '',
-  '{someVar} translation in hbs': '',
-  '{count} translation in hbs': '',
-  '{count} translation in hbs_plural': '',
-  '{count} translation with {someVar} in hbs': '',
-  '{count} translation with {someVar} in hbs_plural': '',
+  '{{someVar}} translation in hbs': '',
+  '{{count}} translation in hbs': '',
+  '{{count}} translation in hbs_plural': '',
+  '{{count}} translation with {{someVar}} in hbs': '',
+  '{{count}} translation with {{someVar}} in hbs_plural': '',
   'Translation with context in hbs_This is a test translation': '',
-  '{another} translation with context in hbs_This is another test translation with context in hbs': '',
-  '{count} plural translation with context in hbs_This is a plural translation with context': '',
-  '{count} plural translation with context in hbs_This is a plural translation with context_plural': ''
+  '{{another}} translation with context in hbs_This is another test translation with context in hbs': '',
+  '{{count}} plural translation with context in hbs_This is a plural translation with context': '',
+  '{{count}} plural translation with context in hbs_This is a plural translation with context_plural': ''
 };
 
 exports.js = {
   'Regular translation in js': '',
-  '{someVar} translation in js': '',
-  '{count} translation in js': '',
-  '{count} translation in js_plural': '',
-  '{count} translation with {someVar} in js': '',
-  '{count} translation with {someVar} in js_plural': '',
+  '{{someVar}} translation in js': '',
+  '{{count}} translation in js': '',
+  '{{count}} translation in js_plural': '',
+  '{{count}} translation with {{someVar}} in js': '',
+  '{{count}} translation with {{someVar}} in js_plural': '',
   'Translation with context in js_This is a test translation': '',
-  '{another} translation with context in js_This is another test translation with context in js': '',
-  '{count} plural translation with context in js_This is a plural translation with context': '',
-  '{count} plural translation with context in js_This is a plural translation with context_plural': ''
+  '{{another}} translation with context in js_This is another test translation with context in js': '',
+  '{{count}} plural translation with context in js_This is a plural translation with context': '',
+  '{{count}} plural translation with context in js_This is a plural translation with context_plural': ''
 };
 
 exports.combined = Object.assign({}, exports.js, exports.hbs);

--- a/tests/fixtures/extract/translations.hbs
+++ b/tests/fixtures/extract/translations.hbs
@@ -1,12 +1,12 @@
 <div>
   {{translate 'Regular translation in hbs'}}
-  {{translate '{someVar} translation in hbs' someVar='Interpolated'}}
+  {{translate '{{someVar}} translation in hbs' someVar='Interpolated'}}
 </div>
 <div>
-  {{translatePlural '{count} translation in hbs' '{count} translations' count='2'}}
+  {{translatePlural '{{count}} translation in hbs' '{{count}} translations' count='2'}}
   {{translatePlural
-    '{count} translation with {someVar} in hbs'
-    '{count} translations with {someVar} in hbs'
+    '{{count}} translation with {{someVar}} in hbs'
+    '{{count}} translations with {{someVar}} in hbs'
     count='2'
     someVar='interpolation'
   }}
@@ -14,15 +14,15 @@
 <div>
   {{translateWithContext 'Translation with context in hbs' 'This is a test translation'}}
   {{translateWithContext
-    '{another} translation with context in hbs'
+    '{{another}} translation with context in hbs'
     'This is another test translation with context in hbs'
     another='Another'
   }}
 </div>
 <div>
   {{translatePluralWithContext
-    '{count} plural translation with context in hbs'
-    '{count} plural translations with context in hbs'
+    '{{count}} plural translation with context in hbs'
+    '{{count}} plural translations with context in hbs'
     'This is a plural translation with context'
     count='9000'
   }}

--- a/tests/fixtures/extract/translations.js
+++ b/tests/fixtures/extract/translations.js
@@ -2,23 +2,23 @@ class MockComponent {
   constructor() {
     this.translations = [
       `{{{translate 'Regular translation in js'}}}`,
-      `{{{translate '{someVar} translation in js' someVar='Interpolated'}}}`,
-      `{{translatePlural '{count} translation in js' '{count} translations' count='2'}}`,
+      `{{{translate '{{someVar}} translation in js' someVar='Interpolated'}}}`,
+      `{{translatePlural '{{count}} translation in js' '{{count}} translations' count='2'}}`,
       `{{translatePlural
-        '{count} translation with {someVar} in js'
-        '{count} translations with {someVar} in js'
+        '{{count}} translation with {{someVar}} in js'
+        '{{count}} translations with {{someVar}} in js'
         count='2'
         someVar='interpolation'
       }}`,
       `{{translateWithContext 'Translation with context in js' 'This is a test translation'}}`,
       `{{translateWithContext
-        '{another} translation with context in js'
+        '{{another}} translation with context in js'
         'This is another test translation with context in js'
         another='Another'
       }}`,
       `{{translatePluralWithContext
-        '{count} plural translation with context in js'
-        '{count} plural translations with context in js'
+        '{{count}} plural translation with context in js'
+        '{{count}} plural translations with context in js'
         'This is a plural translation with context'
         count='9000'
       }}`


### PR DESCRIPTION
I thought this wouldn't work with handlebars because it changed the syntax coloring in my editor.
But it does!

TEST=auto