### PR TITLE
handlebarspreprocessor: pass plural form to translatePlural

### DIFF
--- a/src/handlebars/handlebarspreprocessor.js
+++ b/src/handlebars/handlebarspreprocessor.js
@@ -47,7 +47,7 @@ class HandlebarsPreprocessor {
     let translatorResult;
     if (invocation.isUsingPluralization()) {
       translatorResult = JSON.stringify(
-        this._translator.translatePlural(invocation.getPhrase()));
+        this._translator.translatePlural(invocation.getPhrase(), invocation.getPluralForm()));
     } else {
       const translationContext = invocation.getContext();
       translatorResult = translationContext ?

--- a/tests/handlebars/handlebarspreprocessor.js
+++ b/tests/handlebars/handlebarspreprocessor.js
@@ -39,4 +39,19 @@ describe('HandlebarsPreprocessor works correctly', () => {
 
     expect(handlebarsPreprocessor.process(rawHbsHandlebarsContent)).toEqual(processedHbsHandlebarsContent);
   });
+
+  it('passes correct arguments to translatePlural', () => {
+    const translatePlural = jest.fn(() => ({
+      0: 'singular',
+      1: 'plural',
+      locale: 'en'
+    }));
+    Translator.mockImplementation(() => ({ translatePlural }));
+    const handlebarsPreprocessor = new HandlebarsPreprocessor(new Translator());
+
+    const raw = `{{ translate phrase='singular' pluralForm='plural' }}`;
+    const processed = `{{ runtimeTranslation phrase='{"0":"singular","1":"plural","locale":"en"}' }}`;
+    expect(handlebarsPreprocessor.process(raw)).toEqual(processed);
+    expect(translatePlural.mock.calls).toEqual([['singular', 'plural']]);
+  });
 });


### PR DESCRIPTION
This commit passes the plural form to translatePlural, so that
in cases when there is no plural form found in the translation data,
it will default to whatever this passed in value is.

J=SLAP-593
TEST=auto

Add unit test for this case. See that if I use the old code, it breaks,
but new code passes this test.