### PR TITLE
Throw an error if the translationFile for a locale is invalid

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -310,8 +310,13 @@ exports.SitesGenerator = class {
     const translations = {};
 
     for (const locale of locales) {
-      const localeTranslations = await localFileParser
-        .fetch(locale, localizationConfig.getTranslationFile(locale));
+      const translationFilePath = localizationConfig.getTranslationFile(locale);
+      if (!translationFilePath) {
+        console.log(`Warning: No translation file specified for '${locale}'`);
+        continue;
+      }
+
+      const localeTranslations = await localFileParser.fetch(locale, translationFilePath);
       translations[locale] = { translation: localeTranslations };
     }
 

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -310,13 +310,8 @@ exports.SitesGenerator = class {
     const translations = {};
 
     for (const locale of locales) {
-      const translationFilePath = localizationConfig.getTranslationFile(locale);
-      if (!translationFilePath) {
-        console.log(`Warning: No translation file specified for '${locale}'`);
-        continue;
-      }
-
-      const localeTranslations = await localFileParser.fetch(locale, translationFilePath);
+      const localeTranslations = await localFileParser
+        .fetch(locale, localizationConfig.getTranslationFile(locale));
       translations[locale] = { translation: localeTranslations };
     }
 

--- a/src/i18n/translationfetchers/localfileparser.js
+++ b/src/i18n/translationfetchers/localfileparser.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const { readFileSync, existsSync } = require('fs');
 const { gettextToI18next } = require('i18next-conv');
+const UserError = require('../../errors/usererror');
 
 /**
  * This class parses translations from a local .PO file. The i18next-conv
@@ -31,16 +32,14 @@ class LocalFileParser {
    *                            i18next format.
   */
   async fetch(locale, translationFilePath) {
-    const fileName = translationFilePath || `${locale}.po`;
-    const translationFile = path.join(this._translationsDir, fileName);
-
-    if (existsSync(translationFile)) {
-      const localeTranslations =
-        gettextToI18next(locale, readFileSync(translationFile), this._options);
-      return localeTranslations.then(data => JSON.parse(data));
+    const translationFile = path.join(this._translationsDir, translationFilePath);
+    if (!existsSync(translationFile)) {
+      throw new UserError(`Cannot find translation file for '${locale}' at '${translationFilePath}'`);
     }
 
-    return {};
+    const localeTranslations =
+      gettextToI18next(locale, readFileSync(translationFile), this._options);
+    return localeTranslations.then(data => JSON.parse(data));
   }
 }
 module.exports = LocalFileParser;

--- a/src/i18n/translationfetchers/localfileparser.js
+++ b/src/i18n/translationfetchers/localfileparser.js
@@ -32,9 +32,10 @@ class LocalFileParser {
    *                            i18next format.
   */
   async fetch(locale, translationFilePath) {
-    const translationFile = path.join(this._translationsDir, translationFilePath);
+    const fileName = translationFilePath || `${locale}.po`;
+    const translationFile = path.join(this._translationsDir, fileName);
     if (!existsSync(translationFile)) {
-      throw new UserError(`Cannot find translation file for '${locale}' at '${translationFilePath}'`);
+      throw new UserError(`Cannot find translation file for '${locale}' at '${translationFile}'`);
     }
 
     const localeTranslations =


### PR DESCRIPTION
J=SLAP-615
TEST=manual

1 - Test with a single-locale site (a site without a locale_config.json). Confirm that `jambo build` succeeds and output files look normal. 

2 - Test with a multi-locale site with out any translation files. 

For the locales in the locale_config without a "translationFile" entry, the default [locale].po fileName is used. If that file is not present, a UserError thrown, e.g.:
```
Cannot find translation file for 'es' at 'translations/es.po'
UserError: Cannot find translation file for 'es' at 'translations/es.po'
    at LocalFileParser.fetch (/Users/agrow/repo/jamboree/src/i18n/translationfetchers/localfileparser.js:38:13)
    at exports.SitesGenerator._extractTranslations (/Users/agrow/repo/jamboree/src/commands/build/sitesgenerator.js:314:10)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async exports.SitesGenerator.generate (/Users/agrow/repo/jamboree/src/commands/build/sitesgenerator.js:123:9)
```
Also verify that when there is a "translationFile", specified but the file at that path does not exist, a UserError is thrown. Manually inspect output files and check multi-lang cards to ensure that the same-language translation preprocessing (e.g. interpolation) is applied.