### PR TITLE
Create translator for each PageSet even if no locale config if provided

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -116,12 +116,6 @@ exports.SitesGenerator = class {
       ? await this._extractTranslations(locales, configRegistry.getLocalizationConfig())
       : {};
 
-    const localeToTranslator = {};
-    for (const locale of locales) {
-      localeToTranslator[locale] = await Translator
-        .create(locale, GENERATED_DATA.getLocaleFallbacks(locale), translations);
-    }
-
     // Register needed Handlebars helpers.
     console.log('Registering Jambo Handlebars helpers');
     try {
@@ -134,7 +128,9 @@ exports.SitesGenerator = class {
     for (const pageSet of pageSets) {
       // Pre-process partials and register them with the Handlebars instance
       const locale = pageSet.getLocale();
-      const handlebarsPreprocessor = new HandlebarsPreprocessor(localeToTranslator[locale]);
+      const translator = await Translator
+        .create(locale, GENERATED_DATA.getLocaleFallbacks(locale), translations);
+      const handlebarsPreprocessor = new HandlebarsPreprocessor(translator);
 
       console.log(`Registering Handlebars partials for locale ${locale}`);
       for (const partial of partialRegistry.getPartials()) {

--- a/src/handlebars/handlebarspreprocessor.js
+++ b/src/handlebars/handlebarspreprocessor.js
@@ -19,10 +19,6 @@ class HandlebarsPreprocessor {
    * @returns {string} The transpiled Handlebars content.
    */
   process(handlebarsContent) {
-    if (!this._translator) {
-      return handlebarsContent;
-    }
-
     let processedHandlebarsContent = handlebarsContent;
     const translateHelperCalls =
       processedHandlebarsContent.match(/\{\{\s?translate(JS)?\s.+\}\}/g) || [];

--- a/src/handlebars/handlebarspreprocessor.js
+++ b/src/handlebars/handlebarspreprocessor.js
@@ -19,6 +19,10 @@ class HandlebarsPreprocessor {
    * @returns {string} The transpiled Handlebars content.
    */
   process(handlebarsContent) {
+    if (!this._translator) {
+      return handlebarsContent;
+    }
+
     let processedHandlebarsContent = handlebarsContent;
     const translateHelperCalls =
       processedHandlebarsContent.match(/\{\{\s?translate(JS)?\s.+\}\}/g) || [];


### PR DESCRIPTION
Since single-locale sites don't have a translator they could return an error much later in the HandlebarsProcessor `Cannot read property 'translate' of undefined`. Even same-language content could be used with the translate helpers for interpolation or pluralization, so we can't simply skip the pre-processing. Instead, we will always require a translator for pre-processing, even if the translator has no translations.

TEST=manual