### PR TITLE
Add comparison and boolean Handlebars helpers

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -261,6 +261,33 @@ exports.SitesGenerator = class {
       return (arg1 === arg2) ? options.fn(this) : options.inverse(this);
     });
 
+    hbs.registerHelper({
+      eq: function (v1, v2) {
+        return v1 === v2;
+      },
+      ne: function (v1, v2) {
+        return v1 !== v2;
+      },
+      lt: function (v1, v2) {
+        return v1 < v2;
+      },
+      gt: function (v1, v2) {
+        return v1 > v2;
+      },
+      lte: function (v1, v2) {
+        return v1 <= v2;
+      },
+      gte: function (v1, v2) {
+        return v1 >= v2;
+      },
+      and: function () {
+        return Array.prototype.slice.call(arguments).every(Boolean);
+      },
+      or: function () {
+        return Array.prototype.slice.call(arguments, 0, -1).some(Boolean);
+      }
+    });
+
     hbs.registerHelper('read', function (fileName) {
       return hbs.partials[fileName];
     });


### PR DESCRIPTION
These are from the Answers SDK. In some cases, we need to compare two things and these helpers make doing that much more convenient. Example usages of these include:
```hbs 
{{#if (eq value 'expectedValue')}}...{{/if}}
{{#unless (gt value 'maxValue')}}...{{/if}}
```

There are several expressions in the theme that could use these; but the impetus for this change is adding the locale prefix to the SDK bundle for locales that are not English, ([PR here](https://github.com/yext/answers-hitchhiker-theme/pull/317)) e.g. 
```hbs
{{#unless (eq sdkBundleLocale 'en')}}{{sdkBundleLocale}}-{{/unless}}answerstemplates.compiled.min.js
```

TEST=manual
J=SLAP-633

Run `jambo build` using each of helpers in a test .hbs file. Inspect output .html files and verify that the logic is correct.