### PR TITLE
Add support for global_configs that do not have any locale information

### DIFF
--- a/src/commands/build/globalconfiglocalizer.js
+++ b/src/commands/build/globalconfiglocalizer.js
@@ -27,7 +27,7 @@ module.exports = class GlobalConfigLocalizer {
       ...globalConfig.getConfig(),
       experienceKey: experienceKey,
       apiKey: apiKey,
-      locale: locale
+      ...locale && { locale: locale }
     });
   }
 }

--- a/src/models/configurationregistry.js
+++ b/src/models/configurationregistry.js
@@ -78,7 +78,7 @@ module.exports = class ConfigurationRegistry {
 
     const rawLocaleConfig = configNameToRawConfig[localizationConfigName];
     if (!rawLocaleConfig) {
-      console.log(`Cannot find '${localizationConfigName}', writing pages without locale information.`);
+      console.log(`Cannot find '${localizationConfigName}', using locale information from ${globalConfigName}.`);
     }
 
     const pageConfigs = Object.keys(configNameToRawConfig)


### PR DESCRIPTION
Previously in cases where there was no "locale" specified in the global config, we would create a localized global config with locale set to the empty string. Since missing locale isn't the same thing as empty string locale, only add "locale" to the global config if it's present. Also updated a console log to be clearer.

TEST=manual,unit
J=SLAP-561

Test locally with a site with no locale_config and a global_config without a "locale". Run `jambo build`, print global config from template and see locale is absent. Test setting locale to "en", jambo building, then see locale: "en" printed in template. Test setting locale to empty string and see locale: "" printed in template.