### PR TITLE
Update PageTemplates to use a Partials domain model

### DIFF
--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -46,7 +46,7 @@ module.exports = class PageWriter {
         pageNameToConfig: pageSet.getPageNameToConfig(),
       });
 
-      const template = this._compileHandlebarsTemplate(page.getTemplateContents());
+      const template = hbs.compile(page.getTemplateContents());
       const outputHTML = template(templateArguments);
 
       fs.writeFileSync(
@@ -54,16 +54,6 @@ module.exports = class PageWriter {
         outputHTML
       );
     }
-  }
-
-  /**
-   * Gets the Handlebars template for a given path
-   *
-   * @param {String} templateContents the contents of the page handlebars template file
-   * @returns {HandlebarsTemplateDelegate<T>}
-   */
-  _compileHandlebarsTemplate (templateContents) {
-    return hbs.compile(templateContents);
   }
 
   /**

--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -36,9 +36,6 @@ module.exports = class PageWriter {
       if (!page.getConfig()) {
         throw new Error(`Error: No config found for page: ${page.getPageName()}`);
       }
-      if (!page.getTemplatePath()) {
-        throw new Error(`Error: No template found for page: ${page.getPageName()}`);
-      }
 
       console.log(`Writing output file for the '${page.getPageName()}' page`);
       const templateArguments = this._buildArgsForTemplate({
@@ -48,7 +45,8 @@ module.exports = class PageWriter {
         globalConfig: pageSet.getGlobalConfig().getConfig(),
         pageNameToConfig: pageSet.getPageNameToConfig(),
       });
-      const template = this._getHandlebarsTemplate(page.getTemplatePath());
+
+      const template = this._compileHandlebarsTemplate(page.getTemplateContents());
       const outputHTML = template(templateArguments);
 
       fs.writeFileSync(
@@ -61,11 +59,11 @@ module.exports = class PageWriter {
   /**
    * Gets the Handlebars template for a given path
    *
-   * @param {String} path the path to the page handlebars template
+   * @param {String} templateContents the contents of the page handlebars template file
    * @returns {HandlebarsTemplateDelegate<T>}
    */
-  _getHandlebarsTemplate (path) {
-    return hbs.compile(fs.readFileSync(path).toString());
+  _compileHandlebarsTemplate (templateContents) {
+    return hbs.compile(templateContents);
   }
 
   /**

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -59,7 +59,8 @@ exports.SitesGenerator = class {
     let pageTemplates = [];
     fs.recurseSync(config.dirs.pages, (path, relative, filename) => {
       if (this._isValidFile(filename)) {
-        pageTemplates.push(PageTemplate.from(filename, path));
+        const fileContents = fs.readFileSync(path).toString();
+        pageTemplates.push(PageTemplate.from(filename, path, fileContents));
       }
     });
 

--- a/src/commands/build/templatedirector.js
+++ b/src/commands/build/templatedirector.js
@@ -42,11 +42,9 @@ module.exports = class TemplateDirector {
         const pageTemplate = this._findPageTemplateForLocale(locale, templates);
 
         if (pageTemplate) {
-          localizedPageTemplates[locale].push(new PageTemplate({
-            pageName: pageTemplate.getPageName(),
-            path: pageTemplate.getTemplatePath(),
-            locale: locale
-          }));
+          const localizedTemplate = pageTemplate.clone()
+            .setLocale(locale);
+          localizedPageTemplates[locale].push(localizedTemplate);
         }
       }
     }

--- a/src/models/page.js
+++ b/src/models/page.js
@@ -9,19 +9,19 @@ const { stripExtension } = require('../utils/fileutils');
 module.exports = class Page {
   /**
    * @param {PageConfig} pageConfig
-   * @param {PageTemplate} pageTemplate
+   * @param {String} templateContents
    * @param {String} outputPath
    */
-  constructor({ pageConfig, pageTemplate, outputPath }) {
+  constructor({ pageConfig, templateContents, outputPath }) {
     /**
      * @type {PageConfig}
      */
     this.pageConfig = pageConfig;
 
     /**
-     * @type {PageTemplate}
+     * @type {String}
      */
-    this.pageTemplate = pageTemplate;
+    this.templateContents = templateContents;
 
     /**
      * @type {String}
@@ -61,12 +61,12 @@ module.exports = class Page {
   }
 
   /**
-   * Returns the page's template path
+   * Returns the file contents of the page's template
    *
    * @returns {String}
    */
-  getTemplatePath () {
-    return this.pageTemplate.getTemplatePath();
+  getTemplateContents() {
+    return this.templateContents;
   }
 
   /**
@@ -86,13 +86,13 @@ module.exports = class Page {
   static from({ pageConfig, pageTemplate, urlFormatter }) {
     const outputPath = Page.buildUrl(
       pageConfig.getPageName(),
-      pageTemplate.getTemplatePath(),
+      pageTemplate.getPath(),
       urlFormatter
     );
 
     return new Page({
       pageConfig: pageConfig,
-      pageTemplate: pageTemplate,
+      templateContents: pageTemplate.getFileContents(),
       outputPath: outputPath
     });
   }

--- a/src/models/pagetemplate.js
+++ b/src/models/pagetemplate.js
@@ -50,6 +50,29 @@ module.exports = class PageTemplate {
   }
 
   /**
+   * Updates the locale
+   *
+   * @param {String} locale
+   */
+  setLocale(locale) {
+    this.locale = locale;
+    return this;
+  }
+
+  /**
+   * Creates a a copy of this PageTemplate
+   *
+   * @returns {PageTemplate}
+   */
+  clone () {
+    return new PageTemplate({
+      locale: this.locale,
+      path: this.path,
+      pageName: this.pageName
+    });
+  }
+
+  /**
    * Creates a @type {PageTemplate} from a given filename and path
    *
    * @param {String} filename

--- a/src/models/pagetemplate.js
+++ b/src/models/pagetemplate.js
@@ -1,15 +1,13 @@
 const { getPageName } = require('../utils/fileutils');
+const Partial = require('./partial');
 
 /**
- * PageTemplate represents a Handlebars template file that is
+ * PageTemplate represents a Handlebars template partial that is
  * used to generate a page.
  */
-module.exports = class PageTemplate {
-  constructor({ pageName, path, locale }) {
-    /**
-     * @type {String}
-     */
-    this.path = path;
+module.exports = class PageTemplate extends Partial {
+  constructor({ path, fileContents, pageName, locale }) {
+    super(path, fileContents);
 
     /**
      * @type {String}
@@ -29,15 +27,6 @@ module.exports = class PageTemplate {
    */
   getPageName() {
     return this.pageName;
-  }
-
-  /**
-   * Returns the template path
-   *
-   * @returns {String} template path
-   */
-  getTemplatePath() {
-    return this.path;
   }
 
   /**
@@ -68,6 +57,7 @@ module.exports = class PageTemplate {
     return new PageTemplate({
       locale: this.locale,
       path: this.path,
+      fileContents: this.fileContents,
       pageName: this.pageName
     });
   }
@@ -77,15 +67,17 @@ module.exports = class PageTemplate {
    *
    * @param {String} filename
    * @param {String} path
+   * @param {String} fileContents
    * @returns {PageTemplate}
    */
-  static from (filename, path) {
+  static from (filename, path, fileContents) {
     if (!filename) {
       throw new Error('Error: no filename provided for page template');
     }
 
     return new PageTemplate({
       path: path,
+      fileContents: fileContents,
       pageName: getPageName(filename),
       locale: PageTemplate.parseLocale(filename)
     });

--- a/src/models/partial.js
+++ b/src/models/partial.js
@@ -1,0 +1,49 @@
+const { stripExtension } = require("../utils/fileutils");
+
+/**
+ * A data model representing a partial that registered with Jambo.
+ */
+module.exports = class Partial {
+  /**
+   * @param {String} path
+   * @param {String} fileContents
+   */
+  constructor(path, fileContents) {
+    /**
+     * @type {String}
+     */
+    this.path = path;
+
+    /**
+     * @type {String}
+     */
+    this.fileContents = fileContents;
+  }
+
+  /**
+   * Returns the partial name
+   *
+   * @returns {String}
+   */
+  getName() {
+    return stripExtension(this.path);
+  }
+
+  /**
+   * Returns the partial's path
+   *
+   * @returns {String}
+   */
+  getPath() {
+    return this.path;
+  }
+
+  /**
+   * Returns the partial's contents
+   *
+   * @returns {String}
+   */
+  getFileContents() {
+    return this.fileContents;
+  }
+}

--- a/tests/commands/build/templatedirector.js
+++ b/tests/commands/build/templatedirector.js
@@ -77,14 +77,14 @@ describe('TemplateDirector directs PageTemplates and builds the expected object'
         new PageTemplate({
           pageName: pageTemplates['en'].getPageName(),
           locale: 'es',
-          path: pageTemplates['en'].getTemplatePath()
+          path: pageTemplates['en'].getPath()
         }),
       ],
       'de': [ // Directs to template with correct fallback locale
         new PageTemplate({
           pageName: pageTemplates['fr'].getPageName(),
           locale: 'de',
-          path: pageTemplates['fr'].getTemplatePath()
+          path: pageTemplates['fr'].getPath()
         }),
       ],
       'fr': [ // Directs to template with current locale if present

--- a/tests/models/generateddata.js
+++ b/tests/models/generateddata.js
@@ -103,7 +103,7 @@ describe('GeneratedData is correctly formed using with static from', () => {
             pageTemplate: new PageTemplate({
               locale: locale,
               pageName: pageTemplate1.getPageName(),
-              path: pageTemplate1.getTemplatePath(),
+              path: pageTemplate1.getPath(),
             }),
             outputPath: `${pageConfig1.getPageName()}.html`
           }),
@@ -116,7 +116,7 @@ describe('GeneratedData is correctly formed using with static from', () => {
             pageTemplate: new PageTemplate({
               locale: locale,
               pageName: pageTemplate2.getPageName(),
-              path: pageTemplate2.getTemplatePath(),
+              path: pageTemplate2.getPath(),
             }),
             outputPath: `${pageConfig2.getPageName()}.html`
           }),

--- a/tests/models/page.js
+++ b/tests/models/page.js
@@ -10,6 +10,7 @@ describe('Correctly forms Page object using static from', () => {
     config: 'some config'
   };
   const templatePath = `pages/${pageName}.${locale}.${pageExt}.hbs`;
+  const pageContents = '<html></html>';
   let page = Page.from({
     pageConfig: new PageConfig({
       pageName: pageName,
@@ -19,7 +20,8 @@ describe('Correctly forms Page object using static from', () => {
     pageTemplate: new PageTemplate({
       pageName: pageName,
       locale: locale,
-      path: templatePath
+      path: templatePath,
+      fileContents: pageContents
     }),
     urlFormatter: ((pageName, pageExt) => `${pageName}.${pageExt}.${pageExt}.aspx`),
   });
@@ -31,7 +33,7 @@ describe('Correctly forms Page object using static from', () => {
       ...rawConfig,
       url: page.getOutputPath()
     });
-    expect(page.getTemplatePath()).toEqual(templatePath);
+    expect(page.getTemplateContents()).toEqual(pageContents);
     expect(page.getOutputPath()).toEqual(`${pageName}.${pageExt}.${pageExt}.aspx`);
   });
 });


### PR DESCRIPTION
We need to preprocess all the partials for internationalization work. This means we can't read in the file right before we write it, so instead of storing the templatePath on the page it makes more sense to store the contents of that file. This makes it simpler to preprocess or transpile the contents of the template file. 

TEST=unit,manual

Run `jambo build && grunt webpack` on local internationalized test site. View pages in browser and confirm they look as expected.