### PR TITLE
Reverse conditional to use the correct url formatting pattern for a locale

### DIFF
--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -70,8 +70,8 @@ module.exports = class LocalizationConfig {
       ? locale.substring(0, locale.lastIndexOf("-")) || locale
       : '';
     const basicUrlPattern = locale === this._defaultLocale
-      ? this._baseLocalePattern
-      : this._defaultUrlPattern;
+      ? this._defaultUrlPattern
+      : this._baseLocalePattern;
     let urlPattern = this._getUrlOverride(locale) || basicUrlPattern || '{pageName}.{pageExt}';
     return (pageName, pageExt) => {
       return urlPattern

--- a/tests/models/localizationconfig.js
+++ b/tests/models/localizationconfig.js
@@ -45,7 +45,7 @@ describe('Getting URL Formatting function works properly', () => {
     expect(urlFormatter('pageName', 'pageExt')).toEqual('pageName.pageExt');
   });
 
-  it('applies base url formatting pattern to default locale', () => {
+  it('applies default url formatting pattern to default locale', () => {
     let locale = 'en';
     let localizationConfig = new LocalizationConfig({
       default: locale,
@@ -56,7 +56,7 @@ describe('Getting URL Formatting function works properly', () => {
     });
 
     let urlFormatter = localizationConfig.getUrlFormatter(locale);
-    expect(urlFormatter('pageName', 'pageExt')).toEqual('pages/pageName.pageExt');
+    expect(urlFormatter('pageName', 'pageExt')).toEqual(`pages/${locale}/pageName.pageExt`);
   });
 
   it('applies correct url formatting pattern to non-default locales', () => {
@@ -70,7 +70,7 @@ describe('Getting URL Formatting function works properly', () => {
 
     let locale = 'en';
     let urlFormatter = localizationConfig.getUrlFormatter(locale);
-    expect(urlFormatter('pageName', 'pageExt')).toEqual(`pages/${locale}/pageName.pageExt`);
+    expect(urlFormatter('pageName', 'pageExt')).toEqual(`pages/pageName.pageExt`);
   });
 
   it('applies correct url formatting pattern for locale with urlOverride', () => {


### PR DESCRIPTION
Previously the default url format was using the baseLocalePattern, and all others were using the defaultLocalePattern. It should be the opposite.

TEST=manual,unit

On local test site, generate pages with the default locale and an additional locale, see output paths use expected url formatting pattern.