### PR TITLE
translator.js: pass locale to runtime helpers, set first key to 0

### DIFF
--- a/src/i18n/translator/translator.js
+++ b/src/i18n/translator/translator.js
@@ -35,11 +35,12 @@ class Translator {
    * 
    * @param {string} phrase The phrase to translate.
    * @param {string} pluralForm The untranslated, plural form of the phrase.
+   * @param {string} originalLocale The original locale of the passed in phrase.
    * @returns {Object<string|number, string>} A map containing the various forms.
    *                                          A form is keyed by the
    *                                          corresponding count or 'plural'.
    */
-  translatePlural(phrase, pluralForm) {
+  translatePlural(phrase, pluralForm, originalLocale = 'en') {
     const escapedPhrase = phrase
       .replace(/\[\[/g, '\\[\\[')
       .replace(/\]\]/g, '\\]\\]');
@@ -55,7 +56,7 @@ class Translator {
     if (localeWithPluralTranslations) {
       const localeTranslations = 
         i18nextOptions.resources[localeWithPluralTranslations].translation;
-      
+
       // Create a map of count (or 'plural') to the correct translated form.
       return Object.keys(localeTranslations)
         .filter(translationKey => pluralKeyRegex.test(translationKey))
@@ -65,14 +66,15 @@ class Translator {
             pluralForms[pluralFormIndex] = localeTranslations[translationKey];
             return pluralForms;
           }, 
-          { 1: localeTranslations[phrase] });
+          { 0: localeTranslations[phrase], locale: localeWithPluralTranslations });
     } 
     
     // If no translations can be found, we return a map containing the provided
     // singular and plural forms.
     return {
-      1: phrase,
-      plural: pluralForm
+      0: phrase,
+      plural: pluralForm,
+      locale: originalLocale
     };
   }
 

--- a/tests/fixtures/translations/lt-LT.po
+++ b/tests/fixtures/translations/lt-LT.po
@@ -1,0 +1,13 @@
+#: js/yext/pages/common/sitefields.js:36
+msgid "1 location selected"
+msgid_plural "[[count]] locations selected"
+msgstr[0] "Pasirinkta [[count]] tinklalapis"
+msgstr[1] "Pasirinkta [[count]] tinklalapiai"
+msgstr[2] "Pasirinkta [[count]] tinklalapių"
+
+#: js/yext/reviewsstorm/reviews.js:672
+msgid "Unable to email review"
+msgid_plural "Unable to email reviews"
+msgstr[0] "Nepavyksta nusiųsti apžvalgos el. paštu"
+msgstr[1] "Nepavyksta nusiųsti apžvalgų el. paštu"
+msgstr[2] "Nepavyksta nusiųsti apžvalgų el. paštu"

--- a/tests/i18n/translator/translator.js
+++ b/tests/i18n/translator/translator.js
@@ -3,46 +3,124 @@ const path = require('path');
 const LocalFileParser = require('../../../src/i18n/translationfetchers/localfileparser');
 const Translator = require('../../../src/i18n/translator/translator');
 
-let translator;
-beforeAll(async () => {
-  const translationsPath = path.join(__dirname, '../../fixtures/translations');
-  const localFileParser = new LocalFileParser(translationsPath);
+describe('translations with one plural form (French)', () => {
+  let translator;
+  beforeAll(async () => {
+    const translationsPath = path.join(__dirname, '../../fixtures/translations');
+    const localFileParser = new LocalFileParser(translationsPath);
 
-  const frFRTranslations = await localFileParser.fetch('fr-FR');
-  const frTranslations = await localFileParser.fetch('fr');
-  const translations = {
-    'fr': { translation: frTranslations },
-    'fr-FR': { translation: frFRTranslations }
-  }
+    const frFRTranslations = await localFileParser.fetch('fr-FR');
+    const frTranslations = await localFileParser.fetch('fr');
+    const translations = {
+      'fr': { translation: frTranslations },
+      'fr-FR': { translation: frFRTranslations },
+    }
 
-  translator = await Translator.create('fr-FR', ['fr'], translations);
+    translator = await Translator.create('fr-FR', ['fr'], translations);
+  });
+
+  describe('Translations without pluralization or context', () => {
+    it('simple translation works as expected', () => {
+      const translation = translator.translate('Item');
+      expect(translation).toEqual('Article');
+    });
+
+    it('simple translation with interpolation works as expected', () => {
+      const translation = 
+        translator.translate('Hello [[name]]');
+      expect(translation).toEqual('Bonjour [[name]]');
+    });
+
+    it('translation fallback works as expected', () => {
+      const translation = translator.translate('Breakfast');
+      expect(translation).toEqual('Petit Déjeuner');
+    });
+  });
+
+  describe('Translations with pluralization and no context', () => {
+    it('simple pluralization works as expected', () => {
+      const translation = translator.translatePlural('Item', 'Items');
+      const expectedResult = {
+        0: 'Article',
+        plural: 'Articles',
+        locale: 'fr-FR'
+      };
+
+      expect(translation).toEqual(expectedResult);
+    });
+
+    it('pluralization with interpolation works as expected', () => {
+      const translation = translator.translatePlural(
+        'There is [[count]] item [[name]]', 'There are [[count]] items [[name]]');
+      const expectedResult = {
+        0: 'Il y a [[count]] article [[name]]',
+        plural: 'Il y a [[count]] articles [[name]]',
+        locale: 'fr-FR'
+      };
+
+      expect(translation).toEqual(expectedResult);
+    });
+
+    it('falls back correctly when no translations present', () => {
+      const translation = translator.translatePlural(
+        'Missing [[count]] translation [[name]]', 
+        'Missing [[count]] translations [[name]]');
+      const expectedResult = {
+        0: 'Missing [[count]] translation [[name]]',
+        plural: 'Missing [[count]] translations [[name]]',
+        locale: 'en'
+      };
+
+      expect(translation).toEqual(expectedResult);
+    });
+  });
+
+  describe('Translations with context and no pluralization', () => {
+    it('context works as expected with context = male', () => {
+      const translation = translator.translateWithContext('Child', 'male');
+      expect(translation).toEqual('fils');
+    });
+
+    it('context works as expected with context = female', () => {
+      const translation = translator.translateWithContext('Child', 'female');
+      expect(translation).toEqual('fille');
+    });
+
+    it('context and interpolation works as expected with context = male', () => {
+      const translation = translator.translateWithContext(
+        'I am looking for my child named [[name]]', 'male');
+      expect(translation).toEqual('Je cherche mon fils nommé [[name]]')
+    });
+
+    it('context and interpolation works as expected with context = female', () => {
+      const translation = translator.translateWithContext(
+        'I am looking for my child named [[name]]', 'female');
+      expect(translation).toEqual('Je cherche mon fille nommé [[name]]')
+    });
+  });
 });
 
-describe('Translations without pluralization or context', () => {
-  it('simple translation works as expected', () => {
-    const translation = translator.translate('Item');
-    expect(translation).toEqual('Article');
+describe('translations with multiple plural forms (Lithuanian)', () => {
+  let translator;
+  beforeAll(async () => {
+    const translationsPath = path.join(__dirname, '../../fixtures/translations');
+    const localFileParser = new LocalFileParser(translationsPath);
+
+    const ltLT_Translations = await localFileParser.fetch('lt-LT');
+    const translations = {
+      'lt-LT': { translation: ltLT_Translations }
+    }
+
+    translator = await Translator.create('lt-LT', [], translations);
   });
 
-  it('simple translation with interpolation works as expected', () => {
-    const translation =
-      translator.translate('Hello [[name]]');
-
-    expect(translation).toEqual('Bonjour [[name]]');
-  });
-
-  it('translation fallback works as expected', () => {
-    const translation = translator.translate('Breakfast');
-    expect(translation).toEqual('Petit Déjeuner');
-  });
-});
-
-describe('Translations with pluralization and no context', () => {
   it('simple pluralization works as expected', () => {
-    const translation = translator.translatePlural('Item', 'Items');
+    const translation = translator.translatePlural('Unable to email review', 'Unable to email reviews');
     const expectedResult = {
-      1: 'Article',
-      plural: 'Articles'
+      0: 'Nepavyksta nusiųsti apžvalgos el. paštu',
+      1: 'Nepavyksta nusiųsti apžvalgų el. paštu',
+      2: 'Nepavyksta nusiųsti apžvalgų el. paštu',
+      locale: 'lt-LT'
     };
 
     expect(translation).toEqual(expectedResult);
@@ -50,48 +128,16 @@ describe('Translations with pluralization and no context', () => {
 
   it('pluralization with interpolation works as expected', () => {
     const translation = translator.translatePlural(
-      'There is [[count]] item [[name]]', 'There are [[count]] items [[name]]');
+      '1 location selected',
+      '[[count]] locations selected]'
+    );
     const expectedResult = {
-      1: 'Il y a [[count]] article [[name]]',
-      plural: 'Il y a [[count]] articles [[name]]'
+      0: 'Pasirinkta [[count]] tinklalapis',
+      1: 'Pasirinkta [[count]] tinklalapiai',
+      2: 'Pasirinkta [[count]] tinklalapių',
+      locale: 'lt-LT'
     };
 
     expect(translation).toEqual(expectedResult);
-  });
-
-  it('falls back correctly when no translations present', () => {
-    const translation = translator.translatePlural(
-      'Missing [[count]] translation [[name]]',
-      'Missing [[count]] translations [[name]]');
-    const expectedResult = {
-      1: 'Missing [[count]] translation [[name]]',
-      plural: 'Missing [[count]] translations [[name]]'
-    };
-
-    expect(translation).toEqual(expectedResult);
-  });
-});
-
-describe('Translations with context and no pluralization', () => {
-  it('context works as expected with context = male', () => {
-    const translation = translator.translateWithContext('Child', 'male');
-    expect(translation).toEqual('fils');
-  });
-
-  it('context works as expected with context = female', () => {
-    const translation = translator.translateWithContext('Child', 'female');
-    expect(translation).toEqual('fille');
-  });
-
-  it('context and interpolation works as expected with context = male', () => {
-    const translation = translator.translateWithContext(
-      'I am looking for my child named [[name]]', 'male');
-    expect(translation).toEqual('Je cherche mon fils nommé [[name]]')
-  });
-
-  it('context and interpolation works as expected with context = female', () => {
-    const translation = translator.translateWithContext(
-      'I am looking for my child named [[name]]', 'female');
-    expect(translation).toEqual('Je cherche mon fille nommé [[name]]')
   });
 });


### PR DESCRIPTION
This commit changes translator.js to pass through locale to the runtime
translation helpers, so that the proper plural form can be chosen from
a dynamically generated count (since this depends on both the count
and the locale). The SDK will be getting the locale specific logic
for choosing the correct plural form. Since the first key in i18next
and also gettext is indexed as 0, translatePlural has also been
updated to set the first translation key to 0 instead of 1.

TEST=auto

Add unit tests for a locale with multiple plurals (lt-LT)