### PR TITLE
Import Theme: copy localization config file if exists

### DIFF
--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -39,7 +39,7 @@ exports.ThemeImporter = class {
         await git.clone(themeRepo, localPath);
       }
 
-      if(fs.existsSync(`${localPath}/locale_config.json`)) {
+      if (fs.existsSync(`${localPath}/locale_config.json`)) {
         fs.copyFileSync(
           `${localPath}/locale_config.json`,
           `${this.config.dirs.config}/locale_config.json`);

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -39,6 +39,11 @@ exports.ThemeImporter = class {
         await git.clone(themeRepo, localPath);
       }
 
+      if(fs.existsSync(`${localPath}/locale_config.json`)) {
+        fs.copyFileSync(
+          `${localPath}/locale_config.json`,
+          `${this.config.dirs.config}/locale_config.json`);
+      }
       fs.copyFileSync(
         `${localPath}/global_config.json`,
         `${this.config.dirs.config}/global_config.json`);


### PR DESCRIPTION
TEST=manual
J=SLAP-560

Test that there is no change if the locale_config.json file is not present, using the current theme version and the following commands:

```
command jambo init
command jambo import --theme answers-hitchhiker-theme
```

Then test using the same commands but adding a line to check out the "locale-config" branch of the answers-hitchhiker-theme, which has the locale_config.json file, see it copied. 