### PR TITLE
Test intermixed markdown extraction

### DIFF
--- a/tests/fixtures/extractions/combined.pot
+++ b/tests/fixtures/extractions/combined.pot
@@ -2,6 +2,10 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
+#: tests/fixtures/extractions/rawtemplate.hbs:12
+msgid "<span class=\"yext\">The dog's bone</span>"
+msgstr ""
+
 #: tests/fixtures/extractions/rawcomponent.js:16
 #: tests/fixtures/extractions/rawcomponent.js:35
 #: tests/fixtures/extractions/rawtemplate.hbs:2

--- a/tests/fixtures/extractions/rawtemplate.hbs
+++ b/tests/fixtures/extractions/rawtemplate.hbs
@@ -9,4 +9,5 @@
     </script>
     <button>{{translate phrase='Mail now [[id1]]' context='Mail is a verb' id1=myName}}</button>
     <span>{{translate phrase='this is a raw template'}}</span>
+    {{translate phrase='<span class="yext">The dog\'s bone</span>'}}
 </div>

--- a/tests/fixtures/extractions/rawtemplate.pot
+++ b/tests/fixtures/extractions/rawtemplate.pot
@@ -2,6 +2,10 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
+#: tests/fixtures/extractions/rawtemplate.hbs:12
+msgid "<span class=\"yext\">The dog's bone</span>"
+msgstr ""
+
 #: tests/fixtures/extractions/rawtemplate.hbs:2
 msgid "Hello"
 msgstr ""


### PR DESCRIPTION
Add a test that confirms the extractor escapes double quotes when generating .POT files. The test also confirms that escaping single quotes is handled properly.

J=SLAP-581
TEST=auto

Ran the unit tests