### PR TITLE
handlebarspreprocessor: make translate helper regex non-greedy

### DIFF
--- a/src/handlebars/handlebarspreprocessor.js
+++ b/src/handlebars/handlebarspreprocessor.js
@@ -21,12 +21,11 @@ class HandlebarsPreprocessor {
   process(handlebarsContent) {
     let processedHandlebarsContent = handlebarsContent;
     const translateHelperCalls =
-      processedHandlebarsContent.match(/\{\{\s?translate(JS)?\s.+\}\}/g) || [];
+      processedHandlebarsContent.match(/\{\{\s?translate(JS)?\s(.+?)\}\}/g) || [];
 
     translateHelperCalls.forEach(call => {
       const translateInvocation = TranslateInvocation.from(call);
-      const transpiledCall =
-        this._handleTranslateInvocation(translateInvocation);
+      const transpiledCall = this._handleTranslateInvocation(translateInvocation);
       processedHandlebarsContent = processedHandlebarsContent.replace(call, transpiledCall);
     });
 

--- a/tests/fixtures/handlebars/processedcomponent.js
+++ b/tests/fixtures/handlebars/processedcomponent.js
@@ -13,7 +13,7 @@ class standardCardComponent extends BaseCard['standard'] {
    */
   dataForRender(profile) {
     return {
-      title: 'Bonjour', // The header text of the card
+      title: 'Bonjour' + 'Bonjour', // The header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),

--- a/tests/fixtures/handlebars/processedtemplate.hbs
+++ b/tests/fixtures/handlebars/processedtemplate.hbs
@@ -1,5 +1,5 @@
 <div>
-    <button>Bonjour</button>
+    <button>Bonjour Bonjour</button>
     <div>
         {{ runtimeTranslation phrase='{"0":"Un article [[name]]","1":"Les articles [[name]]","locale":"fr-FR"}' name=myName count=myCount }}
     </div>

--- a/tests/fixtures/handlebars/rawcomponent.js
+++ b/tests/fixtures/handlebars/rawcomponent.js
@@ -13,7 +13,7 @@ class standardCardComponent extends BaseCard['standard'] {
    */
   dataForRender(profile) {
     return {
-      title: {{ translateJS phrase='Hello' }}, // The header text of the card
+      title: {{ translateJS phrase='Hello' }} + {{ translateJS phrase='Hello' }}, // The header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),

--- a/tests/fixtures/handlebars/rawtemplate.hbs
+++ b/tests/fixtures/handlebars/rawtemplate.hbs
@@ -1,5 +1,5 @@
 <div>
-    <button>{{ translate phrase='Hello' }}</button>
+    <button>{{ translate phrase='Hello' }} {{ translate phrase='Hello' }}</button>
     <div>
         {{ translate phrase='Some item [[name]]' pluralForm='Some items [[name]]' name=myName count=myCount }}
     </div>

--- a/tests/handlebars/handlebarspreprocessor.js
+++ b/tests/handlebars/handlebarspreprocessor.js
@@ -40,7 +40,7 @@ describe('HandlebarsPreprocessor works correctly', () => {
     expect(handlebarsPreprocessor.process(rawHbsHandlebarsContent)).toEqual(processedHbsHandlebarsContent);
   });
 
-  it('passes correct arguments to translatePlural', () => {
+  describe('when translating simple plural english', () => {
     const translatePlural = jest.fn(() => ({
       0: 'singular',
       1: 'plural',
@@ -49,9 +49,17 @@ describe('HandlebarsPreprocessor works correctly', () => {
     Translator.mockImplementation(() => ({ translatePlural }));
     const handlebarsPreprocessor = new HandlebarsPreprocessor(new Translator());
 
-    const raw = `{{ translate phrase='singular' pluralForm='plural' }}`;
-    const processed = `{{ runtimeTranslation phrase='{"0":"singular","1":"plural","locale":"en"}' }}`;
-    expect(handlebarsPreprocessor.process(raw)).toEqual(processed);
-    expect(translatePlural.mock.calls).toEqual([['singular', 'plural']]);
+    it('passes correct arguments to translatePlural', () => {
+      const raw = `{{ translate phrase='singular' pluralForm='plural' }}`;
+      const processed = `{{ runtimeTranslation phrase='{"0":"singular","1":"plural","locale":"en"}' }}`;
+      expect(handlebarsPreprocessor.process(raw)).toEqual(processed);
+      expect(translatePlural.mock.calls).toEqual([['singular', 'plural']]);
+    });
+
+    it('transpiles commented out "translate" invocations correctly', () => {
+      const raw = `{{!-- {{ translate phrase='singular' pluralForm='plural' }} --}}`;
+      const processed = `{{!-- {{ runtimeTranslation phrase='{"0":"singular","1":"plural","locale":"en"}' }} --}}`;
+      expect(handlebarsPreprocessor.process(raw)).toEqual(processed);
+    });
   });
 });

--- a/tests/handlebars/handlebarspreprocessor.js
+++ b/tests/handlebars/handlebarspreprocessor.js
@@ -40,7 +40,7 @@ describe('HandlebarsPreprocessor works correctly', () => {
     expect(handlebarsPreprocessor.process(rawHbsHandlebarsContent)).toEqual(processedHbsHandlebarsContent);
   });
 
-  describe('when translating simple plural english', () => {
+  describe('when translating a language with a single plural form', () => {
     const translatePlural = jest.fn(() => ({
       0: 'singular',
       1: 'plural',
@@ -58,7 +58,8 @@ describe('HandlebarsPreprocessor works correctly', () => {
 
     it('transpiles commented out "translate" invocations correctly', () => {
       const raw = `{{!-- {{ translate phrase='singular' pluralForm='plural' }} --}}`;
-      const processed = `{{!-- {{ runtimeTranslation phrase='{"0":"singular","1":"plural","locale":"en"}' }} --}}`;
+      const processed = 
+        `{{!-- {{ runtimeTranslation phrase='{"0":"singular","1":"plural","locale":"en"}' }} --}}`;
       expect(handlebarsPreprocessor.process(raw)).toEqual(processed);
     });
   });


### PR DESCRIPTION
This commit makes the regex non-greedy so that it ends its match on the
first closing mustache found, instead of the last. This fixes both commented out
translation helpers and multiple translation helpers on a single line.

J=SLAP-591, SLAP-595
TEST=auto, manual

added unit tests
test jambo build locally with a commented out helper, and also two helpers on the same line