### PR TITLE
dont wrap static {{translate}} results with quotes

### DIFF
--- a/src/handlebars/handlebarspreprocessor.js
+++ b/src/handlebars/handlebarspreprocessor.js
@@ -55,10 +55,9 @@ class HandlebarsPreprocessor {
           invocation.getPhrase(), translationContext) :
         this._translator.translate(invocation.getPhrase());
     }
-    translatorResult = `'${translatorResult}'`;
 
     if (invocation.canBeTranslatedStatically()) {
-      return translatorResult;
+      return invocation.getInvokedHelper() === 'translateJS' ? `'${translatorResult}'` : translatorResult;
     }
     const interpParams = invocation.getInterpolationParams();
 
@@ -74,6 +73,8 @@ class HandlebarsPreprocessor {
    * Constructs a call to the SDK's Javascript method for run-time translation.
    * This call is constructed using the translation(s) for a phrase and any interpolation
    * paramters.
+   * TODO: after updating translate invocation to use the Handlebars parser, update this method
+   * to escape single quotes in translatorResult.
    *
    * @param {Object|string} translatorResult The translation(s) for the phrase.
    * @param {boolean} needsPluralization If pluralization is required when translating.
@@ -87,16 +88,18 @@ class HandlebarsPreprocessor {
 
     if (needsPluralization) {
       const count = interpolationParams.count;
-      return `ANSWERS.translateJS(${translatorResult}, ${parsedParams}, ${count})`;
+      return `ANSWERS.translateJS('${translatorResult}', ${parsedParams}, ${count})`;
     }
 
-    return `ANSWERS.translateJS(${translatorResult}, ${parsedParams})`;
+    return `ANSWERS.translateJS('${translatorResult}', ${parsedParams})`;
   }
 
   /**
    * Constructs a call to the SDK's Handlebars helper for run-time translation.
    * This call is constructed using the translation(s) for a phrase and any interpolation
    * paramters.
+   * TODO: after updating translate invocation to use the Handlebars parser, update this method
+   * to escape single quotes in translatorResult.
    *
    * @param {Object|string} translatorResult The translation(s) for the phrase.
    * @param {Object<string, ?>} interpolationParams The needed interpolation parameters
@@ -109,7 +112,7 @@ class HandlebarsPreprocessor {
         return params + `${paramName}=${paramValue} `;
       }, '');
 
-    return `{{ runtimeTranslation phrase=${translatorResult} ${paramsString}}}`;
+    return `{{ runtimeTranslation phrase='${translatorResult}' ${paramsString}}}`;
   }
 }
 module.exports = HandlebarsPreprocessor;

--- a/tests/fixtures/handlebars/processedtemplate.hbs
+++ b/tests/fixtures/handlebars/processedtemplate.hbs
@@ -1,5 +1,5 @@
 <div>
-    <button>'Bonjour'</button>
+    <button>Bonjour</button>
     <div>
         {{ runtimeTranslation phrase='{"0":"Un article [[name]]","1":"Les articles [[name]]","locale":"fr-FR"}' name=myName count=myCount }}
     </div>

--- a/tests/fixtures/handlebars/rawcomponent.js
+++ b/tests/fixtures/handlebars/rawcomponent.js
@@ -32,7 +32,7 @@ class standardCardComponent extends BaseCard['standard'] {
         eventOptions: this.addDefaultEventOptions()
       },
       CTA2: {
-        label: {{ translate phrase='Hello' }},
+        label: '{{ translate phrase='Hello' }}',
         iconName: 'chevron',
         url: Formatter.generateCTAFieldTypeLink(profile.c_secondaryCTA),
         target: '_top',


### PR DESCRIPTION
When there is a static translation in hbs, we dont want to wrap it in quotes.
Originally, this item was going to also not wrap static translateJS results
in quotes as well, but after taking another look that seemed confusing, since
translateJS would return a javascript string if it was a runtime translation,
but the raw(?) text if it was a static translation. In order to know whether
to wrap a translate helper in quotes you would have to think about whether
this was something that would be statically translated i.e. (no interpolation or
plurals). This seemed like something that could end up very frustrating.

Instead, with this pr {{translateJS}} will always compile to a js string, and
{{translate}} will always compile down to raw text without quotes,
whether runtime or not.

J=SLAP-592
TEST=auto

updated unit tests