### PR TITLE
Add additional linting rules and ensure codebase compliance.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,13 @@
     "rules": {
         "quotes": ["error", "single"],
         "space-before-function-paren": ["error", {
-            "named": "never"
+            "named": "never",
+            "anonymous": "never"
+        }],
+        "quote-props": ["error", "as-needed"],
+        "max-len": ["error", { 
+            "code": 90,
+            "ignorePattern": "^const\\s.+=\\s*require\\s*\\("
         }]
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "eslint . && jest"
   },
   "repository": {
     "type": "git",

--- a/src/cli.js
+++ b/src/cli.js
@@ -54,7 +54,12 @@ const options = yargs
         .option('theme', { description: 'theme to import', demandOption: true })
         .option(
           'addAsSubmodule', 
-          { description: 'import the theme as a submodule', default: true, type: 'boolean' });
+          { 
+            description: 'import the theme as a submodule', 
+            default: true, 
+            type: 'boolean' 
+          }
+        );
     },
     argv => {
       try {
@@ -71,7 +76,9 @@ const options = yargs
     'override a path within the theme',
     yargs => {
       return yargs
-        .option('path', { description: 'path in the theme to override', demandOption: true })
+        .option(
+          'path', 
+          { description: 'path in the theme to override', demandOption: true })
     },
     argv => {
       try {
@@ -99,7 +106,7 @@ const options = yargs
       try {
         pageScaffolder.create(pageConfiguration);
       } catch (err) {
-        exitWithError(new UserError("Failed to add page", err.stack));
+        exitWithError(new UserError('Failed to add page', err.stack));
       }
     })
   .command(
@@ -108,7 +115,9 @@ const options = yargs
     yargs => {
       return yargs
         .option('name', { description: 'name for the new card', demandOption: true })
-        .option('templateCardFolder', { description: 'folder of card to fork', demandOption: true });
+        .option(
+          'templateCardFolder', 
+          { description: 'folder of card to fork', demandOption: true });
     },
     argv => {
       try {
@@ -123,7 +132,9 @@ const options = yargs
     'add a new direct answer card for use in the site',
     yargs => {
       return yargs
-        .option('name', { description: 'name for the new direct answer card', demandOption: true })
+        .option(
+          'name', 
+          { description: 'name for the new direct answer card', demandOption: true })
         .option(
           'templateCardFolder',
           { description: 'folder of direct answer card to fork', demandOption: true });
@@ -153,7 +164,7 @@ const options = yargs
         if (isCustomError(err)) {
           exitWithError(err);
         }
-        exitWithError(new UserError("Failed to generate the site", err.stack));
+        exitWithError(new UserError('Failed to generate the site', err.stack));
       }
       
     })
@@ -163,7 +174,7 @@ const options = yargs
     yargs => {
       return yargs
         .option('disableScript', {
-            description: 'disable automatic execution ./upgrade.js after the upgrade is done',
+            description: 'disable execution of ./upgrade.js after the upgrade is done',
             type: 'boolean'
           })
         .option('isLegacy', {

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -2,7 +2,7 @@ const fs = require('file-system');
 const hbs = require('handlebars');
 const path = require('path');
 const { parse } = require('comment-json');
-const babel = require("@babel/core");
+const babel = require('@babel/core');
 const globToRegExp = require('glob-to-regexp');
 const _ = require('lodash');
 
@@ -42,14 +42,16 @@ exports.SitesGenerator = class {
         try {
           pagesConfig[pageId] = parse(fs.readFileSync(path, 'utf8'), null, true);
         } catch (err) {
-          throw new UserError('JSON SyntaxError: could not parse file ' + path, err.stack);
+          throw new UserError(
+            'JSON SyntaxError: could not parse file ' + path, err.stack);
         }
       }
     })
 
     const globalConfigName = 'global_config';
     if (!pagesConfig[globalConfigName]) {
-      throw new UserError(`Cannot find ${globalConfigName} file in '` + config.dirs.config + '/\' directory.');
+      throw new UserError(
+        `Cannot find ${globalConfigName} file in '${config.dirs.config}' directory.`);
     }
 
     // Register needed Handlebars helpers.
@@ -57,7 +59,7 @@ exports.SitesGenerator = class {
     try {
       this._registerHelpers();
     } catch (err) {
-      throw new SystemError("Failed to register jambo handlebars helpers", err.stack);
+      throw new SystemError('Failed to register jambo handlebars helpers', err.stack);
     }
 
     // Register theme partials.
@@ -66,14 +68,14 @@ exports.SitesGenerator = class {
     try {
       defaultTheme && this._registerThemePartials(defaultTheme, config.dirs.themes);
     } catch (err) {
-      throw new SystemError("Failed to register theme partials", err.stack);
+      throw new SystemError('Failed to register theme partials', err.stack);
     }
 
     // Register all custom partials.
     try {
       this._registerCustomPartials(config.dirs.partials);
     } catch (err) {
-      throw new UserError("Failed to register custom partials", err.stack);
+      throw new UserError('Failed to register custom partials', err.stack);
     }
 
     const verticalConfigs = Object.keys(pagesConfig).reduce((object, key) => {
@@ -85,7 +87,10 @@ exports.SitesGenerator = class {
 
     // Clear the output directory but keep preserved files before writing new files
     console.log('Cleaning output directory');
-    if (fs.existsSync(config.dirs.output) && !(this._isPreserved(config.dirs.output, config.dirs.preservedFiles))) {
+    const shouldCleanOutput = 
+      fs.existsSync(config.dirs.output) && 
+      !(this._isPreserved(config.dirs.output, config.dirs.preservedFiles));
+    if (shouldCleanOutput) {
       this._clearDirectory(config.dirs.output, config.dirs.preservedFiles);
     }
 
@@ -126,7 +131,8 @@ exports.SitesGenerator = class {
           template = hbs.compile(fs.readFileSync(path).toString());
         }
 
-        const outputFileName = this._stripExtension(relative).substring(config.dirs.pages);
+        const outputFileName = 
+          this._stripExtension(relative).substring(config.dirs.pages);
         const result = template(pageConfig);
         const outputPath =
           `${config.dirs.output}/${outputFileName}`;
@@ -171,7 +177,8 @@ exports.SitesGenerator = class {
   }
 
   /**
-   * Checks whether a file or directory matches a glob wildcard in list of preserved files.
+   * Checks whether a file or directory matches a glob wildcard in list of
+   * preserved files.
    *
    * @param {string} path The path of a directory or file.
    * @param {Array} preservedFiles List of glob wildcards of preserved files.
@@ -226,10 +233,10 @@ exports.SitesGenerator = class {
   }
 
   _stripExtension(fn) {
-    if (fn.indexOf(".") === -1) {
+    if (fn.indexOf('.') === -1) {
       return fn;
     }
-    return fn.substring(0, fn.lastIndexOf("."));
+    return fn.substring(0, fn.lastIndexOf('.'));
   }
 
   /**
@@ -284,11 +291,11 @@ exports.SitesGenerator = class {
       return JSON.stringify(context || {});
     });
 
-    hbs.registerHelper('ifeq', function (arg1, arg2, options) {
+    hbs.registerHelper('ifeq', function(arg1, arg2, options) {
       return (arg1 === arg2) ? options.fn(this) : options.inverse(this);
     });
 
-    hbs.registerHelper('read', function (fileName) {
+    hbs.registerHelper('read', function(fileName) {
       return hbs.partials[fileName];
     });
 
@@ -312,7 +319,7 @@ exports.SitesGenerator = class {
         }).code;
     })
 
-    hbs.registerHelper('partialPattern', function (cardPath, opt) {
+    hbs.registerHelper('partialPattern', function(cardPath, opt) {
       let result = '';
       Object.keys(hbs.partials)
         .filter(key => key.match(new RegExp(cardPath)))
@@ -324,13 +331,13 @@ exports.SitesGenerator = class {
     /**
      * Performs a deep merge of the given objects.
      */
-    hbs.registerHelper('deepMerge', function (...args) {
+    hbs.registerHelper('deepMerge', function(...args) {
       return _.merge({}, ...args.slice(0, args.length - 1));
     });
   }
 
   _calculateRelativePath(filePath) {
-    return path.relative(path.dirname(filePath), "");
+    return path.relative(path.dirname(filePath), '');
   }
 
   _isValidFile(fileName) {

--- a/src/commands/card/cardcreator.js
+++ b/src/commands/card/cardcreator.js
@@ -43,10 +43,11 @@ exports.CardCreator = class {
     }
   }
 
-  _renameCardComponent (customCardName, cardFolder) {
+  _renameCardComponent(customCardName, cardFolder) {
     const cardComponentPath = path.resolve(cardFolder, 'component.js');
     const originalComponent = fs.readFileSync(cardComponentPath).toString();
-    const renamedComponent = this._getRenamedCardComponent(originalComponent, customCardName);
+    const renamedComponent = 
+      this._getRenamedCardComponent(originalComponent, customCardName);
     fs.writeFileSync(cardComponentPath, renamedComponent);
   }
 
@@ -57,7 +58,7 @@ exports.CardCreator = class {
    * @param {string} customCardName
    * @returns {string}
    */
-  _getRenamedCardComponent (content, customCardName) {
+  _getRenamedCardComponent(content, customCardName) {
     const cardNameSuffix = 'CardComponent';
     const registerComponentTypeRegex = /\([\w_]+CardComponent\)/g;
     const regexArray = [ ...content.matchAll(/componentName\s*=\s*'(.*)'/g) ];

--- a/src/commands/directanswercard/directanswercardcreator.js
+++ b/src/commands/directanswercard/directanswercardcreator.js
@@ -10,8 +10,9 @@ exports.DirectAnswerCardCreator = class {
   }
 
   /**
-   * Creates a new, custom direct answer card in the top-level 'directanswercards' directory.
-   * This card will be based off either an existing custom card or one supplied by the Theme.
+   * Creates a new, custom direct answer card in the top-level 'directanswercards'
+   * directory. This card will be based off either an existing custom card or one
+   * supplied by the Theme.
    * 
    * @param {string} cardName           The name of the new card. A folder with a
    *                                    lowercased version of this name will be
@@ -42,21 +43,24 @@ exports.DirectAnswerCardCreator = class {
     }
   }
 
-  _renameCardComponent (customCardName, cardFolder) {
+  _renameCardComponent(customCardName, cardFolder) {
     const cardComponentPath = path.resolve(cardFolder, 'component.js');
     const originalComponent = fs.readFileSync(cardComponentPath).toString();
-    const renamedComponent = this._getRenamedCardComponent(originalComponent, customCardName);
+    const renamedComponent = 
+      this._getRenamedCardComponent(originalComponent, customCardName);
     fs.writeFileSync(cardComponentPath, renamedComponent);
   }
 
   /**
-   * Returns the internal contents for a newly-created direct answer card, updated based on
-   * the given customCardName. (e.g. allfields_standardComponent -> [CustomName]Component)
+   * Returns the internal contents for a newly-created direct answer card, updated
+   * based on the given customCardName. (e.g. allfields_standardComponent ->
+   * [CustomName]Component)
+   * 
    * @param {string} content
    * @param {string} customCardName
    * @returns {string}
    */
-  _getRenamedCardComponent (content, customCardName) {
+  _getRenamedCardComponent(content, customCardName) {
     const cardNameSuffix = 'Component';
     const registerComponentTypeRegex = /\([\w_]+Component\)/g;
     const regexArray = [ ...content.matchAll(/componentName\s*=\s*'(.*)'/g) ];
@@ -73,7 +77,8 @@ exports.DirectAnswerCardCreator = class {
       .replace(registerComponentTypeRegex, `(${customComponentClassName})`)
       .replace(new RegExp(originalComponentName, 'g'), customCardName)
       .replace(
-        /directanswercards[/_](.*)[/_]template/g, `directanswercards/${customCardName}/template`);
+        /directanswercards[/_](.*)[/_]template/g, 
+        `directanswercards/${customCardName}/template`);
   }
 
   /**

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -18,14 +18,14 @@ exports.ThemeImporter = class {
   }
 
   /**
-   * Imports the requested theme into Jambo's Themes directory. Note that the theme can either
-   * be cloned directly into this directory or added there as a submodule.
+   * Imports the requested theme into Jambo's Themes directory. Note that the theme can
+   * either be cloned directly into this directory or added there as a submodule.
    *
    * @param {string} themeName The name of the theme
    * @param {boolean} addAsSubmodule If the theme should be imported as a submodule.
    * @returns {Promise<string>} If the addition of the submodule was successful, a Promise
-   *                            containing the new submodule's local path. If the addition failed,
-   *                            a Promise containing the error.
+   *                            containing the new submodule's local path. If the addition
+   *                            failed, a Promise containing the error.
    */
   async import(themeName, addAsSubmodule) {
     if (!this.config) {
@@ -77,9 +77,15 @@ exports.ThemeImporter = class {
         }
       };
 
-      copyFileIfExists(`${staticAssetsPath}/scss/answers.scss`, `${siteStaticDir}/scss/answers.scss`);
-      copyFileIfExists(`${staticAssetsPath}/scss/answers-variables.scss`, `${siteStaticDir}/scss/answers-variables.scss`);
-      copyFileIfExists(`${staticAssetsPath}/scss/fonts.scss`, `${siteStaticDir}/scss/fonts.scss`);
+      copyFileIfExists(
+        `${staticAssetsPath}/scss/answers.scss`, 
+        `${siteStaticDir}/scss/answers.scss`);
+      copyFileIfExists(
+        `${staticAssetsPath}/scss/answers-variables.scss`, 
+        `${siteStaticDir}/scss/answers-variables.scss`);
+      copyFileIfExists(
+        `${staticAssetsPath}/scss/fonts.scss`, 
+        `${siteStaticDir}/scss/fonts.scss`);
 
       copyFileIfExists(`${staticAssetsPath}/Gruntfile.js`, 'Gruntfile.js');
       copyFileIfExists(`${staticAssetsPath}/webpack-config.js`, 'webpack-config.js');

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -6,9 +6,9 @@ const SystemError = require('../../errors/systemerror');
 const git = simpleGit();
 
 /**
- * RepositorySettings contains the information needed by Jambo to scaffold a new site repository.
- * Currently, these settings include an optional theme and whether or not the theme should be
- * imported as a submodule.
+ * RepositorySettings contains the information needed by Jambo to scaffold a new site
+ * repository. Currently, these settings include an optional theme and whether or not
+ * the theme should be imported as a submodule.
  */
 exports.RepositorySettings = class {
   constructor({ theme, addThemeAsSubmodule }) {
@@ -27,9 +27,10 @@ exports.RepositorySettings = class {
 
 exports.RepositoryScaffolder = class {
   /**
-   * This method scaffolds a new site repository based on the provided RepositorySettings object.
-   * The repository will include all directories needed by Jambo as well as the Git infrastructure
-   * needed for source control. If a theme is specified, that will also be imported.
+   * This method scaffolds a new site repository based on the provided RepositorySettings
+   * object. The repository will include all directories needed by Jambo as well as the 
+   * Git infrastructure needed for source control. If a theme is specified, that will 
+   * also be imported.
    *
    * @param {RepositoryScaffolder} repositorySettings The settings for the new repository.
    */
@@ -65,8 +66,8 @@ exports.RepositoryScaffolder = class {
   }
 
   /**
-   * Create the top-level Jambo config which indicates the paths to the various directories
-   * needed by Jambo.
+   * Create the top-level Jambo config which indicates the paths to the various
+   * directories needed by Jambo.
    *
    * @returns {Object} The constructed config.
    */

--- a/src/commands/override/themeshadower.js
+++ b/src/commands/override/themeshadower.js
@@ -4,9 +4,9 @@ const { addToPartials } = require('../../utils/jamboconfigutils');
 const UserError = require('../../errors/usererror');
 
 /**
- * The ShadowConfiguration specifies what file(s) should be shadowed for a particular theme.
- * The configuration consists of a theme and a path within the theme. The path indicates which
- * file(s) in the Theme should have local shadows.
+ * The ShadowConfiguration specifies what file(s) should be shadowed for a particular
+ * theme. The configuration consists of a theme and a path within the theme. The path 
+ * indicates which file(s) in the Theme should have local shadows.
  */
 exports.ShadowConfiguration = class {
   constructor({ theme, path }) {
@@ -28,9 +28,10 @@ exports.ShadowConfiguration = class {
 };
 
 /**
- * The ThemeShadower takes a ShadowConfiguration and produces the necessary shadows. These shadows
- * are copies of the original files and will take precedence over them when registering partials.
- * This allows the convenient override of bits and pieces of a theme.
+ * The ThemeShadower takes a ShadowConfiguration and produces the necessary shadows. 
+ * These shadows are copies of the original files and will take precedence over them 
+ * when registering partials. This allows the convenient override of bits and 
+ * pieces of a theme.
  */
 exports.ThemeShadower = class {
   constructor(jamboConfig) {

--- a/src/commands/page/add/pagescaffolder.js
+++ b/src/commands/page/add/pagescaffolder.js
@@ -46,7 +46,8 @@ exports.PageScaffolder = class {
 
     let configContents = layout ? { layout } : {};
     if (theme && template) {
-      const rootTemplatePath = `${this.config.dirs.themes}/${theme}/templates/${template}`;
+      const rootTemplatePath = 
+        `${this.config.dirs.themes}/${theme}/templates/${template}`;
       fs.copyFileSync(`${rootTemplatePath}/page.html.hbs`, htmlFilePath);
 
       configContents = assign(

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -11,9 +11,9 @@ const UserError = require('../../errors/systemerror');
 const git = simpleGit();
 
 /**
- * ThemeUpgrader is responsible for upgrading the current defaultTheme to the latest version.
- * It first detects whether the theme was imported as a submodule or raw files, then handles
- * the upgrade accordingly.
+ * ThemeUpgrader is responsible for upgrading the current defaultTheme to the latest 
+ * version. It first detects whether the theme was imported as a submodule or raw files,
+ * then handles the upgrade accordingly.
  */
 exports.ThemeUpgrader = class {
   constructor(jamboConfig) {
@@ -31,7 +31,8 @@ exports.ThemeUpgrader = class {
   async upgrade(themeName, disableScript, isLegacy) {
     const themePath = path.join(this._themesDir, themeName);
     if (!fs.existsSync(themePath)) {
-      throw new UserError(`Theme "${themeName}" not found within the "${this._themesDir}" folder`);
+      throw new UserError(
+        `Theme "${themeName}" not found within the "${this._themesDir}" folder`);
     }
     await this._isGitSubmodule(themePath)
       ? await this._upgradeSubmodule(themePath)
@@ -56,19 +57,20 @@ exports.ThemeUpgrader = class {
    * @param {string} upgradeScriptPath
    * @param {boolean} isLegacy
    */
-  _executePostUpgradeScript (upgradeScriptPath, isLegacy) {
+  _executePostUpgradeScript(upgradeScriptPath, isLegacy) {
     const customCommand = new CustomCommand({
       executable: `./${upgradeScriptPath}`
     });
     if (isLegacy) {
       customCommand.addArgs(['--isLegacy'])
     }
-    const { stdout, stderr } = new CustomCommandExecuter(this.config).execute(customCommand);
+    const { stdout, stderr } = 
+      new CustomCommandExecuter(this.config).execute(customCommand);
     const stdoutString = stdout.toString().trim();
     const stderrString = stderr.toString().trim();
     stdoutString && console.log(stdoutString);
     if (stderrString) {
-      throw new SystemError("Error executing theme post upgrade script", stderrString);
+      throw new SystemError('Error executing theme post upgrade script', stderrString);
     }
   } 
 

--- a/src/errors/systemerror.js
+++ b/src/errors/systemerror.js
@@ -3,7 +3,7 @@
  * not likely to be caused by users of jambo
  */
 class SystemError extends Error {  
-  constructor (message, stack) {
+  constructor(message, stack) {
     super(message);
 
     if (stack) {

--- a/src/errors/usererror.js
+++ b/src/errors/usererror.js
@@ -2,7 +2,7 @@
  * Represents errors that we may reasonably expect a user to make
  */
 class UserError extends Error {  
-  constructor (message, stack) {
+  constructor(message, stack) {
     super(message);
 
     if (stack) {

--- a/src/utils/jamboconfigutils.js
+++ b/src/utils/jamboconfigutils.js
@@ -29,7 +29,7 @@ parseJamboConfig = function() {
     );
     return config;
   } catch (err) {
-    throw new UserError("Error parsing jambo.json", err.stack);
+    throw new UserError('Error parsing jambo.json', err.stack);
   }
   
 }

--- a/tests/utils/envvarparser.js
+++ b/tests/utils/envvarparser.js
@@ -2,13 +2,14 @@ const { EnvironmentVariableParser } = require('../../src/utils/envvarparser');
 
 describe('EnvironmentVariableParser works correctly', () => {
     const var1 = {
-        'foo': {
-            'bar': 'a string'
+        foo: {
+            bar: 'a string'
         },
-        'baz': 'a string'
+        baz: 'a string'
     };
     const var2 = 'a string';
-    const envVarsParser = new EnvironmentVariableParser( { var2, var1: JSON.stringify(var1) });
+    const envVarsParser = 
+        new EnvironmentVariableParser( { var2, var1: JSON.stringify(var1) });
 
     it('deserializes environment variables correctly', () => {
         expect(envVarsParser.parse(['var1'])).toEqual({ var1, var2 });


### PR DESCRIPTION
This PR adds a couple of new rules to the ESLint config:

- 'max-len' enforces a line length of 90 characters (I've excluded 'require'
  statements).
- 'quote-props' ensures we don't wrap object keys in quotes unless
  absolutely necessary.

I have also included the changes needed to make the code compliant with all
of the ESLint rules. You can automatically fix some linting errors with
'eslint -fix'. Lastly, linting is now run as part of 'npm run test'.

TEST=auto

Made sure 'npm run test' did not report any issues.