### PR TITLE
handlebarspreprocessor: update tests to cover 2 translates per line

### DIFF
--- a/tests/fixtures/handlebars/processedcomponent.js
+++ b/tests/fixtures/handlebars/processedcomponent.js
@@ -13,7 +13,7 @@ class standardCardComponent extends BaseCard['standard'] {
    */
   dataForRender(profile) {
     return {
-      title: 'Bonjour', // The header text of the card
+      title: 'Bonjour' + 'Bonjour', // The header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),

--- a/tests/fixtures/handlebars/processedtemplate.hbs
+++ b/tests/fixtures/handlebars/processedtemplate.hbs
@@ -1,5 +1,5 @@
 <div>
-    <button>Bonjour</button>
+    <button>Bonjour Bonjour</button>
     <div>
         {{ runtimeTranslation phrase='{"0":"Un article [[name]]","1":"Les articles [[name]]","locale":"fr-FR"}' name=myName count=myCount }}
     </div>

--- a/tests/fixtures/handlebars/rawcomponent.js
+++ b/tests/fixtures/handlebars/rawcomponent.js
@@ -13,7 +13,7 @@ class standardCardComponent extends BaseCard['standard'] {
    */
   dataForRender(profile) {
     return {
-      title: {{ translateJS phrase='Hello' }}, // The header text of the card
+      title: {{ translateJS phrase='Hello' }} + {{ translateJS phrase='Hello' }}, // The header text of the card
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),

--- a/tests/fixtures/handlebars/rawtemplate.hbs
+++ b/tests/fixtures/handlebars/rawtemplate.hbs
@@ -1,5 +1,5 @@
 <div>
-    <button>{{ translate phrase='Hello' }}</button>
+    <button>{{ translate phrase='Hello' }} {{ translate phrase='Hello' }}</button>
     <div>
         {{ translate phrase='Some item [[name]]' pluralForm='Some items [[name]]' name=myName count=myCount }}
     </div>


### PR DESCRIPTION
The previous change of making the regex non greedy fixed the issue of
having multiple translate invocations on a single line bugging out,
so this pr just adds some coverage for that behavior

J=SLAP-591
TEST=auto

updated unit test fixtures