### PR TITLE
Allow 'apiKey' only in the 'global_config' file.

### DIFF
--- a/src/commands/build/globalconfiglocalizer.js
+++ b/src/commands/build/globalconfiglocalizer.js
@@ -20,13 +20,10 @@ module.exports = class GlobalConfigLocalizer {
   localize(globalConfig, locale) {
     const experienceKey = this._localizationConfig.getExperienceKey(locale)
       || globalConfig.getExperienceKey();
-    const apiKey = this._localizationConfig.getApiKey(locale)
-      || globalConfig.getApiKey();
 
     return new GlobalConfig({
       ...globalConfig.getConfig(),
       experienceKey: experienceKey,
-      apiKey: apiKey,
       ...locale && { locale: locale }
     });
   }

--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -18,7 +18,6 @@ module.exports = class LocalizationConfig {
      * {
      *   'locale': {
      *     experienceKey: ''   // String
-     *     apiKey: ''          // String
      *     params: {}          // Object
      *     urlOverride: ''     // String
      *     translationFile: '' // String
@@ -54,10 +53,6 @@ module.exports = class LocalizationConfig {
 
   getLocales () {
     return Object.keys(this._localeToConfig);
-  }
-
-  getApiKey (locale) {
-    return this._getConfigForLocale(locale).apiKey;
   }
 
   getExperienceKey (locale) {

--- a/tests/commands/build/globalconfiglocalizer.js
+++ b/tests/commands/build/globalconfiglocalizer.js
@@ -27,7 +27,6 @@ describe('GlobalConfigLocalizer generates expected localized global configs', ()
     default: 'en',
     localeConfig: {
       en: {
-        apiKey: 'en_apiKeyFromLocalizationConfig',
         experienceKey: 'en_experienceKeyFromLocalizationConfig'
       },
       fr: {}
@@ -40,7 +39,7 @@ describe('GlobalConfigLocalizer generates expected localized global configs', ()
     expect(globalConfigLocalizer.localize(globalConfig, 'en')).toEqual(
       new GlobalConfig({
         locale: 'en',
-        apiKey: 'en_apiKeyFromLocalizationConfig',
+        apiKey: 'apiKeyFromGlobalConfig',
         experienceKey: 'en_experienceKeyFromLocalizationConfig'
       }));
 

--- a/tests/models/localizationconfig.js
+++ b/tests/models/localizationconfig.js
@@ -15,7 +15,7 @@ describe('LocalizationConfig is properly built from raw object', () => {
           fallback: ['es']
         },
         es: {
-          apiKey: 'en should not fallback to this'
+          experienceKey: 'en should not fallback to this'
         }
       }
     };
@@ -23,8 +23,6 @@ describe('LocalizationConfig is properly built from raw object', () => {
     const locale = 'en';
 
     expect(localizationConfig.getLocales()).toEqual(['en', 'es']);
-    expect(localizationConfig.getApiKey(locale))
-      .toEqual(rawLocalizationConfig.localeConfig[locale].apiKey);
     expect(localizationConfig.getExperienceKey(locale))
       .toEqual(rawLocalizationConfig.localeConfig[locale].experienceKey);
     expect(localizationConfig.getParams(locale))


### PR DESCRIPTION
Previously, we assumed that each locale in the 'locale_config' would need
the ability to specify a localized 'apiKey'. This assumption was not correct.
The 'apiKey' is the same for all experiences in a business. There will be
different experiences per locale, but the 'apiKey' is constant. Because it
is something that is business-specific, we will now only allow it in the
'global_config' file. Any 'apiKey' in 'locale_config' will be ignored.

J=SLAP-640
TEST=auto, manual

Fixed and ran unit tests. Created a site with English and French page sets.
Set the 'apiKey' only in the 'global_config' and saw it used for both locales.