### PR TITLE
sitesgenerator: only print jambo injected data not entire process.env

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -30,7 +30,7 @@ exports.SitesGenerator = class {
     // Pull all data from environment variables.
     const envVarParser = EnvironmentVariableParser.create();
     const env = envVarParser.parse(['JAMBO_INJECTED_DATA'].concat(jsonEnvVars));
-    console.log('Jambo Injected Data:', env);
+    console.log('Jambo Injected Data:', env['JAMBO_INJECTED_DATA']);
 
     console.log('Reading config files');
     const pagesConfig = {};


### PR DESCRIPTION
This commit changes envvarparser to only parser out an env object
with the env keys that are asked for, instead of the entire environment.

TEST=manual

run jambo build before changes, see entire process.env printed
run jambo build after changes, see only JAMBO_INJECTED_DATA printed