### PR TITLE
TranslateInvocation: update to use the Handlebars parser

### DIFF
--- a/src/handlebars/models/translateinvocation.js
+++ b/src/handlebars/models/translateinvocation.js
@@ -133,8 +133,7 @@ class TranslateInvocation {
       } else if (expression.type === 'UndefinedLiteral') {
         map[pair.key] = 'undefined';
       } else if (expression.type === 'SubExpression') {
-        throw new UserError(
-          `Error: parameter "${pair.key}" is a SubExpression.`)
+        throw new Error();
       } else {
         map[pair.key] = expression.original.toString();
       }

--- a/src/handlebars/models/translateinvocation.js
+++ b/src/handlebars/models/translateinvocation.js
@@ -109,7 +109,7 @@ class TranslateInvocation {
     const node = tree.body[0];
     if (node.type !== 'MustacheStatement') {
       throw new UserError(
-        `Error: "${invocationString}" must be a MustacheStatement.`);
+        `Error: "${invocationString}" must be a MustacheStatement. Found type ${node.type}.`);
     }
     return this._fromMustacheStatementNode(node, invocationString);
   }

--- a/src/handlebars/models/translateinvocation.js
+++ b/src/handlebars/models/translateinvocation.js
@@ -102,9 +102,11 @@ class TranslateInvocation {
       throw new UserError(
         `Error: Could not parse "${invocationString}" as a valid translate helper.`, err.stack);
     }
-    if (tree.body.length !== 1) {
-      throw new UserError(
-        `Error: "${invocationString}" has multiple handlebars nodes.`);
+    if (tree.body.length === 0) {
+      throw new UserError(`Error: "${invocationString}" does not have any handlebars nodes.`);
+    }
+    if (tree.body.length > 1) {
+      throw new UserError(`Error: "${invocationString}" has multiple handlebars nodes.`);
     }
     const node = tree.body[0];
     if (node.type !== 'MustacheStatement') {

--- a/tests/handlebars/models/translateinvocation.js
+++ b/tests/handlebars/models/translateinvocation.js
@@ -102,27 +102,23 @@ describe('TranslationInvocation can parse all Hash parameter types (but SubExpre
 describe('TranslationInvocation throws correct errors when given an invalid invocation', () => {
   it('errors when given just a ContentStatement', () => {
     const invocation = 'this is a ContentStatement';
-    expect(() => TranslateInvocation.from(invocation)).toThrow(
-      `Error: "${invocation}" must be a MustacheStatement. Found type ContentStatement`);
+    expect(() => TranslateInvocation.from(invocation)).toThrow();
   });
 
   it('errors when given invalid hbs', () => {
     const invocation = '{{#if}}{{#if}}';
-    expect(() => TranslateInvocation.from(invocation)).toThrow(
-      `Error: Could not parse "${invocation}" as a valid translate helper.`);
+    expect(() => TranslateInvocation.from(invocation)).toThrow();
   });
 
   it('errors when given just a block helper', () => {
     const invocation = '{{#if true}}blah{{/if}}';
-    expect(() => TranslateInvocation.from(invocation)).toThrow(
-      `Error: "${invocation}" must be a MustacheStatement. Found type BlockStatement`);
+    expect(() => TranslateInvocation.from(invocation)).toThrow();
   });
 
   it('errors when given a template with multiple AST nodes', () => {
     const helper = `{{translate phrase='a phrase'}}`
     const invocation = `${helper} ${helper}`;
-    expect(() => TranslateInvocation.from(invocation)).toThrow(
-      `Error: "${invocation}" has multiple handlebars nodes.`);
+    expect(() => TranslateInvocation.from(invocation)).toThrow();
   });
 
   it('errors when given a SubExpression parameter', () => {
@@ -131,12 +127,11 @@ describe('TranslationInvocation throws correct errors when given an invalid invo
       subExpression=(concat 'first half ' 'second half')
     }}`;
     const createInvocation = () => TranslateInvocation.from(invocation);
-    expect(createInvocation).toThrow(
-      `Error: parameter "subExpression" in "${invocation}" is a SubExpression.`);
+    expect(createInvocation).toThrow();
   });
 
   it('errors when given a blank string', () => {
     const createInvocation = () => TranslateInvocation.from("");
-    expect(createInvocation).toThrow(`Error: "" does not have any handlebars nodes.`);
+    expect(createInvocation).toThrow();
   });
 });

--- a/tests/handlebars/models/translateinvocation.js
+++ b/tests/handlebars/models/translateinvocation.js
@@ -1,0 +1,54 @@
+const TranslateInvocation = require('../../../src/handlebars/models/translateinvocation');
+
+describe('TranslateInvocation correctly parses translate helper calls', () => {
+  it('can parse out the correct invoked helper', () => {
+    const phrase = 'We. Live! In: A, Society?.';
+    const translateCall = TranslateInvocation.from(`{{ translate phrase='${phrase}' }}`);
+    expect(translateCall.getInvokedHelper()).toEqual('translate');
+    const translateJSCall = TranslateInvocation.from(`{{ translateJS phrase='${phrase}' }}`);
+    expect(translateJSCall.getInvokedHelper()).toEqual('translateJS');
+  });
+
+  it('can parse out the phrase', () => {
+    const phrase = 'We. Live! In: A, Society?.';
+    const invocation = TranslateInvocation.from(`{{ translate phrase='${phrase}' }}`)
+    expect(invocation.getPhrase()).toEqual(phrase);
+  });
+
+  it('can parse out StringLiteral (wrapped in quotes) interpolation parameters', () => {
+    const phrase = 'Please, [[relative]], pass the [[kitchenAppliance]].';
+    const invocation = TranslateInvocation.from(`{{translate
+      phrase='${phrase}'
+      relative='card.relative'
+      kitchenAppliance='slapchop'
+    }}`)
+    expect(invocation.getInterpolationParams()).toEqual({
+      kitchenAppliance: 'slapchop',
+      relative: 'card.relative'
+    });
+  });
+
+  it('can parse out PathExpression (not wrapped in quotes) interpolation parameters', () => {
+    const phrase = 'Please, [[relative]], pass the [[kitchenAppliance]].';
+    const invocation = TranslateInvocation.from(`{{translate
+      phrase='${phrase}'
+      relative=card.relative
+      kitchenAppliance=slapchop
+    }}`)
+    expect(invocation.getInterpolationParams()).toEqual({
+      kitchenAppliance: 'slapchop',
+      relative: 'card.relative'
+    });
+  });
+
+  it('can detect a plural translate call', () => {
+    const phrase = '[[count]] cookie crisp.';
+    const pluralForm = '[[count]] cookie crispers.';
+    const invocation = TranslateInvocation.from(`{{translate
+      phrase='${phrase}'
+      pluralForm='${pluralForm}'
+      count=1000000
+    }}`)
+    expect(invocation.isUsingPluralization()).toBeTruthy();
+  });
+});

--- a/tests/handlebars/models/translateinvocation.js
+++ b/tests/handlebars/models/translateinvocation.js
@@ -100,15 +100,29 @@ describe('TranslationInvocation can parse all Hash parameter types (but SubExpre
 });
 
 describe('TranslationInvocation throws correct errors when given an invalid invocation', () => {
-  it('errors when given a block helper', () => {
-    const invocation = 'errors when given just a ContentStatement';
-    expect(() => TranslateInvocation.from(invocation)).toThrow(/must be a MustacheStatement/)
+  it('errors when given just a ContentStatement', () => {
+    const invocation = 'this is a ContentStatement';
+    expect(() => TranslateInvocation.from(invocation)).toThrow(
+      `Error: "${invocation}" must be a MustacheStatement. Found type ContentStatement`);
+  });
+
+  it('errors when given invalid hbs', () => {
+    const invocation = '{{#if}}{{#if}}';
+    expect(() => TranslateInvocation.from(invocation)).toThrow(
+      `Error: Could not parse "${invocation}" as a valid translate helper.`);
+  });
+
+  it('errors when given just a block helper', () => {
+    const invocation = '{{#if true}}blah{{/if}}';
+    expect(() => TranslateInvocation.from(invocation)).toThrow(
+      `Error: "${invocation}" must be a MustacheStatement. Found type BlockStatement`);
   });
 
   it('errors when given a template with multiple AST nodes', () => {
     const helper = `{{translate phrase='a phrase'}}`
     const invocation = `${helper} ${helper}`;
-    expect(() => TranslateInvocation.from(invocation)).toThrow(/has multiple handlebars nodes/)
+    expect(() => TranslateInvocation.from(invocation)).toThrow(
+      `Error: "${invocation}" has multiple handlebars nodes.`);
   });
 
   it('errors when given a SubExpression parameter', () => {
@@ -118,6 +132,6 @@ describe('TranslationInvocation throws correct errors when given an invalid invo
     }}`;
     const createInvocation = () => TranslateInvocation.from(invocation);
     expect(createInvocation).toThrow(
-      `Error: parameter "subExpression" in "${invocation}" is a SubExpression.`)
+      `Error: parameter "subExpression" in "${invocation}" is a SubExpression.`);
   });
 });

--- a/tests/handlebars/models/translateinvocation.js
+++ b/tests/handlebars/models/translateinvocation.js
@@ -134,4 +134,9 @@ describe('TranslationInvocation throws correct errors when given an invalid invo
     expect(createInvocation).toThrow(
       `Error: parameter "subExpression" in "${invocation}" is a SubExpression.`);
   });
+
+  it('errors when given a blank string', () => {
+    const createInvocation = () => TranslateInvocation.from("");
+    expect(createInvocation).toThrow(`Error: "" does not have any handlebars nodes.`);
+  });
 });


### PR DESCRIPTION
This commit updates the TranslateInvocation model to use the
Handlebars parser for parsing out properties of the invocation.

J=SLAP-599
TEST=auto, manual

wrote unit tests for TranslateInvocation

added a page with contents `{{{read 'partials/temp'}}}`
and partials/temp.hbs with contents 

```hbs
{{translate phrase='Hello my name is [[name]]' name=card.name}}
blahasdf
```
on running jambo build got result 

```hbs
{{ runtimeTranslation phrase='Bonjour, mon nom est [[name]]' name=card.name }}
blahasdf
```