### PR TITLE
Fix parsing config error

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -50,11 +50,11 @@ exports.SitesGenerator = class {
         let configName = stripExtension(relative);
         try {
           configNameToRawConfig[configName] = parse(fs.readFileSync(path, 'utf8'), null, true);
-        } catch (e) {
-          if (e instanceof SyntaxError) {
+        } catch (err) {
+          if (err instanceof SyntaxError) {
             throw new UserError(`JSON SyntaxError: could not parse file ${path}`, err.stack);
           } else {
-            throw e;
+            throw err;
           }
         }
       }


### PR DESCRIPTION
Fixed a small bug where an Error is caught with the name "e" but is referred to as "err"

J=none
TEST=manual

I reproduced the error manually and confirmed the proper Error is now thrown