### PR TITLE
Add translateWithContext helper

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -291,6 +291,18 @@ exports.SitesGenerator = class {
         return translator.translatePlural(singularPhrase, pluralPhrase, count, interpValues);
       }
     );
+
+    /**
+     * Translates the provided phrase depending on the context.
+     * Supports interpolation.
+     */
+    hbs.registerHelper(
+      'translateWithContext',
+      function (phrase, context, options) {
+        const interpValues = options.hash;
+        return translator.transalteWithContext(phrase, context, interpValues);
+      }
+    )
   }
 
   _registerHelpers() {

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -300,7 +300,7 @@ exports.SitesGenerator = class {
       'translateWithContext',
       function (phrase, context, options) {
         const interpValues = options.hash;
-        return translator.transalteWithContext(phrase, context, interpValues);
+        return translator.translateWithContext(phrase, context, interpValues);
       }
     )
   }

--- a/src/i18n/translator/translator.js
+++ b/src/i18n/translator/translator.js
@@ -49,8 +49,8 @@ class Translator {
   }
 
   /**
-     * Translates the provided phrase depending on the context.
-     * Supports interpolation.
+   * Translates the provided phrase depending on the context.
+   * Supports interpolation.
    * 
    * @param {string} phrase The phrase to translate.
    * @param {string} context The context of the translation

--- a/src/i18n/translator/translator.js
+++ b/src/i18n/translator/translator.js
@@ -49,6 +49,21 @@ class Translator {
   }
 
   /**
+     * Translates the provided phrase depending on the context.
+     * Supports interpolation.
+   * 
+   * @param {string} phrase The phrase to translate.
+   * @param {string} context The context of the translation
+   * @param {Object<string, ?>} interpValues Optional, any values needed to interpolate
+   *                                         the translated string.
+   */
+  translateWithContext(phrase, context, interpValues) {
+    const parsedInterpValues = { ...interpValues, 'context': context};
+
+    return this._i18next.t(phrase, parsedInterpValues);
+  }
+
+  /**
    * Creates a {@link Translator} for the given locale, wrapping a properly configured,
    * new {@link i18next} instance.
    * 

--- a/tests/fixtures/translations/fr-FR.po
+++ b/tests/fixtures/translations/fr-FR.po
@@ -29,3 +29,11 @@ msgstr "fils"
 msgctxt "female"
 msgid "Child"
 msgstr "fille"
+
+msgctxt "male"
+msgid "I am looking for my child named {{name}}"
+msgstr "Je cherche mon fils nommé {{name}}"
+
+msgctxt "female"
+msgid "I am looking for my child named {{name}}"
+msgstr "Je cherche mon fille nommé {{name}}"

--- a/tests/i18n/translationfetchers/localfileparser.js
+++ b/tests/i18n/translationfetchers/localfileparser.js
@@ -14,6 +14,8 @@ describe('LocalFileParser works correctly', () => {
       Child_female: 'fille',
       'There is {{count}} item {{name}}': 'Il y a {{count}} article {{name}}',
       'There is {{count}} item {{name}}_plural': 'Il y a {{count}} articles {{name}}',
+      'I am looking for my child named {{name}}_male': 'Je cherche mon fils nommé {{name}}',
+      'I am looking for my child named {{name}}_female': 'Je cherche mon fille nommé {{name}}',
     };
 
     return localFileParser.fetch('fr-FR').then(translations => {

--- a/tests/i18n/translator/translator.js
+++ b/tests/i18n/translator/translator.js
@@ -68,3 +68,31 @@ describe('Translations with pluralization and no context', () => {
     expect(translation).toEqual('Missing 2 translations Tom');
   });
 });
+
+describe('Translations with context and no pluralization', () => {
+  it('context works as expected with context = male', () => {
+    const translation = translator.translateWithContext('Child', 'male');
+    expect(translation).toEqual('fils');
+  });
+
+  it('context works as expected with context = female', () => {
+    const translation = translator.translateWithContext('Child', 'female');
+    expect(translation).toEqual('fille');
+  });
+
+  it('context and interpolation works as expected with context = male', () => {
+    const translation = translator.translateWithContext(
+      'I am looking for my child named {{name}}', 
+      'male', 
+      { name: 'Sam' });
+    expect(translation).toEqual('Je cherche mon fils nommé Sam')
+  });
+
+  it('context and interpolation works as expected with context = female', () => {
+    const translation = translator.translateWithContext(
+      'I am looking for my child named {{name}}', 
+      'female', 
+      { name: 'Sam' });
+    expect(translation).toEqual('Je cherche mon fille nommé Sam')
+  });
+});


### PR DESCRIPTION
Adds a translateWithContext HBS helper to Jambo. Interpolation is also supported.
The Translator class now has a translateWithContext method.

J=SLAP-464
TEST=auto, manual

Added new unit tests for Translator.translateWithContext that include simple translations with context and interpolated translations with context.

I also tested a local french jambo site with a partial that invokes the helper