### PR TITLE
Use page template from the default locale if no other page template exists

### DIFF
--- a/src/commands/build/pagepartialdirector.js
+++ b/src/commands/build/pagepartialdirector.js
@@ -74,6 +74,8 @@ module.exports = class PagePartialDirector {
         return pagePartial;
       }
     }
+
+    return partialsForPage.find(partial => this._isDefaultLocale(partial.getLocale()));
   }
 
   /**


### PR DESCRIPTION
TEST=manual

Test locally with a a config/locations.es.json and a pages/locations.html.hbs, see Spanish locations page is built.