### PR TITLE
Fix translation of phrases with colons and periods

### DIFF
--- a/src/i18n/translator/translator.js
+++ b/src/i18n/translator/translator.js
@@ -219,6 +219,8 @@ class Translator {
     const i18nextInstance = i18next.createInstance();
     await i18nextInstance.init({
       lng: locale,
+      nsSeparator: false,     // allow keys to be phrases having `:`
+      keySeparator: false,    // allow keys to be phrases having `.`
       fallbackLng: fallbacks,
       resources: translations,
     });

--- a/tests/fixtures/handlebars/processedtemplate.hbs
+++ b/tests/fixtures/handlebars/processedtemplate.hbs
@@ -14,4 +14,6 @@
     </div>
     <button>L'homme</button>
     <span class="yext">L'os du chien</span>
+    Le chien.
+    Le: chien
 </div>

--- a/tests/fixtures/handlebars/rawtemplate.hbs
+++ b/tests/fixtures/handlebars/rawtemplate.hbs
@@ -14,4 +14,6 @@
     </div>
     <button>{{ translate phrase='The man' }}</button>
     {{ translate phrase='<span class="yext">The dog\'s bone</span>' }}
+    {{ translate phrase='The dog.'}}
+    {{ translate phrase='The: dog'}}
 </div>

--- a/tests/fixtures/translations/fr-FR.po
+++ b/tests/fixtures/translations/fr-FR.po
@@ -61,3 +61,9 @@ msgid "The [[count]] person went on a walk"
 msgid_plural "The [[count]] people went on a walk"
 msgstr[0] "La [[count]] femme a fait une promenade"
 msgstr[1] "Les [[count]] femmes fait une promenade"
+
+msgid "The dog."
+msgstr "Le chien."
+
+msgid "The: dog"
+msgstr "Le: chien"

--- a/tests/handlebars/handlebarspreprocessor.js
+++ b/tests/handlebars/handlebarspreprocessor.js
@@ -16,6 +16,10 @@ describe('HandlebarsPreprocessor works correctly', () => {
           return 'L\'homme';
         } else if (phrase === '<span class="yext">The dog\'s bone</span>') {
           return '<span class="yext">L\'os du chien</span>';
+        } else if (phrase === 'The dog.') {
+          return 'Le chien.';
+        } else if (phrase === 'The: dog') {
+          return 'Le: chien';
         }
       },
       translateWithContext: () => 'Mail maintenant [[id1]]',

--- a/tests/i18n/translationfetchers/localfileparser.js
+++ b/tests/i18n/translationfetchers/localfileparser.js
@@ -24,6 +24,8 @@ describe('LocalFileParser works correctly', () => {
       "The [[count]] person went on a walk_female_plural": "Les [[count]] femmes fait une promenade",
       "The [[count]] person went on a walk_male": "Le [[count]] homme est parti en promenade",
       "The [[count]] person went on a walk_male_plural": "Les [[count]] Hommes fait une promenade",
+      "The dog.": "Le chien.",
+      "The: dog": "Le: chien"
     };
 
     return localFileParser.fetch('fr-FR').then(translations => {

--- a/tests/i18n/translator/translator.js
+++ b/tests/i18n/translator/translator.js
@@ -35,6 +35,16 @@ describe('translations with one plural form (French)', () => {
       const translation = translator.translate('Breakfast');
       expect(translation).toEqual('Petit Déjeuner');
     });
+
+    it('translation with a period . work as expected', () => {
+      const translation = translator.translate('The dog.');
+      expect(translation).toEqual('Le chien.');
+    });
+
+    it('translation with a colon : work as expected', () => {
+      const translation = translator.translate('The: dog');
+      expect(translation).toEqual('Le: chien');
+    });
   });
 
   describe('Translations with pluralization and no context', () => {


### PR DESCRIPTION
Fixes the translator when translating phrases with periods or colons

By default, i18next uses periods to separate keys and colons to separate namespaces. This PR disables that functionality and allows us to use translations with a colon or period in the key.

J=none
TEST=auto, manual

Added tests that confirm the preprocessor and the translator can handle phrases with periods and colons. Manually tested the translator on an internationalized answers site.