### PR TITLE
Add a preprocessor for all partials registered with Handlebars.

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -268,6 +268,7 @@ exports.SitesGenerator = class {
      */
     hbs.registerHelper('translate', function (phrase, options) {
       const interpValues = options.hash;
+      console.log(interpValues.stuff1);
       return translator.translate(phrase, interpValues);
     });
 

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -268,7 +268,6 @@ exports.SitesGenerator = class {
      */
     hbs.registerHelper('translate', function (phrase, options) {
       const interpValues = options.hash;
-      console.log(interpValues.stuff1);
       return translator.translate(phrase, interpValues);
     });
 

--- a/src/partials/models/translateinvocation.js
+++ b/src/partials/models/translateinvocation.js
@@ -1,0 +1,99 @@
+const _ = require('lodash');
+
+// An enum representing the different parameter types that can appear when the
+// 'translate' helper is invoked.
+const ParamTypes = {
+    PHRASE: 'phrase',
+    PLURAL: 'pluralForm',
+    CONTEXT: 'context',
+    COUNT: 'count',
+    OTHER: 'other'
+}
+Object.freeze(ParamTypes);
+
+/**
+ * A data model representing an invocation of Jambo's 'translate' helper.
+ */
+class TranslateInvocation {
+    constructor(providedParams) {
+        this._providedParams = providedParams;
+    }
+
+    /**
+     * Whether or not this invocation requires pluralization.
+     * 
+     * @returns {boolean}
+     */
+    isUsingPluralization() {
+        return this._providedParams.hasOwnProperty(ParamTypes.PLURAL);
+    }
+
+    /**
+     * If the translation requested by the invocation can be resolved at
+     * compile-time. This is true if no pluralizaiton or interpolation is
+     * requested.
+     * 
+     * @returns {boolean}
+     */
+    canBeTranslatedStatically() {
+        return Object.keys(this._providedParams).every(
+            param => param === ParamTypes.PHRASE || param === ParamTypes.CONTEXT);
+    }
+
+    /**
+     * Returns the phrase needing translation.
+     * 
+     * @returns {string} The phrase to be translated.
+     */
+    getPhrase() {
+        return this._providedParams[ParamTypes.PHRASE];
+    }
+
+    /**
+     * Returns any included translation context.
+     * 
+     * @returns {string} The translation context.
+     */
+    getContext() {
+        return this._providedParams[ParamTypes.CONTEXT];
+    }
+
+    /**
+     * Returns any interpolation params included with the invocation. 
+     * 
+     * @returns {Object<string, string>} The interpolation params.
+     */
+    getInterpolationParams() {
+        const interpParams = _.cloneDeep(this._providedParams);
+        const paramsToRemove = 
+            [ParamTypes.CONTEXT, ParamTypes.PHRASE, ParamTypes.PLURAL];
+        paramsToRemove.forEach(param => delete interpParams[param]);
+
+        return interpParams;
+    }
+
+    /**
+     * Creates a {@link TranslateInvocation} from a partial's call to Jambo's
+     * 'translate' helper.
+     * 
+     * @param {string} invocationString The string in the partial calling 'translate'.
+     * @returns {TranslateInvocation} The resulting {@link TranslateInvocation}.
+     */
+    static from(invocationString) {
+        const paramRegex = 
+            /([a-zA-z]+=\'[a-zA-Z\s\{\}\.]+\')|([a-zA-z]+=\d+)/g;
+            
+        const parsedParams = (invocationString.match(paramRegex) || [])
+            .reduce((params, paramString) => {
+                const paramOperands = paramString.split('=');
+                const paramName = paramOperands[0];
+                const paramValue = paramOperands[1];
+                params[paramName] = paramValue;
+                return params;
+            }, {});
+        
+        return new TranslateInvocation(parsedParams);
+    }
+}
+
+module.exports = TranslateInvocation;

--- a/src/partials/models/translateinvocation.js
+++ b/src/partials/models/translateinvocation.js
@@ -30,7 +30,7 @@ class TranslateInvocation {
 
   /**
    * If the translation requested by the invocation can be resolved at
-   * compile-time. This is true if no pluralizaiton or interpolation is
+   * compile-time. This is true if no pluralization or interpolation is
    * requested.
    * 
    * @returns {boolean}
@@ -81,7 +81,7 @@ class TranslateInvocation {
    */
   static from(invocationString) {
     const paramRegex =
-      /([a-zA-z]+=\'[a-zA-Z\s\{\}\.]+\')|([a-zA-z]+=\d+)/g;
+      /([a-zA-z0-9]+=\'[a-zA-Z\s\{\}\.]+\')|([a-zA-z0-9]+=\d+)/g;
 
     const parsedParams = (invocationString.match(paramRegex) || [])
       .reduce((params, paramString) => {

--- a/src/partials/models/translateinvocation.js
+++ b/src/partials/models/translateinvocation.js
@@ -3,11 +3,11 @@ const _ = require('lodash');
 // An enum representing the different parameter types that can appear when the
 // 'translate' helper is invoked.
 const ParamTypes = {
-    PHRASE: 'phrase',
-    PLURAL: 'pluralForm',
-    CONTEXT: 'context',
-    COUNT: 'count',
-    OTHER: 'other'
+  PHRASE: 'phrase',
+  PLURAL: 'pluralForm',
+  CONTEXT: 'context',
+  COUNT: 'count',
+  OTHER: 'other'
 }
 Object.freeze(ParamTypes);
 
@@ -15,85 +15,85 @@ Object.freeze(ParamTypes);
  * A data model representing an invocation of Jambo's 'translate' helper.
  */
 class TranslateInvocation {
-    constructor(providedParams) {
-        this._providedParams = providedParams;
-    }
+  constructor(providedParams) {
+    this._providedParams = providedParams;
+  }
 
-    /**
-     * Whether or not this invocation requires pluralization.
-     * 
-     * @returns {boolean}
-     */
-    isUsingPluralization() {
-        return this._providedParams.hasOwnProperty(ParamTypes.PLURAL);
-    }
+  /**
+   * Whether or not this invocation requires pluralization.
+   * 
+   * @returns {boolean}
+   */
+  isUsingPluralization() {
+    return this._providedParams.hasOwnProperty(ParamTypes.PLURAL);
+  }
 
-    /**
-     * If the translation requested by the invocation can be resolved at
-     * compile-time. This is true if no pluralizaiton or interpolation is
-     * requested.
-     * 
-     * @returns {boolean}
-     */
-    canBeTranslatedStatically() {
-        return Object.keys(this._providedParams).every(
-            param => param === ParamTypes.PHRASE || param === ParamTypes.CONTEXT);
-    }
+  /**
+   * If the translation requested by the invocation can be resolved at
+   * compile-time. This is true if no pluralizaiton or interpolation is
+   * requested.
+   * 
+   * @returns {boolean}
+   */
+  canBeTranslatedStatically() {
+    return Object.keys(this._providedParams).every(
+      param => param === ParamTypes.PHRASE || param === ParamTypes.CONTEXT);
+  }
 
-    /**
-     * Returns the phrase needing translation.
-     * 
-     * @returns {string} The phrase to be translated.
-     */
-    getPhrase() {
-        return this._providedParams[ParamTypes.PHRASE];
-    }
+  /**
+   * Returns the phrase needing translation.
+   * 
+   * @returns {string} The phrase to be translated.
+   */
+  getPhrase() {
+    return this._providedParams[ParamTypes.PHRASE];
+  }
 
-    /**
-     * Returns any included translation context.
-     * 
-     * @returns {string} The translation context.
-     */
-    getContext() {
-        return this._providedParams[ParamTypes.CONTEXT];
-    }
+  /**
+   * Returns any included translation context.
+   * 
+   * @returns {string} The translation context.
+   */
+  getContext() {
+    return this._providedParams[ParamTypes.CONTEXT];
+  }
 
-    /**
-     * Returns any interpolation params included with the invocation. 
-     * 
-     * @returns {Object<string, string>} The interpolation params.
-     */
-    getInterpolationParams() {
-        const interpParams = _.cloneDeep(this._providedParams);
-        const paramsToRemove = 
-            [ParamTypes.CONTEXT, ParamTypes.PHRASE, ParamTypes.PLURAL];
-        paramsToRemove.forEach(param => delete interpParams[param]);
+  /**
+   * Returns any interpolation params included with the invocation. 
+   * 
+   * @returns {Object<string, string>} The interpolation params.
+   */
+  getInterpolationParams() {
+    const interpParams = _.cloneDeep(this._providedParams);
+    const paramsToRemove =
+      [ParamTypes.CONTEXT, ParamTypes.PHRASE, ParamTypes.PLURAL];
+    paramsToRemove.forEach(param => delete interpParams[param]);
 
-        return interpParams;
-    }
+    return interpParams;
+  }
 
-    /**
-     * Creates a {@link TranslateInvocation} from a partial's call to Jambo's
-     * 'translate' helper.
-     * 
-     * @param {string} invocationString The string in the partial calling 'translate'.
-     * @returns {TranslateInvocation} The resulting {@link TranslateInvocation}.
-     */
-    static from(invocationString) {
-        const paramRegex = 
-            /([a-zA-z]+=\'[a-zA-Z\s\{\}\.]+\')|([a-zA-z]+=\d+)/g;
-            
-        const parsedParams = (invocationString.match(paramRegex) || [])
-            .reduce((params, paramString) => {
-                const paramOperands = paramString.split('=');
-                const paramName = paramOperands[0];
-                const paramValue = paramOperands[1];
-                params[paramName] = paramValue;
-                return params;
-            }, {});
-        
-        return new TranslateInvocation(parsedParams);
-    }
+  /**
+   * Creates a {@link TranslateInvocation} from a partial's call to Jambo's
+   * 'translate' helper.
+   * 
+   * @param {string} invocationString The string in the partial calling 'translate'.
+   * @returns {TranslateInvocation} The resulting {@link TranslateInvocation}.
+   */
+  static from(invocationString) {
+    const paramRegex =
+      /([a-zA-z]+=\'[a-zA-Z\s\{\}\.]+\')|([a-zA-z]+=\d+)/g;
+
+    const parsedParams = (invocationString.match(paramRegex) || [])
+      .reduce((params, paramString) => {
+        const paramOperands = paramString.split('=');
+        const paramName = paramOperands[0];
+        const paramValue = paramOperands[1];
+        params[paramName] = paramValue;
+        return params;
+      }, {});
+
+    return new TranslateInvocation(parsedParams);
+  }
 }
 
 module.exports = TranslateInvocation;

--- a/src/partials/partialpreprocessor.js
+++ b/src/partials/partialpreprocessor.js
@@ -11,9 +11,9 @@ class PartialPreprocessor {
   }
 
   /**
-   * Processes the provided partial, looking for usages of the 'translate'
-   * helper. These usages are transpiled into either a translated string or a call
-   * to the SDK's run-time translation methods.
+   * Processes the provided partial, looking for usages of the 'translate' or
+   * 'translateJS' helpers. These usages are transpiled into either a translated
+   * string or a call to the SDK's run-time translation methods.
    * 
    * @param {string} partial The partial to process.
    * @returns {string} The transpiled partial.
@@ -21,7 +21,7 @@ class PartialPreprocessor {
   process(partial) {
     let processedPartial = partial;
     const translateHelperCalls =
-      processedPartial.match(/\{\{\s?translate\s.+\}\}/g) || [];
+      processedPartial.match(/\{\{\s?translate(JS)?\s.+\}\}/g) || [];
 
     translateHelperCalls.forEach(call => {
       const translateInvocation = TranslateInvocation.from(call);
@@ -34,9 +34,9 @@ class PartialPreprocessor {
   }
 
   /**
-   * Transpiles a usage of the 'translate' helper. If the translation
-   * can be resolved at compile-time (no pluralization or interpolation), the
-   * usage will be transpiled to it. Otherwise, it will be transpiled to the
+   * Transpiles a usage of the 'translate' or 'translateJS' helper. If the 
+   * translation can be resolved at compile-time (no pluralization or interpolation), 
+   * the usage will be transpiled to it. Otherwise, it will be transpiled to the
    * appropriate call to the SDK's run-time translation method.
    * 
    * @param {TranslateInvocation} invocation The {@link TranslateInvocation} 
@@ -54,14 +54,52 @@ class PartialPreprocessor {
         this._translator.translateWithContext(
           invocation.getPhrase(), translationContext) :
         this._translator.translate(invocation.getPhrase);
-      translatorResult = `'${translatorResult}'`;
     }
-    let interpolationParams = JSON.stringify(invocation.getInterpolationParams());
-    interpolationParams = interpolationParams.replace(/[\'\"]/g, '');
+    translatorResult = `'${translatorResult}'`;
 
-    return invocation.canBeTranslatedStatically() ?
-        translatorResult :
-        `ANSWERS.translateJS(${translatorResult}, ${interpolationParams})`;
+    if (invocation.canBeTranslatedStatically()) {
+      return translatorResult;
+    }
+    const interpParams = invocation.getInterpolationParams();
+    
+    return invocation.getInvokedHelper() === 'translateJS' ?
+        this._createRuntimeCallForJS(translatorResult, interpParams) :
+        this._createRuntimeCallForHBS(translatorResult, interpParams);
+  }
+
+  /**
+   * Constructs a call to the SDK's Javascript method for run-time translation. 
+   * This call is constructed using the translation(s) for a phrase and any interpolation
+   * paramters.
+   * 
+   * @param {Object|string} translatorResult The translation(s) for the phrase.
+   * @param {Object<string, ?>} interpolationParams The needed interpolation parameters
+   *                                                (including 'count').
+   * @returns {string} The string-ified call to ANSWERS.translateJS.
+   */
+  _createRuntimeCallForJS(translatorResult, interpolationParams) {
+    let parsedParams = JSON.stringify(interpolationParams);
+    parsedParams = parsedParams.replace(/[\'\"]/g, '');
+
+    return `ANSWERS.translateJS(${translatorResult}, ${parsedParams})`;
+  }
+
+  /**
+   * Constructs a call to the SDK's Handlebars helper for run-time translation.
+   * This call is constructed using the translation(s) for a phrase and any interpolation
+   * paramters.
+   * 
+   * @param {Object|string} translatorResult The translation(s) for the phrase.
+   * @param {Object<string, ?>} interpolationParams The needed interpolation parameters
+   *                                                (including 'count').
+   * @returns {string} The string-ified call to the 'runtimeTranslation' helper.
+   */
+  _createRuntimeCallForHBS(translatorResult, interpolationParams) {
+    const paramsString = Object.entries(interpolationParams)
+      .reduce((params, [paramName, paramValue]) => {
+        return params + `${paramName}=${paramValue} `;
+      }, '');
+    return `{ runtimeTranslation phrase=${translatorResult} ${paramsString}}`;
   }
 }
 module.exports = PartialPreprocessor;

--- a/src/partials/partialpreprocessor.js
+++ b/src/partials/partialpreprocessor.js
@@ -1,0 +1,67 @@
+const TranslateInvocation = require('./models/translateinvocation');
+
+/**
+ * This class performs preprocessing on partials before they are registered
+ * with Handlebars. The preprocessing is applicable to any type of partial
+ * used with Jambo.
+ */
+class PartialPreprocessor {
+  constructor(translator) {
+    this._translator = translator;
+  }
+
+  /**
+   * Processes the provided partial, looking for usages of the 'translate'
+   * helper. These usages are transpiled into either a translated string or a call
+   * to the SDK's run-time translation methods.
+   * 
+   * @param {string} partial The partial to process.
+   * @returns {string} The transpiled partial.
+   */
+  process(partial) {
+    let processedPartial = partial;
+    const translateHelperCalls =
+      processedPartial.match(/\{\{\stranslate\s.+\}\}/g) || [];
+
+    translateHelperCalls.forEach(call => {
+      const translateInvocation = TranslateInvocation.from(call);
+      const transpiledCall =
+        this._handleTranslateInvocation(translateInvocation);
+      processedPartial = processedPartial.replace(call, transpiledCall);
+    });
+
+    return processedPartial;
+  }
+
+  /**
+   * Transpiles a usage of the 'translate' helper. If the translation
+   * can be resolved at compile-time (no pluralization or interpolation), the
+   * usage will be transpiled to it. Otherwise, it will be transpiled to the
+   * appropriate call to the SDK's run-time translation method.
+   * 
+   * @param {TranslateInvocation} invocation The {@link TranslateInvocation} 
+   *                                         representaiton of the usage.
+   * @returns {string} The transpiled result.
+   */
+  _handleTranslateInvocation(invocation) {
+    let translatorResult;
+    if (invocation.isUsingPluralization()) {
+      translatorResult = JSON.stringify(
+        this._translator.translatePlural(invocation.getPhrase()));
+    } else {
+      const translationContext = invocation.getContext();
+      translatorResult = translationContext ?
+        this._translator.translateWithContext(
+          invocation.getPhrase(), translationContext) :
+        this._translator.translate(invocation.getPhrase);
+      translatorResult = `'${translatorResult}'`;
+    }
+    let interpolationParams = JSON.stringify(invocation.getInterpolationParams());
+    interpolationParams = interpolationParams.replace(/[\'\"]/g, '');
+
+    return invocation.canBeTranslatedStatically() ?
+        translatorResult :
+        `ANSWERS.translateJS(${translatorResult}, ${interpolationParams})`;
+  }
+}
+module.exports = PartialPreprocessor;

--- a/src/partials/partialpreprocessor.js
+++ b/src/partials/partialpreprocessor.js
@@ -99,6 +99,7 @@ class PartialPreprocessor {
       .reduce((params, [paramName, paramValue]) => {
         return params + `${paramName}=${paramValue} `;
       }, '');
+    
     return `{ runtimeTranslation phrase=${translatorResult} ${paramsString}}`;
   }
 }

--- a/src/partials/partialpreprocessor.js
+++ b/src/partials/partialpreprocessor.js
@@ -21,7 +21,7 @@ class PartialPreprocessor {
   process(partial) {
     let processedPartial = partial;
     const translateHelperCalls =
-      processedPartial.match(/\{\{\stranslate\s.+\}\}/g) || [];
+      processedPartial.match(/\{\{\s?translate\s.+\}\}/g) || [];
 
     translateHelperCalls.forEach(call => {
       const translateInvocation = TranslateInvocation.from(call);

--- a/src/partials/partialpreprocessor.js
+++ b/src/partials/partialpreprocessor.js
@@ -63,7 +63,10 @@ class PartialPreprocessor {
     const interpParams = invocation.getInterpolationParams();
     
     return invocation.getInvokedHelper() === 'translateJS' ?
-        this._createRuntimeCallForJS(translatorResult, interpParams) :
+        this._createRuntimeCallForJS(
+          translatorResult, 
+          interpParams, 
+          invocation.isUsingPluralization()) :
         this._createRuntimeCallForHBS(translatorResult, interpParams);
   }
 
@@ -73,13 +76,19 @@ class PartialPreprocessor {
    * paramters.
    * 
    * @param {Object|string} translatorResult The translation(s) for the phrase.
+   * @param {boolean} needsPluralization If pluralization is required when translating.
    * @param {Object<string, ?>} interpolationParams The needed interpolation parameters
    *                                                (including 'count').
    * @returns {string} The string-ified call to ANSWERS.translateJS.
    */
-  _createRuntimeCallForJS(translatorResult, interpolationParams) {
+  _createRuntimeCallForJS(translatorResult, interpolationParams, needsPluralization) {
     let parsedParams = JSON.stringify(interpolationParams);
     parsedParams = parsedParams.replace(/[\'\"]/g, '');
+
+    if (needsPluralization) {
+      const count = interpolationParams.count;
+      return `ANSWERS.translateJS(${translatorResult}, ${parsedParams}, ${count})`;
+    }
 
     return `ANSWERS.translateJS(${translatorResult}, ${parsedParams})`;
   }

--- a/tests/fixtures/partials/processedcomponent.js
+++ b/tests/fixtures/partials/processedcomponent.js
@@ -24,7 +24,7 @@ class standardCardComponent extends BaseCard['standard'] {
         showLessText: 'Show less' // Label when toggle will hide truncated text
       },
       CTA1: {
-        label: ANSWERS.translateJS('Mail maintenant {{name}}', {name:profile.name}), // The CTA's label
+        label: ANSWERS.translateJS('Mail maintenant {{id1}}', {id1:profile.name}), // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened

--- a/tests/fixtures/partials/processedcomponent.js
+++ b/tests/fixtures/partials/processedcomponent.js
@@ -17,7 +17,7 @@ class standardCardComponent extends BaseCard['standard'] {
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      details: ANSWERS.translateJS({"1":"Un article {{name}}","many":"Les articles {{name}}"}, {name:profile.name,count:profile.count}), // The text in the body of the card
+      details: ANSWERS.translateJS('{"1":"Un article {{name}}","many":"Les articles {{name}}"}', {name:profile.name,count:profile.count}), // The text in the body of the card
       showMoreDetails: {
         showMoreLimit: 750, // Character count limit
         showMoreText: 'Show more', // Label when toggle will show truncated text
@@ -32,7 +32,7 @@ class standardCardComponent extends BaseCard['standard'] {
         eventOptions: this.addDefaultEventOptions()
       },
       CTA2: {
-        label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
+        label: 'Bonjour',
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
         target: '_top',

--- a/tests/fixtures/partials/processedcomponent.js
+++ b/tests/fixtures/partials/processedcomponent.js
@@ -1,0 +1,59 @@
+{{> cards/card_component componentName='standard' }}
+
+class standardCardComponent extends BaseCard['standard'] {
+  constructor(config = {}, systemConfig = {}) {
+    super(config, systemConfig);
+  }
+
+  /**
+   * This returns an object that will be called `card`
+   * in the template. Put all mapping logic here.
+   *
+   * @param profile profile of the entity in the card
+   */
+  dataForRender(profile) {
+    return {
+      title: 'Bonjour', // The header text of the card
+      url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
+      target: '_top', // If the title's URL should open in a new tab, etc.
+      titleEventOptions: this.addDefaultEventOptions(),
+      details: ANSWERS.translateJS({"1":"Un article {{name}}","many":"Les articles {{name}}"}, {name:profile.name,count:profile.count}), // The text in the body of the card
+      showMoreDetails: {
+        showMoreLimit: 750, // Character count limit
+        showMoreText: 'Show more', // Label when toggle will show truncated text
+        showLessText: 'Show less' // Label when toggle will hide truncated text
+      },
+      CTA1: {
+        label: ANSWERS.translateJS('Mail maintenant {{name}}', {name:profile.name}), // The CTA's label
+        iconName: 'chevron', // The icon to use for the CTA
+        url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
+        target: '_top', // Where the new URL will be opened
+        eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
+        eventOptions: this.addDefaultEventOptions()
+      },
+      CTA2: {
+        label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
+        iconName: 'chevron',
+        url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
+        target: '_top',
+        eventType: 'CTA_CLICK',
+        eventOptions: this.addDefaultEventOptions()
+      }
+    };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/standard';
+  }
+}
+
+ANSWERS.registerTemplate(
+  'cards/standard',
+  `{{{read 'cards/standard/template' }}}`
+);
+ANSWERS.registerComponentType(standardCardComponent);

--- a/tests/fixtures/partials/processedcomponent.js
+++ b/tests/fixtures/partials/processedcomponent.js
@@ -17,7 +17,7 @@ class standardCardComponent extends BaseCard['standard'] {
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      details: ANSWERS.translateJS('{"1":"Un article {{name}}","many":"Les articles {{name}}"}', {name:profile.name,count:profile.count}), // The text in the body of the card
+      details: ANSWERS.translateJS('{"1":"Un article {{name}}","many":"Les articles {{name}}"}', {name:profile.name,count:profile.count}, profile.count), // The text in the body of the card
       showMoreDetails: {
         showMoreLimit: 750, // Character count limit
         showMoreText: 'Show more', // Label when toggle will show truncated text

--- a/tests/fixtures/partials/processedtemplate.hbs
+++ b/tests/fixtures/partials/processedtemplate.hbs
@@ -1,0 +1,11 @@
+<div>
+    <button>'Bonjour'</button>
+    <div>
+        { runtimeTranslation phrase='{"1":"Un article {{name}}","many":"Les articles {{name}}"}' name=myName count=myCount }
+    </div>
+    <script>
+        const profile = { name: 'Tom' };
+        ANSWERS.translateJS('Mail maintenant {{id1}}', {id1:profile.name})
+    </script>
+    <button>{ runtimeTranslation phrase='Mail maintenant {{id1}}' id1=myName }</button>
+</div>

--- a/tests/fixtures/partials/rawcomponent.js
+++ b/tests/fixtures/partials/rawcomponent.js
@@ -13,18 +13,18 @@ class standardCardComponent extends BaseCard['standard'] {
    */
   dataForRender(profile) {
     return {
-      title: {{ translate phrase='Hello' }}, // The header text of the card
+      title: {{ translateJS phrase='Hello' }}, // The header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      details: {{ translate phrase='Some item {{name}}' pluralForm='Some items {{name}}' name='profile.name' count='profile.count' }}, // The text in the body of the card
+      details: {{ translateJS phrase='Some item {{name}}' pluralForm='Some items {{name}}' name=profile.name count=profile.count }}, // The text in the body of the card
       showMoreDetails: {
         showMoreLimit: 750, // Character count limit
         showMoreText: 'Show more', // Label when toggle will show truncated text
         showLessText: 'Show less' // Label when toggle will hide truncated text
       },
       CTA1: {
-        label: {{translate phrase='Mail now {{id1}}' context='Mail is a verb' id1='profile.name'}}, // The CTA's label
+        label: {{translateJS phrase='Mail now {{id1}}' context='Mail is a verb' id1=profile.name}}, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened
@@ -32,7 +32,7 @@ class standardCardComponent extends BaseCard['standard'] {
         eventOptions: this.addDefaultEventOptions()
       },
       CTA2: {
-        label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
+        label: {{ translate phrase='Hello' }},
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
         target: '_top',

--- a/tests/fixtures/partials/rawcomponent.js
+++ b/tests/fixtures/partials/rawcomponent.js
@@ -24,7 +24,7 @@ class standardCardComponent extends BaseCard['standard'] {
         showLessText: 'Show less' // Label when toggle will hide truncated text
       },
       CTA1: {
-        label: {{ translate phrase='Mail now {{name}}' context='Mail is a verb' name='profile.name' }}, // The CTA's label
+        label: {{translate phrase='Mail now {{id1}}' context='Mail is a verb' id1='profile.name'}}, // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened

--- a/tests/fixtures/partials/rawcomponent.js
+++ b/tests/fixtures/partials/rawcomponent.js
@@ -1,0 +1,59 @@
+{{> cards/card_component componentName='standard' }}
+
+class standardCardComponent extends BaseCard['standard'] {
+  constructor(config = {}, systemConfig = {}) {
+    super(config, systemConfig);
+  }
+
+  /**
+   * This returns an object that will be called `card`
+   * in the template. Put all mapping logic here.
+   *
+   * @param profile profile of the entity in the card
+   */
+  dataForRender(profile) {
+    return {
+      title: {{ translate phrase='Hello' }}, // The header text of the card
+      url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
+      target: '_top', // If the title's URL should open in a new tab, etc.
+      titleEventOptions: this.addDefaultEventOptions(),
+      details: {{ translate phrase='Some item {{name}}' pluralForm='Some items {{name}}' name='profile.name' count='profile.count' }}, // The text in the body of the card
+      showMoreDetails: {
+        showMoreLimit: 750, // Character count limit
+        showMoreText: 'Show more', // Label when toggle will show truncated text
+        showLessText: 'Show less' // Label when toggle will hide truncated text
+      },
+      CTA1: {
+        label: {{ translate phrase='Mail now {{name}}' context='Mail is a verb' name='profile.name' }}, // The CTA's label
+        iconName: 'chevron', // The icon to use for the CTA
+        url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
+        target: '_top', // Where the new URL will be opened
+        eventType: 'CTA_CLICK', // Type of Analytics event fired when clicking the CTA
+        eventOptions: this.addDefaultEventOptions()
+      },
+      CTA2: {
+        label: profile.c_secondaryCTA ? profile.c_secondaryCTA.label : null,
+        iconName: 'chevron',
+        url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
+        target: '_top',
+        eventType: 'CTA_CLICK',
+        eventOptions: this.addDefaultEventOptions()
+      }
+    };
+  }
+
+  /**
+   * The template to render
+   * @returns {string}
+   * @override
+   */
+  static defaultTemplateName (config) {
+    return 'cards/standard';
+  }
+}
+
+ANSWERS.registerTemplate(
+  'cards/standard',
+  `{{{read 'cards/standard/template' }}}`
+);
+ANSWERS.registerComponentType(standardCardComponent);

--- a/tests/fixtures/partials/rawtemplate.hbs
+++ b/tests/fixtures/partials/rawtemplate.hbs
@@ -1,0 +1,11 @@
+<div>
+    <button>{{ translate phrase='Hello' }}</button>
+    <div>
+        {{ translate phrase='Some item {{name}}' pluralForm='Some items {{name}}' name=myName count=myCount }}
+    </div>
+    <script>
+        const profile = { name: 'Tom' };
+        {{translateJS phrase='Mail now {{id1}}' context='Mail is a verb' id1=profile.name}}
+    </script>
+    <button>{{translate phrase='Mail now {{id1}}' context='Mail is a verb' id1=myName}}</button>
+</div>

--- a/tests/partials/partialpreprocessor.js
+++ b/tests/partials/partialpreprocessor.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const { readFileSync } = require('file-system');
+
+const Translator = require('../../src/i18n/translator/translator');
+const PartialPreprocessor = require('../../src/partials/partialpreprocessor');
+jest.mock('../../src/i18n/translator/translator')
+
+describe('PartialPreprocessor works correctly', () => {
+    Translator.mockImplementation(() => {
+        return {
+            translate: () => 'Bonjour',
+            translateWithContext: () => 'Mail maintenant {{name}}',
+            translatePlural: () => {
+                return {
+                    1: 'Un article {{name}}',
+                    many: 'Les articles {{name}}'
+                };
+            }
+        };
+    });
+    const translator = new Translator();
+    const partialPreprocessor = new PartialPreprocessor(translator);
+
+    it('transpiles all "translate" invocations in a JS partial', () => {
+        const rawJsPartial = readFileSync(
+            path.join(__dirname, '../fixtures/partials/rawcomponent.js'), 'utf8');
+        const processedJsPartial = readFileSync(
+            path.join(__dirname, '../fixtures/partials/processedcomponent.js'), 'utf8');
+        
+        expect(partialPreprocessor.process(rawJsPartial)).toEqual(processedJsPartial);
+    });
+});

--- a/tests/partials/partialpreprocessor.js
+++ b/tests/partials/partialpreprocessor.js
@@ -9,7 +9,7 @@ describe('PartialPreprocessor works correctly', () => {
   Translator.mockImplementation(() => {
     return {
       translate: () => 'Bonjour',
-      translateWithContext: () => 'Mail maintenant {{name}}',
+      translateWithContext: () => 'Mail maintenant {{id1}}',
       translatePlural: () => {
         return {
           1: 'Un article {{name}}',

--- a/tests/partials/partialpreprocessor.js
+++ b/tests/partials/partialpreprocessor.js
@@ -6,27 +6,27 @@ const PartialPreprocessor = require('../../src/partials/partialpreprocessor');
 jest.mock('../../src/i18n/translator/translator')
 
 describe('PartialPreprocessor works correctly', () => {
-    Translator.mockImplementation(() => {
+  Translator.mockImplementation(() => {
+    return {
+      translate: () => 'Bonjour',
+      translateWithContext: () => 'Mail maintenant {{name}}',
+      translatePlural: () => {
         return {
-            translate: () => 'Bonjour',
-            translateWithContext: () => 'Mail maintenant {{name}}',
-            translatePlural: () => {
-                return {
-                    1: 'Un article {{name}}',
-                    many: 'Les articles {{name}}'
-                };
-            }
+          1: 'Un article {{name}}',
+          many: 'Les articles {{name}}'
         };
-    });
-    const translator = new Translator();
-    const partialPreprocessor = new PartialPreprocessor(translator);
+      }
+    };
+  });
+  const translator = new Translator();
+  const partialPreprocessor = new PartialPreprocessor(translator);
 
-    it('transpiles all "translate" invocations in a JS partial', () => {
-        const rawJsPartial = readFileSync(
-            path.join(__dirname, '../fixtures/partials/rawcomponent.js'), 'utf8');
-        const processedJsPartial = readFileSync(
-            path.join(__dirname, '../fixtures/partials/processedcomponent.js'), 'utf8');
-        
-        expect(partialPreprocessor.process(rawJsPartial)).toEqual(processedJsPartial);
-    });
+  it('transpiles all "translate" invocations in a JS partial', () => {
+    const rawJsPartial = readFileSync(
+      path.join(__dirname, '../fixtures/partials/rawcomponent.js'), 'utf8');
+    const processedJsPartial = readFileSync(
+      path.join(__dirname, '../fixtures/partials/processedcomponent.js'), 'utf8');
+
+    expect(partialPreprocessor.process(rawJsPartial)).toEqual(processedJsPartial);
+  });
 });

--- a/tests/partials/partialpreprocessor.js
+++ b/tests/partials/partialpreprocessor.js
@@ -21,12 +21,21 @@ describe('PartialPreprocessor works correctly', () => {
   const translator = new Translator();
   const partialPreprocessor = new PartialPreprocessor(translator);
 
-  it('transpiles all "translate" invocations in a JS partial', () => {
+  it('transpiles all "translate" and "translateJS" invocations in a JS partial', () => {
     const rawJsPartial = readFileSync(
       path.join(__dirname, '../fixtures/partials/rawcomponent.js'), 'utf8');
     const processedJsPartial = readFileSync(
       path.join(__dirname, '../fixtures/partials/processedcomponent.js'), 'utf8');
 
     expect(partialPreprocessor.process(rawJsPartial)).toEqual(processedJsPartial);
+  });
+
+  it('transpiles all "translate" and "translateJS" invocations in a HBS partial', () => {
+    const rawHbsPartial = readFileSync(
+      path.join(__dirname, '../fixtures/partials/rawtemplate.hbs'), 'utf8');
+    const processedHbsPartial = readFileSync(
+      path.join(__dirname, '../fixtures/partials/processedtemplate.hbs'), 'utf8');
+
+    expect(partialPreprocessor.process(rawHbsPartial)).toEqual(processedHbsPartial);
   });
 });


### PR DESCRIPTION
This PR adds the PartialPreprocessor class. This class performs some processing
on partials before Jambo registers them with Handlebars. Specifically, it looks
to transpile all usages of the 'translate' helper from a partial. If the
translation can be resolved at compile-time, the 'translate' call is replaced
with the translated string. If the translation must be done at run-time, the
call is replaced with a call to the SDK's new run-time translation methods.
Translations must be done at run-time if they require pluralization or
interpolation.

Currently, the transpilation only works for JS partials. A subsequent PR will
add support for normal .hbs partials as well.

The Translator class will need to be updated to support run-time translations.
Specifically, the translatePlural method will provide all singular and plural
forms of the string. The SDK's run-time method can then choose the right form
at run-time. The translate and translateWithContext methods will need to be
updated as well to supply a formatter string when interpolation is required.
The SDK's run-time method will take the formatter string and the interpolation
options and produce the right translation.

J=SLAP-557
TEST=auto

Added unit tests for the PartialPreprocessor. In the tests, I mocked the
Translator class to have the behavior outlined above.