### PR TITLE
Update generation to support backwards compatiblity with locale naming

### DIFF
--- a/src/commands/build/pageconfigdecorator.js
+++ b/src/commands/build/pageconfigdecorator.js
@@ -1,4 +1,5 @@
 const PageConfig = require('../../models/pageconfig');
+const LocalizationConfig = require('../../models/localizationconfig');
 
 /**
  * PageConfigDecorator decorates {@link PageConfig}s, adding additional
@@ -6,16 +7,11 @@ const PageConfig = require('../../models/pageconfig');
  * information provided.
  */
 module.exports = class PageConfigDecorator {
-  constructor({ localeToFallbacks, defaultLocale }) {
+  constructor(localizationConfig) {
     /**
-     * @type {Object<String, Array<String>>}
+     * @type {LocalizationConfig}
      */
-    this._localeToFallbacks = localeToFallbacks;
-
-    /**
-     * @type {String}
-     */
-    this._defaultLocale = defaultLocale;
+    this._localizationConfig = localizationConfig;
   }
 
   /**
@@ -55,8 +51,8 @@ module.exports = class PageConfigDecorator {
    * @returns {PageConfig}
    */
   _decoratePageConfig(localeSpecificConfig, configsForPage) {
-    const currentLocale = localeSpecificConfig.getLocale() || this._defaultLocale;
-    const localeFallbacks = this._localeToFallbacks[currentLocale] || [];
+    const currentLocale = localeSpecificConfig.getLocale() || this._localizationConfig.getDefaultLocale();
+    const localeFallbacks = this._localizationConfig.getFallbacks(currentLocale);
     const fallbackConfigs = [];
     for (let i = localeFallbacks.length - 1; i >= 0 ; i--) {
       const fallbackConfig = configsForPage
@@ -138,6 +134,6 @@ module.exports = class PageConfigDecorator {
    * @returns {boolean}
    */
   _isDefaultLocale(locale) {
-    return locale === this._defaultLocale || !locale;
+    return locale === this._localizationConfig.getDefaultLocale() || !locale;
   }
 }

--- a/src/commands/build/pagesetsbuilder.js
+++ b/src/commands/build/pagesetsbuilder.js
@@ -6,6 +6,7 @@ const PageConfigDecorator = require('./pageconfigdecorator');
 const PageSet = require('../../models/pageset');
 const PageTemplate = require('../../models/pagetemplate');
 const PageTemplateDirector = require('./pagetemplatedirector');
+const { NO_LOCALE } = require('../../constants');
 
 /**
  * PageSetsBuilder is responsible for matching {@link PageConfigs} and
@@ -44,7 +45,10 @@ module.exports = class PageSetsBuilder {
     for (const [locale, pageConfigs] of Object.entries(localeToPageConfigs)) {
       const templates = localeToPageTemplates[locale];
       if (!templates || templates.length < 1) {
-        console.log(`Warning: No page templates found for given locale '${locale}', not generating a page set for '${locale}'`);
+        const localeMessage = config.getLocale() !== NO_LOCALE
+          ? ` for '${locale}' locale`
+          : '';
+        console.log(`Warning: No page templates found${localeMessage}, not generating a page set${localeMessage}`);
         continue;
       }
 
@@ -75,7 +79,7 @@ module.exports = class PageSetsBuilder {
         .find(template => template.getPageName() === config.getPageName());
 
       if (!pageTemplate) {
-        const localeMessage = config.getLocale()
+        const localeMessage = config.getLocale() !== NO_LOCALE
           ? ` found for '${config.getLocale()}' locale`
           : '';
         console.log(`Warning: No page template '${config.getPageName()}'${localeMessage}, not generating a '${config.getPageName()}' page${localeMessage}`);

--- a/src/commands/build/pagesetsbuilder.js
+++ b/src/commands/build/pagesetsbuilder.js
@@ -75,7 +75,9 @@ module.exports = class PageSetsBuilder {
         .find(template => template.getPageName() === config.getPageName());
 
       if (!pageTemplate) {
-        const localeMessage = config.getLocale() ? ` found for '${config.getLocale()}' locale` : '';
+        const localeMessage = config.getLocale()
+          ? ` found for '${config.getLocale()}' locale`
+          : '';
         console.log(`Warning: No page template '${config.getPageName()}'${localeMessage}, not generating a '${config.getPageName()}' page${localeMessage}`);
         continue;
       }

--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -31,7 +31,9 @@ module.exports = class PageWriter {
     if (!pageSet || pageSet.getPages().length < 1) {
       return;
     }
-    const localeMessage = pageSet.getLocale() ? ` for '${pageSet.getLocale()}' locale` : '';
+    const localeMessage = pageSet.getLocale()
+      ? ` for '${pageSet.getLocale()}' locale`
+      : '';
     console.log(`Writing files${localeMessage}`);
 
     for (const page of pageSet.getPages()) {

--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const PageSet = require('../../models/pageset');
 const UserError = require('../../errors/usererror');
+const { NO_LOCALE } = require('../../constants');
 
 /**
  * PageWriter is responsible for writing output files for the given {@link PageSet} to
@@ -31,7 +32,7 @@ module.exports = class PageWriter {
     if (!pageSet || pageSet.getPages().length < 1) {
       return;
     }
-    const localeMessage = pageSet.getLocale()
+    const localeMessage = pageSet.getLocale() !== NO_LOCALE
       ? ` for '${pageSet.getLocale()}' locale`
       : '';
     console.log(`Writing files${localeMessage}`);

--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -31,7 +31,8 @@ module.exports = class PageWriter {
     if (!pageSet || pageSet.getPages().length < 1) {
       return;
     }
-    console.log(`Writing files for '${pageSet.getLocale()}' locale`);
+    const localeMessage = pageSet.getLocale() ? ` for '${pageSet.getLocale()}' locale` : '';
+    console.log(`Writing files${localeMessage}`);
 
     for (const page of pageSet.getPages()) {
       if (!page.getConfig()) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+exports.NO_LOCALE = '';

--- a/src/models/configurationregistry.js
+++ b/src/models/configurationregistry.js
@@ -81,14 +81,15 @@ module.exports = class ConfigurationRegistry {
     if (!rawLocaleConfig) {
       console.log(`Cannot find '${localizationConfigName}', using locale information from ${globalConfigName}.`);
     }
+    const localizationConfig = new LocalizationConfig(rawLocaleConfig);
 
     const pageConfigs = Object.keys(configNameToRawConfig)
       .map((configName) => {
         if (configName !== globalConfigName && configName !== localizationConfigName) {
-          const pageName = rawLocaleConfig
+          const pageName = localizationConfig.hasConfig()
             ? getPageName(configName)
             : configName;
-          const locale = rawLocaleConfig && ConfigurationRegistry._parseLocale(configName);
+          const locale = localizationConfig.hasConfig() && ConfigurationRegistry._parseLocale(configName);
           return new PageConfig({
             pageName: pageName,
             locale: locale,
@@ -100,7 +101,7 @@ module.exports = class ConfigurationRegistry {
 
     return new ConfigurationRegistry({
       globalConfig: new GlobalConfig(rawGlobalConfig),
-      localizationConfig: new LocalizationConfig(rawLocaleConfig),
+      localizationConfig: localizationConfig,
       pageConfigs: pageConfigs,
     });
   }

--- a/src/models/configurationregistry.js
+++ b/src/models/configurationregistry.js
@@ -85,9 +85,13 @@ module.exports = class ConfigurationRegistry {
     const pageConfigs = Object.keys(configNameToRawConfig)
       .map((configName) => {
         if (configName !== globalConfigName && configName !== localizationConfigName) {
+          const pageName = rawLocaleConfig
+            ? getPageName(configName)
+            : configName;
+          const locale = rawLocaleConfig && ConfigurationRegistry._parseLocale(configName);
           return new PageConfig({
-            pageName: getPageName(configName),
-            locale: ConfigurationRegistry._parseLocale(configName),
+            pageName: pageName,
+            locale: locale,
             rawConfig: configNameToRawConfig[configName]
           });
         }

--- a/src/models/generateddata.js
+++ b/src/models/generateddata.js
@@ -12,19 +12,13 @@ const PageTemplate = require('./pagetemplate');
 module.exports = class GeneratedData {
   /**
    * @param {LocalizationConfig} localizationConfig
-   * @param {String} defaultLocale
    * @param {Array<PageSet>} pageSets
    */
-  constructor({ localizationConfig, defaultLocale, pageSets }) {
+  constructor(pageSets, localizationConfig) {
     /**
      * @type {LocalizationConfig}
      */
     this._localizationConfig = localizationConfig;
-
-    /**
-     * @type {String}
-     */
-    this._defaultLocale = defaultLocale;
 
     /**
      * @type {Array<PageSet>}
@@ -39,8 +33,7 @@ module.exports = class GeneratedData {
    * @returns {Array<String>}
    */
   getLocales () {
-    const locales = this._localizationConfig.getLocales();
-    return locales.length ? locales : [ this._defaultLocale ];
+    return this._localizationConfig.getLocales();
   }
 
   /**
@@ -72,18 +65,11 @@ module.exports = class GeneratedData {
    * @returns {GeneratedData}
    */
   static from({ globalConfig, localizationConfig, pageConfigs, pageTemplates }) {
-    const defaultLocale = localizationConfig.getDefaultLocale() || globalConfig.getLocale() || '';
-
     const pageSets = new PageSetsBuilder({
       localizationConfig: localizationConfig,
       globalConfig: globalConfig,
-      defaultLocale: defaultLocale,
     }).build(pageConfigs, pageTemplates);
 
-    return new GeneratedData({
-      pageSets: pageSets,
-      localizationConfig: localizationConfig,
-      defaultLocale: defaultLocale
-    })
+    return new GeneratedData(pageSets, localizationConfig);
   }
 }

--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -1,3 +1,5 @@
+const { NO_LOCALE } = require("../constants");
+
 /**
  * LocalizationConfig represents the configuration required to localize pages. It contains
  * configuration and URL formatting for each locale.
@@ -8,7 +10,7 @@ module.exports = class LocalizationConfig {
    */
   constructor(rawLocalizationConfig) {
     const config = rawLocalizationConfig || {};
-    this._defaultLocale = config.default || '';
+    this._defaultLocale = config.default || NO_LOCALE;
 
     /**
      * localeToConfig is an Object mapping locale to configuration

--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -8,7 +8,7 @@ module.exports = class LocalizationConfig {
    */
   constructor(rawLocalizationConfig) {
     const config = rawLocalizationConfig || {};
-    this._defaultLocale = config.default || ''; // TODO do we want this to be the default
+    this._defaultLocale = config.default || '';
 
     /**
      * localeToConfig is an Object mapping locale to configuration
@@ -28,6 +28,17 @@ module.exports = class LocalizationConfig {
     const urlFormat = config.urlFormat || {};
     this._defaultUrlPattern = urlFormat.default || '';
     this._baseLocalePattern = urlFormat.baseLocale || '';
+  }
+
+  /**
+   * Returns a boolean indicating whether this LocalizationConfig has
+   * configuration. It returns false when there is no meaningful
+   * configuration for locales, and true when there is configuration.
+   *
+   * @returns {boolean}
+   */
+  hasConfig () {
+    return Object.keys(this._localeToConfig).length > 0;
   }
 
   getDefaultLocale () {

--- a/src/models/pageconfig.js
+++ b/src/models/pageconfig.js
@@ -1,3 +1,5 @@
+const { NO_LOCALE } = require("../constants");
+
 /**
  * PageConfig is a representation of the configuration for the Page for
  * the given locale.
@@ -17,7 +19,7 @@ module.exports = class PageConfig {
     /**
      * @type {String}
      */
-    this.locale = locale || '';
+    this.locale = locale || NO_LOCALE;
 
     /**
      * @type {Object}

--- a/src/models/pagetemplate.js
+++ b/src/models/pagetemplate.js
@@ -1,4 +1,5 @@
 const { stripExtension } = require("../utils/fileutils");
+const { NO_LOCALE } = require("../constants");
 
 /**
  * PageTemplate represents a Handlebars template that is used to
@@ -24,7 +25,7 @@ module.exports = class PageTemplate {
     /**
      * @type {String}
      */
-    this.locale = locale || '';
+    this.locale = locale || NO_LOCALE;
   }
 
   /**

--- a/src/models/pagetemplate.js
+++ b/src/models/pagetemplate.js
@@ -1,5 +1,5 @@
-const { stripExtension } = require("../utils/fileutils");
-const { NO_LOCALE } = require("../constants");
+const { stripExtension } = require('../utils/fileutils');
+const { NO_LOCALE } = require('../constants');
 
 /**
  * PageTemplate represents a Handlebars template that is used to

--- a/src/models/pagetemplate.js
+++ b/src/models/pagetemplate.js
@@ -1,5 +1,4 @@
-const { getPageName } = require('../utils/fileutils');
-const SystemError = require('../errors/systemerror');
+const { stripExtension } = require("../utils/fileutils");
 
 /**
  * PageTemplate represents a Handlebars template that is used to
@@ -85,27 +84,6 @@ module.exports = class PageTemplate {
       path: this.path,
       fileContents: this.fileContents,
       pageName: this.pageName
-    });
-  }
-
-  /**
-   * Creates a @type {PageTemplate} from a given filename and path
-   *
-   * @param {String} filename
-   * @param {String} path
-   * @param {String} fileContents
-   * @returns {PageTemplate}
-   */
-  static from (filename, path, fileContents) {
-    if (!filename) {
-      throw new SystemError('Error: no filename provided for page template');
-    }
-
-    return new PageTemplate({
-      path: path,
-      fileContents: fileContents,
-      pageName: getPageName(filename),
-      locale: PageTemplate.parseLocale(filename)
     });
   }
 

--- a/tests/commands/build/pageconfigdecorator.js
+++ b/tests/commands/build/pageconfigdecorator.js
@@ -1,6 +1,7 @@
 const PageConfig = require('../../../src/models/pageconfig');
 const PageConfigDecorator = require('../../../src/commands/build/pageconfigdecorator');
 const LocalizationConfig = require('../../../src/models/localizationconfig');
+const { NO_LOCALE } = require('../../../src/constants');
 
 describe('PageConfigDecorator decorates PageConfigs and builds the expected object', () => {
   it('builds decorated pages configs correctly when there is no locale config', () => {
@@ -17,14 +18,14 @@ describe('PageConfigDecorator decorates PageConfigs and builds the expected obje
     ]);
 
     expect(decoratedConfigs).toEqual({
-      '': [
+      [NO_LOCALE]: [
         new PageConfig({
-          locale: '',
+          locale: NO_LOCALE,
           pageName: 'pageName1',
           rawConfig: { verticalKey: 'verticalKey' },
         }),
         new PageConfig({
-          locale: '',
+          locale: NO_LOCALE,
           pageName: 'pageName2',
           rawConfig: { pageTitle: 'pageTitle' },
         })

--- a/tests/commands/build/pageconfigdecorator.js
+++ b/tests/commands/build/pageconfigdecorator.js
@@ -1,13 +1,11 @@
 const PageConfig = require('../../../src/models/pageconfig');
 const PageConfigDecorator = require('../../../src/commands/build/pageconfigdecorator');
+const LocalizationConfig = require('../../../src/models/localizationconfig');
 
 describe('PageConfigDecorator decorates PageConfigs and builds the expected object', () => {
-  it('builds decorated pages configs correctly when there is only a default locale', () => {
-    const defaultLocale = 'en';
-    const decoratedConfigs = new PageConfigDecorator({
-      localeToFallbacks: {},
-      defaultLocale: defaultLocale
-    }).decorate([
+  it('builds decorated pages configs correctly when there is no locale config', () => {
+    const localeConfig = new LocalizationConfig();
+    const decoratedConfigs = new PageConfigDecorator(localeConfig).decorate([
       new PageConfig({
         pageName: 'pageName1',
         rawConfig: { verticalKey: 'verticalKey' },
@@ -19,14 +17,14 @@ describe('PageConfigDecorator decorates PageConfigs and builds the expected obje
     ]);
 
     expect(decoratedConfigs).toEqual({
-      [defaultLocale]: [
+      '': [
         new PageConfig({
-          locale: defaultLocale,
+          locale: '',
           pageName: 'pageName1',
           rawConfig: { verticalKey: 'verticalKey' },
         }),
         new PageConfig({
-          locale: defaultLocale,
+          locale: '',
           pageName: 'pageName2',
           rawConfig: { pageTitle: 'pageTitle' },
         })
@@ -66,13 +64,17 @@ describe('PageConfigDecorator decorates PageConfigs and builds the expected obje
         test: 'it_test'
       },
     });
-    const decoratedConfig = new PageConfigDecorator({
-      localeToFallbacks: {
-        fr: [ 'it', 'de' ],
-        de: [ 'it' ],
-      },
-      defaultLocale: defaultLocale
-    }).decorate([
+    const decoratedConfig = new PageConfigDecorator(new LocalizationConfig({
+      default: defaultLocale,
+      localeConfig: {
+        fr: {
+          fallback: [ 'it', 'de' ]
+        },
+        de: {
+          fallback: [ 'it' ],
+        }
+      }
+    })).decorate([
       configForDefaultLocale,
       frConfig,
       itConfig1,
@@ -178,9 +180,11 @@ describe('Merges the internals of multiple PageConfigs', () => {
 
 describe('Matches locales properly', () => {
   const defaultLocale = 'fr';
-  const pageConfigDecorator = new PageConfigDecorator({
-    defaultLocale: defaultLocale
-  });
+  const pageConfigDecorator = new PageConfigDecorator(
+    new LocalizationConfig({
+      default: defaultLocale
+    })
+  );
 
   it('default config matches if locale is not specified', () => {
     expect(pageConfigDecorator._isLocaleMatch(defaultLocale, defaultLocale)).toEqual(true);

--- a/tests/commands/build/pagetemplatedirector.js
+++ b/tests/commands/build/pagetemplatedirector.js
@@ -1,6 +1,7 @@
 const PageTemplateDirector = require('../../../src/commands/build/pagetemplatedirector');
 const PageTemplate = require('../../../src/models/pagetemplate');
 const LocalizationConfig = require('../../../src/models/localizationconfig');
+const { NO_LOCALE } = require('../../../src/constants');
 
 describe('PageTemplateDirector directs PageTemplates and builds the expected object', () => {
   it('creates page templates correctly with no locale config', () => {
@@ -22,20 +23,20 @@ describe('PageTemplateDirector directs PageTemplates and builds the expected obj
       .direct(pageTemplates);
 
     expect(localeToPageTemplates).toEqual({
-      '': [
+      [NO_LOCALE]: [
         new PageTemplate({
           pageName: 'path',
-          locale: '',
+          locale: NO_LOCALE,
           path: `pages/path.html.hbs`
         }),
         new PageTemplate({
           pageName: 'path2',
-          locale: '',
+          locale: NO_LOCALE,
           path: `pages/path2.html.hbs`
         }),
         new PageTemplate({
           pageName: 'path3',
-          locale: '',
+          locale: NO_LOCALE,
           path: `pages/path3.html.hbs`
         }),
       ]

--- a/tests/commands/build/pagetemplatedirector.js
+++ b/tests/commands/build/pagetemplatedirector.js
@@ -1,9 +1,9 @@
 const PageTemplateDirector = require('../../../src/commands/build/pagetemplatedirector');
 const PageTemplate = require('../../../src/models/pagetemplate');
+const LocalizationConfig = require('../../../src/models/localizationconfig');
 
 describe('PageTemplateDirector directs PageTemplates and builds the expected object', () => {
-  it('creates page templates correctly when only defaultLocale is present', () => {
-    const defaultLocale = 'en';
+  it('creates page templates correctly with no locale config', () => {
     const pageTemplates = [
       new PageTemplate({
         pageName: 'path',
@@ -18,27 +18,24 @@ describe('PageTemplateDirector directs PageTemplates and builds the expected obj
         path: `pages/path3.html.hbs`
       }),
     ];
-    const localeToPageTemplates = new PageTemplateDirector({
-      locales: [],
-      localeToFallbacks: {},
-      defaultLocale: defaultLocale
-    }).direct(pageTemplates);
+    const localeToPageTemplates = new PageTemplateDirector(new LocalizationConfig())
+      .direct(pageTemplates);
 
     expect(localeToPageTemplates).toEqual({
-      [defaultLocale]: [
+      '': [
         new PageTemplate({
           pageName: 'path',
-          locale: defaultLocale,
+          locale: '',
           path: `pages/path.html.hbs`
         }),
         new PageTemplate({
           pageName: 'path2',
-          locale: defaultLocale,
+          locale: '',
           path: `pages/path2.html.hbs`
         }),
         new PageTemplate({
           pageName: 'path3',
-          locale: defaultLocale,
+          locale: '',
           path: `pages/path3.html.hbs`
         }),
       ]
@@ -46,12 +43,6 @@ describe('PageTemplateDirector directs PageTemplates and builds the expected obj
   });
 
   it('creates localeToPageTemplates with the correct locales and paths when locale data is provided', () => {
-    const locales = ['en', 'es', 'fr', 'de', 'it'];
-    const localeToFallbacks = {
-      'en': ['fr'],
-      'es': ['de', 'en'],
-      'de': ['fr', 'es']
-    };
     const pageTemplates = {
       en: new PageTemplate({
         pageName: 'path',
@@ -64,10 +55,22 @@ describe('PageTemplateDirector directs PageTemplates and builds the expected obj
         path: `pages/path.fr.html.hbs`
       }),
     };
-    const localeToPageTemplates = new PageTemplateDirector({
-      locales: locales,
-      localeToFallbacks: localeToFallbacks,
-    }).direct(Object.values(pageTemplates));
+    const localeToPageTemplates = new PageTemplateDirector(new LocalizationConfig({
+      default: 'it',
+      localeConfig: {
+        'en': {
+          fallback: ['fr']
+        },
+        'es': {
+          fallback: ['de', 'en']
+        },
+        'de': {
+          fallback: ['fr', 'es']
+        },
+        'it': {},
+        'fr': {}
+      }
+    })).direct(Object.values(pageTemplates));
 
     expect(localeToPageTemplates).toEqual({
       'en': [ // Directs to template with current locale even if fallbacks exist

--- a/tests/models/configurationregistry.js
+++ b/tests/models/configurationregistry.js
@@ -3,6 +3,7 @@ const { getPageName } = require('../../src/utils/fileutils');
 const GlobalConfig = require('../../src/models/globalconfig');
 const LocalizationConfig = require('../../src/models/localizationconfig');
 const PageConfig = require('../../src/models/pageconfig');
+const { NO_LOCALE } = require('../../src/constants');
 
 describe('ConfigurationRegistry forms object properly using static frm', () => {
   it('creates GlobalConfig object properly', () => {
@@ -39,7 +40,7 @@ describe('ConfigurationRegistry forms object properly using static frm', () => {
       .toEqual(new LocalizationConfig());
   });
 
-  it('creates PageConfigs properly', () => {
+  it('creates PageConfigs properly when locale_config is present', () => {
     const configName = 'configName';
     const configNameWithLocale = `${configName}.es`;
     const rawPageConfig = {
@@ -47,10 +48,10 @@ describe('ConfigurationRegistry forms object properly using static frm', () => {
     };
     const rawConfigs = {
       global_config: {},
-      locale_config: {}
+      locale_config: {},
+      [configName]: rawPageConfig,
+      [configNameWithLocale]: rawPageConfig,
     };
-    rawConfigs[configName] = rawPageConfig;
-    rawConfigs[configNameWithLocale] = rawPageConfig;
     const rawConfigsCopy = { ...rawConfigs };
     const configRegistry = ConfigurationRegistry.from(rawConfigs);
 
@@ -62,11 +63,40 @@ describe('ConfigurationRegistry forms object properly using static frm', () => {
           rawConfig: rawPageConfig
         }),
         new PageConfig({
-          pageName: getPageName(configNameWithLocale),
-          locale: ConfigurationRegistry._parseLocale(configNameWithLocale),
+          pageName: configNameWithLocale,
+          locale: NO_LOCALE,
           rawConfig: rawPageConfig
         })
       ]);
     expect(rawConfigs).toEqual(rawConfigsCopy);
+  });
+
+  it('creates PageConfigs properly when locale_config is present', () => {
+    const configName = 'configName';
+    const configNameWithLocale = `${configName}.es`;
+    const configRegistry = ConfigurationRegistry.from({
+      global_config: {},
+      locale_config: {
+        localeConfig: {
+          'es': {}
+        }
+      },
+      [configName]: {},
+      [configNameWithLocale]: {}
+    });
+
+    expect(configRegistry.getPageConfigs())
+    .toEqual([
+      new PageConfig({
+        pageName: 'configName',
+        locale: NO_LOCALE,
+        rawConfig: {}
+      }),
+      new PageConfig({
+        pageName: 'configName',
+        locale: 'es',
+        rawConfig: {}
+      })
+    ]);
   });
 });

--- a/tests/models/configurationregistry.js
+++ b/tests/models/configurationregistry.js
@@ -40,7 +40,7 @@ describe('ConfigurationRegistry forms object properly using static frm', () => {
       .toEqual(new LocalizationConfig());
   });
 
-  it('creates PageConfigs properly when locale_config is present', () => {
+  it('creates PageConfigs properly when locale_config is absent', () => {
     const configName = 'configName';
     const configNameWithLocale = `${configName}.es`;
     const rawPageConfig = {

--- a/tests/models/generateddata.js
+++ b/tests/models/generateddata.js
@@ -5,6 +5,7 @@ const PageConfig = require('../../src/models/pageconfig');
 const PageTemplate = require('../../src/models/pagetemplate');
 const PageSet = require('../../src/models/pageset');
 const Page = require('../../src/models/page');
+const { NO_LOCALE } = require('../../src/constants');
 
 describe('GeneratedData is correctly formed using with static from', () => {
   it('works if no LocalizationConfig provided and no pages - initial repo state', () => {
@@ -63,16 +64,16 @@ describe('GeneratedData is correctly formed using with static from', () => {
     expect(generatedData.getLocales()).toEqual([]);
     expect(generatedData.getPageSets()).toEqual([
       new PageSet({
-        locale: '',
+        locale: NO_LOCALE,
         pages: [
           new Page({
             pageConfig: new PageConfig({
-              locale: '',
+              locale: NO_LOCALE,
               pageName: pageConfig1.getPageName(),
               rawConfig: pageConfig1.getConfig(),
             }),
             pageTemplate: new PageTemplate({
-              locale: '',
+              locale: NO_LOCALE,
               pageName: pageTemplate1.getPageName(),
               path: pageTemplate1.getPath(),
             }),
@@ -80,12 +81,12 @@ describe('GeneratedData is correctly formed using with static from', () => {
           }),
           new Page({
             pageConfig: new PageConfig({
-              locale: '',
+              locale: NO_LOCALE,
               pageName: pageConfig2.getPageName(),
               rawConfig: pageConfig2.getConfig(),
             }),
             pageTemplate: new PageTemplate({
-              locale: '',
+              locale: NO_LOCALE,
               pageName: pageTemplate2.getPageName(),
               path: pageTemplate2.getPath(),
             }),

--- a/tests/models/generateddata.js
+++ b/tests/models/generateddata.js
@@ -6,34 +6,6 @@ const PageTemplate = require('../../src/models/pagetemplate');
 const PageSet = require('../../src/models/pageset');
 const Page = require('../../src/models/page');
 
-describe('GeneratedData returns locales from LocalizationConfig or default', () => {
-  it('prefers locales from LocalizationConfig over default', () => {
-    const localizationConfig = new LocalizationConfig({
-      localeConfig: {
-        'en': {},
-        'es': {},
-        'de': {},
-      }
-    });
-
-    const locales = new GeneratedData({
-      defaultLocale: 'fr',
-      localizationConfig: localizationConfig
-    }).getLocales();
-
-    return expect(locales).toEqual(localizationConfig.getLocales());
-  });
-
-  it('falls back to defaultLocale if not present in LocalizationConfig', () => {
-    const locales = new GeneratedData({
-      defaultLocale: 'de',
-      localizationConfig: new LocalizationConfig()
-    }).getLocales();
-
-    return expect(locales).toEqual(['de']);
-  });
-});
-
 describe('GeneratedData is correctly formed using with static from', () => {
   it('works if no LocalizationConfig provided and no pages - initial repo state', () => {
     const generatedData = GeneratedData.from({
@@ -47,9 +19,8 @@ describe('GeneratedData is correctly formed using with static from', () => {
       pageTemplates: []
     });
 
-    expect(generatedData.getLocales()).toEqual(['en']);
+    expect(generatedData.getLocales()).toEqual([]);
     expect(generatedData.getPageSets()).toEqual([]);
-    expect(generatedData.getLocaleFallbacks('en')).toEqual([]);
   });
 
   it('builds object correctly if no LocalizationConfig provided', () => {
@@ -89,19 +60,19 @@ describe('GeneratedData is correctly formed using with static from', () => {
       ]
     });
 
-    expect(generatedData.getLocales()).toEqual([locale]);
+    expect(generatedData.getLocales()).toEqual([]);
     expect(generatedData.getPageSets()).toEqual([
       new PageSet({
-        locale: locale,
+        locale: '',
         pages: [
           new Page({
             pageConfig: new PageConfig({
-              locale: locale,
+              locale: '',
               pageName: pageConfig1.getPageName(),
               rawConfig: pageConfig1.getConfig(),
             }),
             pageTemplate: new PageTemplate({
-              locale: locale,
+              locale: '',
               pageName: pageTemplate1.getPageName(),
               path: pageTemplate1.getPath(),
             }),
@@ -109,12 +80,12 @@ describe('GeneratedData is correctly formed using with static from', () => {
           }),
           new Page({
             pageConfig: new PageConfig({
-              locale: locale,
+              locale: '',
               pageName: pageConfig2.getPageName(),
               rawConfig: pageConfig2.getConfig(),
             }),
             pageTemplate: new PageTemplate({
-              locale: locale,
+              locale: '',
               pageName: pageTemplate2.getPageName(),
               path: pageTemplate2.getPath(),
             }),

--- a/tests/models/pageconfig.js
+++ b/tests/models/pageconfig.js
@@ -1,4 +1,5 @@
 const PageConfig = require('../../src/models/pageconfig');
+const { NO_LOCALE } = require('../../src/constants');
 
 describe('Properly builds PageConfig object', () => {
   const pageName = 'test';
@@ -23,7 +24,7 @@ describe('Properly builds PageConfig object', () => {
       rawConfig: rawConfig,
     })
     expect(pageConfig.getPageName()).toEqual(pageName);
-    expect(pageConfig.getLocale()).toEqual('');
+    expect(pageConfig.getLocale()).toEqual(NO_LOCALE);
     expect(pageConfig.getConfig()).toEqual(rawConfig);
   });
 });

--- a/tests/models/pagetemplate.js
+++ b/tests/models/pagetemplate.js
@@ -1,4 +1,5 @@
 const PageTemplate = require('../../src/models/pagetemplate');
+const { NO_LOCALE } = require('../../src/constants');
 
 describe('Correctly forms PageTemplate object from constructor', () => {
   it('PageTemplate is built properly when locale is present', () => {
@@ -14,7 +15,7 @@ describe('Correctly forms PageTemplate object from constructor', () => {
     const template = new PageTemplate({
       pageName: 'test',
     });
-    expect(template.getLocale()).toEqual('');
+    expect(template.getLocale()).toEqual(NO_LOCALE);
     expect(template.getPageName()).toEqual('test');
   });
 });

--- a/tests/models/pagetemplate.js
+++ b/tests/models/pagetemplate.js
@@ -1,28 +1,5 @@
 const PageTemplate = require('../../src/models/pagetemplate');
 
-describe('Correctly forms PageTemplate object using static from', () => {
-  it('PageTemplate is built properly when locale is present', () => {
-    const pageName = 'pageName';
-    const locale = 'en';
-    const templatePath = `pages/${pageName}.${locale}.html.hbs`;
-    const pageTemplate = PageTemplate.from(`${pageName}.${locale}.html.hbs`, templatePath);
-
-    expect(pageTemplate.getPageName()).toEqual(pageName);
-    expect(pageTemplate.getLocale()).toEqual(locale);
-    expect(templatePath).toEqual(templatePath);
-  });
-
-  it('PageTemplate is built properly with no locale', () => {
-    const pageName = 'pageName';
-    const templatePath = `pages/${pageName}.html.hbs`;
-    const pageTemplate = PageTemplate.from(`${pageName}.html.hbs`, templatePath);
-
-    expect(pageTemplate.getPageName()).toEqual(pageName);
-    expect(pageTemplate.getLocale()).toEqual('');
-    expect(templatePath).toEqual(templatePath);
-  });
-});
-
 describe('Correctly forms PageTemplate object from constructor', () => {
   it('PageTemplate is built properly when locale is present', () => {
     const template = new PageTemplate({


### PR DESCRIPTION
There was an issue where the localized-pages branch was not backwards compatible if the locale-specific naming scheme was used in page files for locales that *didn't* match the locale in the global_config. For example, if the locale in my global_config was "en", but I had a page files: `config/name.es.json` and `page/page.es.html.hbs`, they would be considered files for the "es" locale, and would not be generated, even though we didn't have a locale_config. Eliminated defaulting to the global_config's locale since we were only using it for a key in an Object and it was complicating the fallback logic.

TEST=manual,unit

Tested on a repo with files using the locale-specific naming scheme without a locale_config.json file; verified that the following pages were generated: locations.es.html, index.es.html, index.html, with the following warnings: 
- Warning: No page template 'index.fr', not generating a 'index.fr' page
- Warning: No page template 'locations.fr', not generating a 'locations.fr' page

Tested on the same repo with a locale_config.json file; verified that the following pages were generated: es/index.html, es/locations.html, fr/override/index.html, index.html, with the following warning:
- Warning: No page template 'locations' found for 'fr' locale, not generating a 'locations' page found for 'fr' locale
