### PR TITLE
Return proper error codes

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -172,11 +172,11 @@ const options = yargs
     argv => {
       const themeUpgrader = new ThemeUpgrader(jamboConfig);
       themeUpgrader
-        .upgrade(jamboConfig.defaultTheme, argv.disableScript, argv.isLegacy).catch((e) => {
+        .upgrade(jamboConfig.defaultTheme, argv.disableScript, argv.isLegacy).catch((err) => {
           if(isCustomError(err)){
             exitWithError(err);
           }
-          exitWithError(new SystemError(error.message, error.stack));
+          exitWithError(new SystemError(err.message, err.stack));
         });
     })
   .strict()

--- a/src/cli.js
+++ b/src/cli.js
@@ -17,7 +17,7 @@ const { exitWithError, isCustomError } = require('./utils/errorutils');
 
 let jamboConfig;
 
-try{
+try {
   jamboConfig = fs.existsSync('jambo.json') && parseJamboConfig();
 } catch (e) {
   exitWithError(e);
@@ -44,7 +44,7 @@ const options = yargs
     argv => {
       const repositorySettings = new initCommand.RepositorySettings(argv);
       const repositoryScaffolder = new initCommand.RepositoryScaffolder();
-      repositoryScaffolder.create(repositorySettings).catch((e) => {exitWithError(e)});
+      repositoryScaffolder.create(repositorySettings).catch(e => exitWithError(e));
     })
   .command(
     'import',
@@ -59,7 +59,9 @@ const options = yargs
     argv => {
       try{
         const themeImporter = new themeCommand.ThemeImporter(jamboConfig);
-        themeImporter.import(argv.theme, argv.addAsSubmodule).then(console.log).catch((e) => {exitWithError(e)});
+        themeImporter.import(argv.theme, argv.addAsSubmodule)
+          .then(console.log)
+          .catch(e => exitWithError(e));
       } catch (e) {
         exitWithError(e);
       }
@@ -172,12 +174,13 @@ const options = yargs
     argv => {
       const themeUpgrader = new ThemeUpgrader(jamboConfig);
       themeUpgrader
-        .upgrade(jamboConfig.defaultTheme, argv.disableScript, argv.isLegacy).catch((err) => {
-          if(isCustomError(err)){
-            exitWithError(err);
-          }
-          exitWithError(new SystemError(err.message, err.stack));
-        });
+        .upgrade(jamboConfig.defaultTheme, argv.disableScript, argv.isLegacy)
+          .catch(err => {
+            if(isCustomError(err)){
+              exitWithError(err);
+            }
+            exitWithError(new SystemError(err.message, err.stack));
+          });
     })
   .strict()
   .argv;

--- a/src/cli.js
+++ b/src/cli.js
@@ -57,7 +57,7 @@ const options = yargs
           { description: 'import the theme as a submodule', default: true, type: 'boolean' });
     },
     argv => {
-      try{
+      try {
         const themeImporter = new themeCommand.ThemeImporter(jamboConfig);
         themeImporter.import(argv.theme, argv.addAsSubmodule)
           .then(console.log)
@@ -74,7 +74,7 @@ const options = yargs
         .option('path', { description: 'path in the theme to override', demandOption: true })
     },
     argv => {
-      try{
+      try {
         const shadowConfiguration = 
           new overrideCommand.ShadowConfiguration(addThemeToArgs(argv));
         const themeShadower = new overrideCommand.ThemeShadower(jamboConfig);
@@ -96,7 +96,7 @@ const options = yargs
       const pageConfiguration = 
         new addPageCommand.PageConfiguration(addThemeToArgs(argv));
       const pageScaffolder = new addPageCommand.PageScaffolder(jamboConfig);
-      try{
+      try {
         pageScaffolder.create(pageConfiguration);
       } catch (err) {
         exitWithError(new UserError("Failed to add page", err.stack));
@@ -111,7 +111,7 @@ const options = yargs
         .option('templateCardFolder', { description: 'folder of card to fork', demandOption: true });
     },
     argv => {
-      try{
+      try {
         const cardCreator = new addCardCommand.CardCreator(jamboConfig);
         cardCreator.create(argv.name, argv.templateCardFolder);
       } catch (e) {
@@ -129,7 +129,7 @@ const options = yargs
           { description: 'folder of direct answer card to fork', demandOption: true });
     },
     argv => {
-      try{
+      try {
         const cardCreator = new DirectAnswerCardCreator(jamboConfig);
         cardCreator.create(argv.name, argv.templateCardFolder);
       } catch (e) {
@@ -147,10 +147,10 @@ const options = yargs
     },
     argv => {
       const sitesGenerator = new buildCommand.SitesGenerator(jamboConfig);
-      try{
+      try {
         sitesGenerator.generate(argv.jsonEnvVars);
       } catch (err) {
-        if(isCustomError(err)){
+        if (isCustomError(err)) {
           exitWithError(err);
         }
         exitWithError(new UserError("Failed to generate the site", err.stack));
@@ -176,7 +176,7 @@ const options = yargs
       themeUpgrader
         .upgrade(jamboConfig.defaultTheme, argv.disableScript, argv.isLegacy)
           .catch(err => {
-            if(isCustomError(err)){
+            if (isCustomError(err)) {
               exitWithError(err);
             }
             exitWithError(new SystemError(err.message, err.stack));

--- a/src/cli.js
+++ b/src/cli.js
@@ -175,12 +175,12 @@ const options = yargs
       const themeUpgrader = new ThemeUpgrader(jamboConfig);
       themeUpgrader
         .upgrade(jamboConfig.defaultTheme, argv.disableScript, argv.isLegacy)
-          .catch(err => {
-            if (isCustomError(err)) {
-              exitWithError(err);
-            }
-            exitWithError(new SystemError(err.message, err.stack));
-          });
+        .catch(err => {
+          if (isCustomError(err)) {
+            exitWithError(err);
+          }
+          exitWithError(new SystemError(err.message, err.stack));
+        });
     })
   .strict()
   .argv;

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,6 +12,7 @@ const { parseJamboConfig } = require('./utils/jamboconfigutils');
 const yargs = require('yargs');
 const fs = require('file-system');
 const SystemError = require('./errors/systemerror');
+const UserError = require('./errors/usererror');
 const { exitWithError } = require('./utils/errorutils');
 
 const jamboConfig = fs.existsSync('jambo.json') && parseJamboConfig();
@@ -78,7 +79,11 @@ const options = yargs
       const pageConfiguration = 
         new addPageCommand.PageConfiguration(addThemeToArgs(argv));
       const pageScaffolder = new addPageCommand.PageScaffolder(jamboConfig);
-      pageScaffolder.create(pageConfiguration);
+      try{
+        pageScaffolder.create(pageConfiguration);
+      } catch (err) {
+        exitWithError(new UserError("Failed to add page", err.stack));
+      }
     })
   .command(
     'card',
@@ -117,7 +122,12 @@ const options = yargs
     },
     argv => {
       const sitesGenerator = new buildCommand.SitesGenerator(jamboConfig);
-      sitesGenerator.generate(argv.jsonEnvVars);
+      try{
+        sitesGenerator.generate(argv.jsonEnvVars);
+      } catch (err) {
+        exitWithError(new UserError("Failed to generate the site", err.stack));
+      }
+      
     })
   .command(
     'upgrade',

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -9,7 +9,6 @@ const _ = require('lodash');
 const { EnvironmentVariableParser } = require('../../utils/envvarparser');
 const UserError = require('../../errors/usererror');
 const SystemError = require('../../errors/systemerror');
-const { exitWithError } = require('../../utils/errorutils');
 
 exports.SitesGenerator = class {
   constructor(jamboConfig) {
@@ -27,7 +26,7 @@ exports.SitesGenerator = class {
   generate(jsonEnvVars=[]) {
     const config = this.config;
     if (!config) {
-      exitWithError(new UserError('Cannot find Jambo config in this directory, exiting.'));
+      throw new UserError('Cannot find Jambo config in this directory, exiting.');
     }
     
     // Pull all data from environment variables.
@@ -43,14 +42,14 @@ exports.SitesGenerator = class {
         try {
           pagesConfig[pageId] = parse(fs.readFileSync(path, 'utf8'), null, true);
         } catch (err) {
-          exitWithError(new UserError(err.message, err.stack));
+          throw new UserError(err.message, err.stack);
         }
       }
     })
 
     const globalConfigName = 'global_config';
     if (!pagesConfig[globalConfigName]) {
-      exitWithError(new UserError(`Cannot find ${globalConfigName} file in '` + config.dirs.config + '/\' directory.'));
+      throw new UserError(`Cannot find ${globalConfigName} file in '` + config.dirs.config + '/\' directory.');
     }
 
     // Register needed Handlebars helpers.
@@ -58,7 +57,7 @@ exports.SitesGenerator = class {
     try {
       this._registerHelpers();
     } catch (err) {
-      exitWithError(new SystemError("Failed to register jambo handlebars helpers", err.stack))
+      throw new SystemError("Failed to register jambo handlebars helpers", err.stack);
     }
 
     // Register theme partials.
@@ -67,14 +66,14 @@ exports.SitesGenerator = class {
     try {
       defaultTheme && this._registerThemePartials(defaultTheme, config.dirs.themes);
     } catch (err) {
-      exitWithError(new SystemError("Failed to register theme partials", err.stack));
+      throw new SystemError("Failed to register theme partials", err.stack);
     }
 
     // Register all custom partials.
     try {
       this._registerCustomPartials(config.dirs.partials);
     } catch (err) {
-      exitWithError(new UserError("Failed to register custom partials", err.stack));
+      throw new UserError("Failed to register custom partials", err.stack);
     }
 
     const verticalConfigs = Object.keys(pagesConfig).reduce((object, key) => {
@@ -103,7 +102,7 @@ exports.SitesGenerator = class {
         const pageId = filename.split('.')[0];
 
         if (!pagesConfig[pageId]) {
-          exitWithError(new UserError(`No config found for page: ${pageId}`));
+          throw new UserError(`No config found for page: ${pageId}`);
         }
 
         console.log(`Writing output file for the '${pageId}' page`);

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -42,7 +42,7 @@ exports.SitesGenerator = class {
         try {
           pagesConfig[pageId] = parse(fs.readFileSync(path, 'utf8'), null, true);
         } catch (err) {
-          throw new UserError(err.message, err.stack);
+          throw new UserError('JSON SyntaxError: could not parse file ' + path, err.stack);
         }
       }
     })

--- a/src/commands/card/cardcreator.js
+++ b/src/commands/card/cardcreator.js
@@ -1,7 +1,6 @@
 const fs = require('fs-extra');
 const { addToPartials } = require('../../utils/jamboconfigutils');
 const path = require('path');
-const { exitWithError } = require('../../utils/errorutils');
 const UserError = require('../../errors/usererror')
 
 exports.CardCreator = class {
@@ -31,7 +30,7 @@ exports.CardCreator = class {
         fs.existsSync(`${themeCardsDir}/${cardFolderName}`) ||
         fs.existsSync(`${this._customCardsDir}/${cardFolderName}`);
     if (isFolderInUse) {
-        exitWithError(new UserError(`A folder with name ${cardFolderName} already exists`));
+        throw new UserError(`A folder with name ${cardFolderName} already exists`);
     }
 
     const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
@@ -40,7 +39,7 @@ exports.CardCreator = class {
         fs.copySync(templateCardFolder, cardFolder);
         this._renameCardComponent(cardFolderName, cardFolder);
     } else {
-        exitWithError(new UserError(`The folder ${templateCardFolder} does not exist`));
+        throw new UserError(`The folder ${templateCardFolder} does not exist`);
     }
   }
 

--- a/src/commands/card/cardcreator.js
+++ b/src/commands/card/cardcreator.js
@@ -1,6 +1,8 @@
 const fs = require('fs-extra');
 const { addToPartials } = require('../../utils/jamboconfigutils');
 const path = require('path');
+const { exitWithError } = require('../../utils/errorutils');
+const UserError = require('../../errors/usererror')
 
 exports.CardCreator = class {
   constructor(jamboConfig) {
@@ -29,8 +31,7 @@ exports.CardCreator = class {
         fs.existsSync(`${themeCardsDir}/${cardFolderName}`) ||
         fs.existsSync(`${this._customCardsDir}/${cardFolderName}`);
     if (isFolderInUse) {
-        console.error(`A folder with name ${cardFolderName} already exists`);
-        return;
+        exitWithError(new UserError(`A folder with name ${cardFolderName} already exists`));
     }
 
     const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
@@ -39,8 +40,7 @@ exports.CardCreator = class {
         fs.copySync(templateCardFolder, cardFolder);
         this._renameCardComponent(cardFolderName, cardFolder);
     } else {
-        console.error(`The folder ${templateCardFolder} does not exist`);
-        return;
+        exitWithError(new UserError(`The folder ${templateCardFolder} does not exist`));
     }
   }
 

--- a/src/commands/directanswercard/directanswercardcreator.js
+++ b/src/commands/directanswercard/directanswercardcreator.js
@@ -2,7 +2,6 @@ const fs = require('fs-extra');
 const { addToPartials } = require('../../utils/jamboconfigutils');
 const path = require('path');
 const UserError = require('../../errors/usererror')
-const { exitWithError } = require('../../utils/errorutils');
 
 exports.DirectAnswerCardCreator = class {
   constructor(jamboConfig) {
@@ -30,7 +29,7 @@ exports.DirectAnswerCardCreator = class {
         fs.existsSync(`${themeCardsDir}/${cardFolderName}`) ||
         fs.existsSync(`${this._customCardsDir}/${cardFolderName}`);
     if (isFolderInUse) {
-        exitWithError(new UserError(`A folder with name ${cardFolderName} already exists`));
+        throw new UserError(`A folder with name ${cardFolderName} already exists`);
     }
 
     const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
@@ -39,7 +38,7 @@ exports.DirectAnswerCardCreator = class {
         fs.copySync(templateCardFolder, cardFolder);
         this._renameCardComponent(cardFolderName, cardFolder);
     } else {
-        exitWithError(new UserError(`The folder ${templateCardFolder} does not exist`));
+        throw new UserError(`The folder ${templateCardFolder} does not exist`);
     }
   }
 

--- a/src/commands/directanswercard/directanswercardcreator.js
+++ b/src/commands/directanswercard/directanswercardcreator.js
@@ -1,6 +1,8 @@
 const fs = require('fs-extra');
 const { addToPartials } = require('../../utils/jamboconfigutils');
 const path = require('path');
+const UserError = require('../../errors/usererror')
+const { exitWithError } = require('../../utils/errorutils');
 
 exports.DirectAnswerCardCreator = class {
   constructor(jamboConfig) {
@@ -28,8 +30,7 @@ exports.DirectAnswerCardCreator = class {
         fs.existsSync(`${themeCardsDir}/${cardFolderName}`) ||
         fs.existsSync(`${this._customCardsDir}/${cardFolderName}`);
     if (isFolderInUse) {
-        console.error(`A folder with name ${cardFolderName} already exists`);
-        return;
+        exitWithError(new UserError(`A folder with name ${cardFolderName} already exists`));
     }
 
     const cardFolder = `${this._customCardsDir}/${cardFolderName}`;
@@ -38,8 +39,7 @@ exports.DirectAnswerCardCreator = class {
         fs.copySync(templateCardFolder, cardFolder);
         this._renameCardComponent(cardFolderName, cardFolder);
     } else {
-        console.error(`The folder ${templateCardFolder} does not exist`);
-        return;
+        exitWithError(new UserError(`The folder ${templateCardFolder} does not exist`));
     }
   }
 

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -7,6 +7,9 @@ const {
 } = require('comment-json');
 const { ShadowConfiguration, ThemeShadower } = require('../override/themeshadower');
 const { getRepoForTheme } = require('../../utils/gitutils');
+const SystemError = require('../../errors/systemerror');
+const UserError = require('../../errors/usererror');
+const { exitWithError } = require('../../utils/errorutils');
 
 exports.ThemeImporter = class {
   constructor(jamboConfig) {
@@ -26,8 +29,7 @@ exports.ThemeImporter = class {
    */
   async import(themeName, addAsSubmodule) {
     if (!this.config) {
-      console.warn('No jambo.json found. Did you `jambo init` yet?')
-      return;
+      exitWithError(new UserError('No jambo.json found. Did you `jambo init` yet?'));
     }
     try {
       const themeRepo = getRepoForTheme(themeName);
@@ -47,8 +49,8 @@ exports.ThemeImporter = class {
       this._copyLayoutFiles(themeName);
 
       return localPath;
-    } catch (error) {
-      return Promise.reject(error.toString());
+    } catch (err) {
+      exitWithError(new SystemError(err.message, err.stack));
     }
   }
 

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -50,7 +50,7 @@ exports.ThemeImporter = class {
 
       return localPath;
     } catch (err) {
-      if(isCustomError(err)){
+      if (isCustomError(err)) {
         throw err;
       }
       throw new SystemError(err.message, err.stack);

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -9,7 +9,7 @@ const { ShadowConfiguration, ThemeShadower } = require('../override/themeshadowe
 const { getRepoForTheme } = require('../../utils/gitutils');
 const SystemError = require('../../errors/systemerror');
 const UserError = require('../../errors/usererror');
-const { exitWithError } = require('../../utils/errorutils');
+const { isCustomError } = require('../../utils/errorutils');
 
 exports.ThemeImporter = class {
   constructor(jamboConfig) {
@@ -29,7 +29,7 @@ exports.ThemeImporter = class {
    */
   async import(themeName, addAsSubmodule) {
     if (!this.config) {
-      exitWithError(new UserError('No jambo.json found. Did you `jambo init` yet?'));
+      throw new UserError('No jambo.json found. Did you `jambo init` yet?');
     }
     try {
       const themeRepo = getRepoForTheme(themeName);
@@ -50,7 +50,10 @@ exports.ThemeImporter = class {
 
       return localPath;
     } catch (err) {
-      exitWithError(new SystemError(err.message, err.stack));
+      if(isCustomError(err)){
+        throw err;
+      }
+      throw new SystemError(err.message, err.stack);
     }
   }
 

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -4,7 +4,6 @@ const fs = require('file-system');
 const simpleGit = require('simple-git/promise');
 const SystemError = require('../../errors/systemerror');
 const git = simpleGit();
-const { exitWithError } = require('../../utils/errorutils')
 
 /**
  * RepositorySettings contains the information needed by Jambo to scaffold a new site repository.
@@ -50,7 +49,7 @@ exports.RepositoryScaffolder = class {
           repositorySettings.shouldAddThemeAsSubmodule());
       }
     } catch (err) {
-      exitWithError(new SystemError(err.message, err.stack));
+      throw new SystemError(err.message, err.stack);
     }
   }
 

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -2,7 +2,9 @@ const themeCommand = require('../import/themeimporter');
 
 const fs = require('file-system');
 const simpleGit = require('simple-git/promise');
+const SystemError = require('../../errors/systemerror');
 const git = simpleGit();
+const { exitWithError } = require('../../utils/errorutils')
 
 /**
  * RepositorySettings contains the information needed by Jambo to scaffold a new site repository.
@@ -47,8 +49,8 @@ exports.RepositoryScaffolder = class {
           theme, 
           repositorySettings.shouldAddThemeAsSubmodule());
       }
-    } catch (error) {
-      return Promise.reject(error.toString());
+    } catch (err) {
+      exitWithError(new SystemError(err.message, err.stack));
     }
   }
 

--- a/src/commands/override/themeshadower.js
+++ b/src/commands/override/themeshadower.js
@@ -1,6 +1,8 @@
 const fs = require('file-system');
 const path = require('path');
 const { addToPartials } = require('../../utils/jamboconfigutils');
+const UserError = require('../../errors/usererror');
+const { exitWithError } = require('../../utils/errorutils');
 
 /**
  * The ShadowConfiguration specifies what file(s) should be shadowed for a particular theme.
@@ -10,7 +12,7 @@ const { addToPartials } = require('../../utils/jamboconfigutils');
 exports.ShadowConfiguration = class {
   constructor({ theme, path }) {
     if (!theme || !path) {
-      throw new Error('Theme and path must be specified when shadowing');
+      exitWithError(new UserError('Theme and path must be specified when shadowing'));
     }
 
     this._theme = theme;

--- a/src/commands/override/themeshadower.js
+++ b/src/commands/override/themeshadower.js
@@ -44,9 +44,9 @@ exports.ThemeShadower = class {
     const pathToTheme = `${this.config.dirs.themes}/${theme}`;
     const fullPathInThemes = `${pathToTheme}/${path}`;
 
-    try{
+    try {
       this._createShadowDir(fullPathInThemes, path);
-    } catch (err){
+    } catch (err) {
       throw new UserError('Override failed', err.stack);
     }
     

--- a/src/commands/override/themeshadower.js
+++ b/src/commands/override/themeshadower.js
@@ -2,7 +2,6 @@ const fs = require('file-system');
 const path = require('path');
 const { addToPartials } = require('../../utils/jamboconfigutils');
 const UserError = require('../../errors/usererror');
-const { exitWithError } = require('../../utils/errorutils');
 
 /**
  * The ShadowConfiguration specifies what file(s) should be shadowed for a particular theme.
@@ -12,7 +11,7 @@ const { exitWithError } = require('../../utils/errorutils');
 exports.ShadowConfiguration = class {
   constructor({ theme, path }) {
     if (!theme || !path) {
-      exitWithError(new UserError('Theme and path must be specified when shadowing'));
+      throw new UserError('Theme and path must be specified when shadowing');
     }
 
     this._theme = theme;
@@ -48,7 +47,7 @@ exports.ThemeShadower = class {
     try{
       this._createShadowDir(fullPathInThemes, path);
     } catch (err){
-      exitWithError(new UserError('Override failed', err.stack));
+      throw new UserError('Override failed', err.stack);
     }
     
     addToPartials(path);

--- a/src/commands/override/themeshadower.js
+++ b/src/commands/override/themeshadower.js
@@ -45,7 +45,12 @@ exports.ThemeShadower = class {
     const pathToTheme = `${this.config.dirs.themes}/${theme}`;
     const fullPathInThemes = `${pathToTheme}/${path}`;
 
-    this._createShadowDir(fullPathInThemes, path);
+    try{
+      this._createShadowDir(fullPathInThemes, path);
+    } catch (err){
+      exitWithError(new UserError('Override failed', err.stack));
+    }
+    
     addToPartials(path);
   }
 
@@ -53,7 +58,7 @@ exports.ThemeShadower = class {
    * Creates the necessary local directories for the provided shadow. If the
    * shadow corresponds to a top-level file, no new directories will be created.
    *
-   * @param {boolean} isFile If the shadow corresponds to a single file.
+   * @param {string} fullPathInThemes The path inside the theme
    * @param {string} localShadowPath The path of the new, local shadow.
    */
   _createShadowDir(fullPathInThemes, localShadowPath) {

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -6,7 +6,7 @@ const { getRepoForTheme } = require('../../utils/gitutils');
 const { CustomCommand } = require('../../utils/customcommands/command');
 const { CustomCommandExecuter } = require('../../utils/customcommands/commandexecuter');
 const SystemError = require('../../errors/systemerror');
-const { exitWithError } = require('../../utils/errorutils');
+const UserError = require('../../errors/systemerror');
 
 const git = simpleGit();
 
@@ -31,7 +31,7 @@ exports.ThemeUpgrader = class {
   async upgrade(themeName, disableScript, isLegacy) {
     const themePath = path.join(this._themesDir, themeName);
     if (!fs.existsSync(themePath)) {
-      exitWithError(new SystemError(`Theme "${themeName}" not found within the "${this._themesDir}" folder`));
+      throw new UserError(`Theme "${themeName}" not found within the "${this._themesDir}" folder`);
     }
     await this._isGitSubmodule(themePath)
       ? await this._upgradeSubmodule(themePath)
@@ -67,7 +67,9 @@ exports.ThemeUpgrader = class {
     const stdoutString = stdout.toString().trim();
     const stderrString = stderr.toString().trim();
     stdoutString && console.log(stdoutString);
-    stderrString && exitWithError(new SystemError("Error executing theme post upgrade script", stderrString));
+    if(stderrString){
+      throw new SystemError("Error executing theme post upgrade script", stderrString);
+    }
   } 
 
   /**

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -67,7 +67,7 @@ exports.ThemeUpgrader = class {
     const stdoutString = stdout.toString().trim();
     const stderrString = stderr.toString().trim();
     stdoutString && console.log(stdoutString);
-    if(stderrString){
+    if (stderrString) {
       throw new SystemError("Error executing theme post upgrade script", stderrString);
     }
   } 

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -5,6 +5,8 @@ const simpleGit = require('simple-git/promise');
 const { getRepoForTheme } = require('../../utils/gitutils');
 const { CustomCommand } = require('../../utils/customcommands/command');
 const { CustomCommandExecuter } = require('../../utils/customcommands/commandexecuter');
+const SystemError = require('../../errors/systemerror');
+const { exitWithError } = require('../../utils/errorutils');
 
 const git = simpleGit();
 
@@ -29,7 +31,7 @@ exports.ThemeUpgrader = class {
   async upgrade(themeName, disableScript, isLegacy) {
     const themePath = path.join(this._themesDir, themeName);
     if (!fs.existsSync(themePath)) {
-      throw new Error(`theme "${themeName}" not found within the "${this._themesDir}" folder`)
+      exitWithError(new SystemError(`Theme "${themeName}" not found within the "${this._themesDir}" folder`));
     }
     await this._isGitSubmodule(themePath)
       ? await this._upgradeSubmodule(themePath)
@@ -64,8 +66,8 @@ exports.ThemeUpgrader = class {
     const { stdout, stderr } = new CustomCommandExecuter(this.config).execute(customCommand);
     const stdoutString = stdout.toString().trim();
     const stderrString = stderr.toString().trim();
-    stderrString && console.error(stderrString);
     stdoutString && console.log(stdoutString);
+    stderrString && exitWithError(new SystemError("Error executing theme post upgrade script", stderrString));
   } 
 
   /**

--- a/src/errors/systemerror.js
+++ b/src/errors/systemerror.js
@@ -6,10 +6,10 @@ class SystemError extends Error {
   constructor (message, stack) {
     super(message);
 
-    if(stack){
+    if (stack) {
       this.stack = stack;
       this.message = message;
-    }else{
+    } else {
       Error.captureStackTrace(this, this.constructor);
     }
 

--- a/src/errors/systemerror.js
+++ b/src/errors/systemerror.js
@@ -1,0 +1,20 @@
+/**
+ * Represents errors related to the system which are
+ * not likely to be caused by users of jambo
+ */
+class SystemError extends Error {  
+  constructor (message, stack) {
+    super(message);
+
+    if(stack){
+      this.stack = stack;
+    }else{
+      Error.captureStackTrace(this, this.constructor);
+    }
+
+    this.name = 'SystemError'
+    this.exitCode = 14;
+  }
+}
+
+module.exports = SystemError;

--- a/src/errors/systemerror.js
+++ b/src/errors/systemerror.js
@@ -8,6 +8,7 @@ class SystemError extends Error {
 
     if(stack){
       this.stack = stack;
+      this.message = message;
     }else{
       Error.captureStackTrace(this, this.constructor);
     }

--- a/src/errors/usererror.js
+++ b/src/errors/usererror.js
@@ -7,6 +7,7 @@ class UserError extends Error {
 
     if(stack){
       this.stack = stack;
+      this.message = message;
     }else{
       Error.captureStackTrace(this, this.constructor);
     }

--- a/src/errors/usererror.js
+++ b/src/errors/usererror.js
@@ -1,0 +1,19 @@
+/**
+ * Represents errors that we may reasonably expect a user to make
+ */
+class UserError extends Error {  
+  constructor (message, stack) {
+    super(message);
+
+    if(stack){
+      this.stack = stack;
+    }else{
+      Error.captureStackTrace(this, this.constructor);
+    }
+
+    this.name = 'UserError'
+    this.exitCode = 13;
+  }
+}
+
+module.exports = UserError;

--- a/src/errors/usererror.js
+++ b/src/errors/usererror.js
@@ -5,10 +5,10 @@ class UserError extends Error {
   constructor (message, stack) {
     super(message);
 
-    if(stack){
+    if (stack) {
       this.stack = stack;
       this.message = message;
-    }else{
+    } else {
       Error.captureStackTrace(this, this.constructor);
     }
 

--- a/src/utils/errorutils.js
+++ b/src/utils/errorutils.js
@@ -1,0 +1,11 @@
+/**
+ * Print the error, and then end the 
+ * process with the specified exit code
+ * @param {Error} error
+ */
+exports.exitWithError = (err) => {
+  console.error(err.message);
+  console.error(err.stack);
+  exitCode = err.exitCode || 1;
+  process.exit(exitCode);
+}

--- a/src/utils/errorutils.js
+++ b/src/utils/errorutils.js
@@ -1,11 +1,16 @@
+const fs = require('fs');
+
 /**
- * Print the error, and then end the 
- * process with the specified exit code
+ * Print the error, and then forcefully end the 
+ * process with the specified exit code. Pending
+ * async operations will be lost.
  * @param {Error} error
  */
 exports.exitWithError = (err) => {
-  console.error(err.message);
-  console.error(err.stack);
-  exitCode = err.exitCode || 1;
+  fs.writeSync(process.stderr.fd,
+    `${err.message}\n` +
+    `${err.stack}`
+  );
+  const exitCode = err.exitCode || 1;
   process.exit(exitCode);
 }

--- a/src/utils/errorutils.js
+++ b/src/utils/errorutils.js
@@ -1,4 +1,6 @@
 const fs = require('fs');
+const UserError = require('../errors/usererror');
+const SystemError = require('../errors/systemerror');
 
 /**
  * Print the error, and then forcefully end the 
@@ -13,4 +15,13 @@ exports.exitWithError = (err) => {
   );
   const exitCode = err.exitCode || 1;
   process.exit(exitCode);
+}
+
+/**
+ * Returns true if the error is a custom error
+ * (Either UserError or SystemError)
+ * @param {Error} err The error to evaluate
+ */
+exports.isCustomError = (err) => {
+  return (err instanceof UserError || err instanceof SystemError);
 }

--- a/src/utils/gitutils.js
+++ b/src/utils/gitutils.js
@@ -1,4 +1,3 @@
-const { exitWithError } = require('../utils/errorutils')
 const UserError = require('../errors/usererror')
 /**
  * Gets the git repo URL for the given theme name.
@@ -9,6 +8,6 @@ exports.getRepoForTheme = function(themeName) {
     case 'answers-hitchhiker-theme':
       return 'git@github.com:yext/answers-hitchhiker-theme.git';
     default:
-      exitWithError(new UserError('Unrecognized theme'));
+      throw new UserError('Unrecognized theme');
   }
 }

--- a/src/utils/gitutils.js
+++ b/src/utils/gitutils.js
@@ -1,3 +1,5 @@
+const { exitWithError } = require('../utils/errorutils')
+const UserError = require('../errors/usererror')
 /**
  * Gets the git repo URL for the given theme name.
  * @param {string} themeName 
@@ -7,6 +9,6 @@ exports.getRepoForTheme = function(themeName) {
     case 'answers-hitchhiker-theme':
       return 'git@github.com:yext/answers-hitchhiker-theme.git';
     default:
-      throw 'Unrecognized theme';
+      exitWithError(new UserError('Unrecognized theme'));
   }
 }

--- a/src/utils/jamboconfigutils.js
+++ b/src/utils/jamboconfigutils.js
@@ -14,7 +14,7 @@ const UserError = require('../errors/usererror');
  * @returns {Object} The parsed Jambo configuration, as an {@link Object}. 
  */
 parseJamboConfig = function() {
-  try{
+  try {
     let config = mergeOptions(
       {
         dirs: {

--- a/src/utils/jamboconfigutils.js
+++ b/src/utils/jamboconfigutils.js
@@ -5,6 +5,8 @@ const {
   parse,
   stringify
 } = require('comment-json');
+const { exitWithError } = require('./errorutils');
+const UserError = require('../errors/usererror');
 
 /**
  * Parses the repository's Jambo config file. If certain attributes are not
@@ -13,19 +15,24 @@ const {
  * @returns {Object} The parsed Jambo configuration, as an {@link Object}. 
  */
 parseJamboConfig = function() {
-  let config = mergeOptions(
-    {
-      dirs: {
-        themes: 'themes',
-        config: 'config',
-        output: 'public',
-        pages: 'pages',
-        partials: ['partials'],
-      }
-    },
-    parse(fs.readFileSync('jambo.json', 'utf8'))
-  );
-  return config;
+  try{
+    let config = mergeOptions(
+      {
+        dirs: {
+          themes: 'themes',
+          config: 'config',
+          output: 'public',
+          pages: 'pages',
+          partials: ['partials'],
+        }
+      },
+      parse(fs.readFileSync('jambo.json', 'utf8'))
+    );
+    return config;
+  } catch (err) {
+    exitWithError(new UserError("Error parsing jambo.json", err.stack));
+  }
+  
 }
 exports.parseJamboConfig = parseJamboConfig;
 

--- a/src/utils/jamboconfigutils.js
+++ b/src/utils/jamboconfigutils.js
@@ -5,7 +5,6 @@ const {
   parse,
   stringify
 } = require('comment-json');
-const { exitWithError } = require('./errorutils');
 const UserError = require('../errors/usererror');
 
 /**
@@ -30,7 +29,7 @@ parseJamboConfig = function() {
     );
     return config;
   } catch (err) {
-    exitWithError(new UserError("Error parsing jambo.json", err.stack));
+    throw new UserError("Error parsing jambo.json", err.stack);
   }
   
 }


### PR DESCRIPTION
Jambo now returns the following codes:
| Exit code | Reason              |
|-----------|---------------------|
| 0         | Success             |
| 1         | Unhandled Exception |
| 13        | UserError           |
| 14        | SystemError         |

This commit adds an exitWithError() function to errorutils which will print the error and then terminate jambo. If a UserError or SystemError is passed to exitWithError, then jambo will exit with codes 13 or 14 respectively. Any other Errors passed will terminate jambo with exit code 1. I chose codes 13 and 14 since node process has definitions for most codes between 2 and 12.

In general, a UserError or a SystemError should be thrown so that they can be caught inside src/cli.js and passed to exitWithError().

J=SLAP-538
TEST=manual

I tested various fail cases and observed the exit codes:
| Exit Code | Error                                                   |
|-----------|---------------------------------------------------------|
| 1         | Invalid command                                     |
| 13        | Attempt to import invalid theme                         |
| 13        | Overriding without having the theme imported            |
| 13        | Attempt to import before running init                   |
| 13        | Add card with invalid card to fork                      |
| 13        | Create direct answer card in folder that already exists |
| 13        | Jambo config incorrectly named                          |
| 13        | Invalid jambo config                               |
| 13        | Global config incorrectly named                         |
| 13        | Invalid global config                                   |
| 13         | Override a path that doesn't exist                      |
| 13         | Add page with invalid template                          |
| 13         | Handlebars build syntax error                                   |
| 14        | Cannot find module fs-extra when upgrading theme        |
|14        | Attempting to upgrade when the site is not a git repo   |