### PR TITLE
Add error message if missing all page templates for a locale

### DIFF
--- a/src/commands/build/pagesetsbuilder.js
+++ b/src/commands/build/pagesetsbuilder.js
@@ -59,12 +59,18 @@ module.exports = class PageSetsBuilder {
 
     const pageSets = [];
     for (const [locale, pageConfigs] of Object.entries(localeToPageConfigs)) {
+      const partials = localeToPagePartials[locale];
+      if (!partials) {
+        console.log(`Warning: No page partials found for given locale '${locale}', not generating a page set for '${locale}'`);
+        continue;
+      }
+
       const localizedGlobalConfig = new GlobalConfigLocalizer(this._localizationConfig)
         .localize(this._globalConfig, locale);
 
       pageSets.push(new PageSet({
         locale: locale,
-        pages: this._buildPages(pageConfigs, localeToPagePartials[locale]),
+        pages: this._buildPages(pageConfigs, partials),
         globalConfig: localizedGlobalConfig,
         params: this._localizationConfig.getParams(locale)
       }));


### PR DESCRIPTION
Previously this was throwing a "Cannot read property 'find' of undefined" error. Updating to print a helpful message and continue without generating a page set when missing page templates.

TEST=manual

Run `jambo build` locally for a site without page templates for a given locale.
