### PR TITLE
Intermixed markdown

### DIFF
--- a/src/i18n/translator/translator.js
+++ b/src/i18n/translator/translator.js
@@ -148,7 +148,7 @@ class Translator {
    * @param {Array<string>} fallbacks A prioritized list of translation fallbacks
    *                                  for the locale.
    * @param {string} translations The translations for the locale and associated fallbacks.
-   * @param {Object<string, Object} A map of locale to translations
+   * @param {Object<string, Object>} A map of locales to translations
    */
   static async create(locale, fallbacks, translations) {
     const i18nextInstance = i18next.createInstance();

--- a/src/i18n/translator/translator.js
+++ b/src/i18n/translator/translator.js
@@ -147,8 +147,7 @@ class Translator {
    * @param {string} locale The desired locale.
    * @param {Array<string>} fallbacks A prioritized list of translation fallbacks
    *                                  for the locale.
-   * @param {string} translations The translations for the locale and associated fallbacks.
-   * @param {Object<string, Object>} A map of locales to translations
+   * @param {Object<string, Object>} translations A map of locales to translations
    */
   static async create(locale, fallbacks, translations) {
     const i18nextInstance = i18next.createInstance();

--- a/src/i18n/translator/translator.js
+++ b/src/i18n/translator/translator.js
@@ -148,6 +148,7 @@ class Translator {
    * @param {Array<string>} fallbacks A prioritized list of translation fallbacks
    *                                  for the locale.
    * @param {string} translations The translations for the locale and associated fallbacks.
+   * @param {Object<string, Object} A map of locale to translations
    */
   static async create(locale, fallbacks, translations) {
     const i18nextInstance = i18next.createInstance();

--- a/tests/fixtures/translations/fr.po
+++ b/tests/fixtures/translations/fr.po
@@ -11,3 +11,9 @@ msgstr ""
 
 msgid "Breakfast"
 msgstr "Petit Déjeuner"
+
+msgid "Alternatively, you can<a class=\"yxt-AlternativeVerticals-universalLink\" href=universalUrl>view results across all search categories</a>"
+msgstr "Sinon vous pouvez<a class=\"yxt-AlternativeVerticals-universalLink\" href=universalUrl>afficher les résultats dans toutes les catégories de recherche</a>"
+
+msgid "<span class=\"yext\">The dog's bone<span>"
+msgstr "<span class=\"yext\">L'os du chien<span>"

--- a/tests/i18n/translator/translator.js
+++ b/tests/i18n/translator/translator.js
@@ -98,6 +98,23 @@ describe('translations with one plural form (French)', () => {
       expect(translation).toEqual('Je cherche mon fille nommé [[name]]')
     });
   });
+
+  describe('supports text intermixed with HTML', () => {
+    it('text with html link', () => {
+      const translation = translator.translate('Alternatively, you can<a class="yxt-AlternativeVerticals-universalLink" href=universalUrl>view results across all search categories</a>');
+      expect(translation).toEqual('Sinon vous pouvez<a class="yxt-AlternativeVerticals-universalLink" href=universalUrl>afficher les résultats dans toutes les catégories de recherche</a>');
+    });
+
+    it('apostrophe inside text and html class with double quotes', () => {
+      const translation = translator.translate('<span class="yext">The dog\'s bone<span>');
+      expect(translation).toEqual('<span class="yext">L\'os du chien<span>');
+    });
+
+    it('apostrophe inside text and html class with double quotes (all inside double quoted string)', () => {
+      const translation = translator.translate("<span class=\"yext\">The dog's bone<span>");
+      expect(translation).toEqual("<span class=\"yext\">L'os du chien<span>");
+    });
+  });
 });
 
 describe('translations with multiple plural forms (Lithuanian)', () => {


### PR DESCRIPTION
Add tests that confirm that the translator handles intermixed markdown as expected

J=SLAP-581
TEST=auto, manual

In addition to automatic tests, I also tested the handlebars translate helper in an internationalized jambo site. The mixed markdown fails due to the regex not picking characters including "<" and ">". Oliver's switch to the handlebars parser fixes this issue: https://github.com/yext/jambo/pull/98