### PR TITLE
TranslationExtractor: use visitor instead of looping over first layer of statements

### DIFF
--- a/src/i18n/extractor/translationextractor.js
+++ b/src/i18n/extractor/translationextractor.js
@@ -75,16 +75,18 @@ class TranslationExtractor {
 
   _extractMessagesFromTemplate(template, filepath) {
     const tree = Handlebars.parseWithoutProcessing(template);
-    for (const statement of tree.body) {
-      if (this._statementIsTranslationHelper(statement)) {
-        this._registerMessageToExtractor(statement, filepath);
-      }
-    }
+    const visitor = new Handlebars.Visitor();
+    visitor.MustacheStatement =
+      mustacheStatement => this._handleMustacheStatement(mustacheStatement, filepath);
+    visitor.accept(tree);
   }
 
-  _statementIsTranslationHelper (statement) {
-    return statement.type === 'MustacheStatement' &&
-      this._options.translateMethods.includes(statement.path.original);
+  _handleMustacheStatement(mustacheStatement, filepath) {
+    const isTranslationHelper =
+    this._options.translateMethods.includes(mustacheStatement.path.original);
+    if (isTranslationHelper) {
+      this._registerMessageToExtractor(mustacheStatement, filepath);
+    }
   }
   
   _registerMessageToExtractor (mustacheStatement, filepath) {

--- a/tests/fixtures/extractions/combined.pot
+++ b/tests/fixtures/extractions/combined.pot
@@ -2,18 +2,18 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: tests/fixtures/extractions/rawtemplate.hbs:12
+#: tests/fixtures/extractions/rawtemplate.hbs:13
 msgid "<span class=\"yext\">The dog's bone</span>"
 msgstr ""
 
 #: tests/fixtures/extractions/rawcomponent.js:16
 #: tests/fixtures/extractions/rawcomponent.js:35
-#: tests/fixtures/extractions/rawtemplate.hbs:2
+#: tests/fixtures/extractions/rawtemplate.hbs:3
 msgid "Hello"
 msgstr ""
 
 #: tests/fixtures/extractions/rawcomponent.js:20
-#: tests/fixtures/extractions/rawtemplate.hbs:4
+#: tests/fixtures/extractions/rawtemplate.hbs:5
 msgid "Some item [[name]]"
 msgid_plural "Some items [[name]]"
 msgstr[0] ""
@@ -23,18 +23,18 @@ msgstr[1] ""
 msgid "this is a raw component"
 msgstr ""
 
-#: tests/fixtures/extractions/rawtemplate.hbs:11
+#: tests/fixtures/extractions/rawtemplate.hbs:12
 msgid "this is a raw template"
 msgstr ""
 
 #: tests/fixtures/extractions/rawcomponent.js:27
-#: tests/fixtures/extractions/rawtemplate.hbs:10
-#: tests/fixtures/extractions/rawtemplate.hbs:8
+#: tests/fixtures/extractions/rawtemplate.hbs:11
+#: tests/fixtures/extractions/rawtemplate.hbs:9
 msgctxt "Mail is a verb"
 msgid "Mail now [[id1]]"
 msgstr ""
 
-#: tests/fixtures/extractions/rawtemplate.hbs:14
+#: tests/fixtures/extractions/rawtemplate.hbs:15
 msgctxt "male"
 msgid "The [[count]] person went on a walk"
 msgid_plural "The [[count]] people went on a walk"

--- a/tests/fixtures/extractions/rawtemplate.hbs
+++ b/tests/fixtures/extractions/rawtemplate.hbs
@@ -1,16 +1,18 @@
-<div>
-    <button>{{ translate phrase='Hello' }}</button>
+{{#*inline 'details'}}
     <div>
-        {{ translate phrase='Some item [[name]]' pluralForm='Some items [[name]]' name=myName count=myCount }}
+        <button>{{ translate phrase='Hello' }}</button>
+        <div>
+            {{ translate phrase='Some item [[name]]' pluralForm='Some items [[name]]' name=myName count=myCount }}
+        </div>
+        <script>
+            const profile = { name: 'Tom' };
+            {{translateJS phrase='Mail now [[id1]]' context='Mail is a verb' id1=profile.name}}
+        </script>
+        <button>{{translate phrase='Mail now [[id1]]' context='Mail is a verb' id1=myName}}</button>
+        <span>{{translate phrase='this is a raw template'}}</span>
+        {{translate phrase='<span class="yext">The dog\'s bone</span>'}}
+        <div>
+            {{ translate phrase='The [[count]] person went on a walk' pluralForm='The [[count]] people went on a walk' context='male' count=myCount}}
+        </div>
     </div>
-    <script>
-        const profile = { name: 'Tom' };
-        {{translateJS phrase='Mail now [[id1]]' context='Mail is a verb' id1=profile.name}}
-    </script>
-    <button>{{translate phrase='Mail now [[id1]]' context='Mail is a verb' id1=myName}}</button>
-    <span>{{translate phrase='this is a raw template'}}</span>
-    {{translate phrase='<span class="yext">The dog\'s bone</span>'}}
-    <div>
-        {{ translate phrase='The [[count]] person went on a walk' pluralForm='The [[count]] people went on a walk' context='male' count=myCount}}
-    </div>
-</div>
+{{/inline}}

--- a/tests/fixtures/extractions/rawtemplate.pot
+++ b/tests/fixtures/extractions/rawtemplate.pot
@@ -2,31 +2,31 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: tests/fixtures/extractions/rawtemplate.hbs:12
+#: tests/fixtures/extractions/rawtemplate.hbs:13
 msgid "<span class=\"yext\">The dog's bone</span>"
 msgstr ""
 
-#: tests/fixtures/extractions/rawtemplate.hbs:2
+#: tests/fixtures/extractions/rawtemplate.hbs:3
 msgid "Hello"
 msgstr ""
 
-#: tests/fixtures/extractions/rawtemplate.hbs:4
+#: tests/fixtures/extractions/rawtemplate.hbs:5
 msgid "Some item [[name]]"
 msgid_plural "Some items [[name]]"
 msgstr[0] ""
 msgstr[1] ""
 
-#: tests/fixtures/extractions/rawtemplate.hbs:11
+#: tests/fixtures/extractions/rawtemplate.hbs:12
 msgid "this is a raw template"
 msgstr ""
 
-#: tests/fixtures/extractions/rawtemplate.hbs:10
-#: tests/fixtures/extractions/rawtemplate.hbs:8
+#: tests/fixtures/extractions/rawtemplate.hbs:11
+#: tests/fixtures/extractions/rawtemplate.hbs:9
 msgctxt "Mail is a verb"
 msgid "Mail now [[id1]]"
 msgstr ""
 
-#: tests/fixtures/extractions/rawtemplate.hbs:14
+#: tests/fixtures/extractions/rawtemplate.hbs:15
 msgctxt "male"
 msgid "The [[count]] person went on a walk"
 msgid_plural "The [[count]] people went on a walk"


### PR DESCRIPTION
Noticed a bug while working on the sdk extractor, the extractor
would only detect {{translate calls on the first level of a
handlebars AST, and any {{translate calls nested within any
handlebars logic would not be detected. This is fixed by
updating the extractor to use Handlebars.Visitor, which
automatically visits all nodes no matter the depth.

TEST=auto

updated unit tests, see that old code would fail but new code passes