### PR TITLE
Add an SDK bundle locale override option to 'locale_config'

### DIFF
--- a/src/commands/build/pagesetsbuilder.js
+++ b/src/commands/build/pagesetsbuilder.js
@@ -55,11 +55,16 @@ module.exports = class PageSetsBuilder {
       const localizedGlobalConfig = new GlobalConfigLocalizer(this._localizationConfig)
         .localize(this._globalConfig, locale);
 
+      const sdkBundleLocale = this._localizationConfig.getSdkBundleLocaleOverride(locale)
+        || locale
+        || 'en';
+
       pageSets.push(new PageSet({
         locale: locale,
         pages: this._buildPages(pageConfigs, templates),
         globalConfig: localizedGlobalConfig,
-        params: this._localizationConfig.getParams(locale)
+        params: this._localizationConfig.getParams(locale),
+        sdkBundleLocale: sdkBundleLocale
       }));
     }
     return pageSets;

--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -43,13 +43,10 @@ module.exports = class PageWriter {
       }
 
       console.log(`Writing output file for the '${page.getName()}' page`);
-      const templateArguments = this._buildArgsForTemplate({
-        pageConfig: page.getConfig(),
-        relativePath: this._calculateRelativePath(page.getOutputPath()),
-        params: pageSet.getParams(),
-        globalConfig: pageSet.getGlobalConfig().getConfig(),
-        pageNameToConfig: pageSet.getPageNameToConfig(),
-      });
+      const templateArguments = this._buildArgsForTemplate(
+        page.getConfig(),
+        this._calculateRelativePath(page.getOutputPath()),
+        pageSet);
 
       const template = hbs.compile(page.getTemplateContents());
       const outputHTML = template(templateArguments);
@@ -66,20 +63,19 @@ module.exports = class PageWriter {
    *
    * @param {Object} pageConfig the configuration for the current page
    * @param {String} relativePath
-   * @param {String} params
-   * @param {Object} globalConfig
-   * @param {Object} pageNameToConfig
+   * @param {PageSet} pageSet
    * @returns {Object}
    */
-  _buildArgsForTemplate ({ pageConfig, relativePath, params, globalConfig, pageNameToConfig }) {
+  _buildArgsForTemplate (pageConfig, relativePath, pageSet) {
     return Object.assign(
       {},
       pageConfig,
       {
-        verticalConfigs: pageNameToConfig,
-        global_config: globalConfig,
+        verticalConfigs: pageSet.getPageNameToConfig(),
+        global_config: pageSet.getGlobalConfig().getConfig(),
+        params: pageSet.getParams(),
+        sdkBundleLocale: pageSet.getSdkBundleLocale(),
         relativePath: relativePath,
-        params: params,
         env: this._env
      }
     );

--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -68,6 +68,10 @@ module.exports = class LocalizationConfig {
     return this._getConfigForLocale(locale).params || {};
   }
 
+  getSdkBundleLocaleOverride (locale) {
+    return this._getConfigForLocale(locale).sdkBundleLocaleOverride;
+  }
+
   getTranslationFile (locale) {
     return this._getConfigForLocale(locale).translationFile;
   }

--- a/src/models/pageset.js
+++ b/src/models/pageset.js
@@ -13,8 +13,9 @@ module.exports = class PageSet {
    * @param {Array<Page>} pages
    * @param {GlobalConfig} globalConfig
    * @param {Object} params
+   * @param {string} sdkBundleLocale
    */
-  constructor({ locale, pages, globalConfig, params }) {
+  constructor({ locale, pages, globalConfig, params, sdkBundleLocale }) {
     /**
      * @type {String}
      */
@@ -44,6 +45,11 @@ module.exports = class PageSet {
      * @type {Object}
      */
     this.params = params || {};
+
+    /**
+     * @type {string}
+     */
+    this.sdkBundleLocale = sdkBundleLocale;
   }
 
   /**
@@ -71,6 +77,15 @@ module.exports = class PageSet {
    */
   getParams () {
     return this.params;
+  }
+
+  /*
+   * Returns the sdkBundleLocale
+   *
+   * @returns {string} sdkBundleLocale
+   */
+  getSdkBundleLocale () {
+    return this.sdkBundleLocale;
   }
 
   /**

--- a/tests/commands/build/pagewriter.js
+++ b/tests/commands/build/pagewriter.js
@@ -1,8 +1,8 @@
-const PageWriter = require('../../../src/commands/build/pagewriter');
-const PageSet = require('../../../src/models/pageset');
+const GlobalConfig = require('../../../src/models/globalconfig');
 const Page = require('../../../src/models/page');
 const PageConfig = require('../../../src/models/pageconfig');
-const GlobalConfig = require('../../../src/models/globalconfig');
+const PageSet = require('../../../src/models/pageset');
+const PageWriter = require('../../../src/commands/build/pagewriter');
 
 describe('PageWriter builds the object passed to the Handlebars Templates properly', () => {
   it('builds args as expected when all are present', () => {

--- a/tests/commands/build/pagewriter.js
+++ b/tests/commands/build/pagewriter.js
@@ -1,49 +1,62 @@
 const PageWriter = require('../../../src/commands/build/pagewriter');
+const PageSet = require('../../../src/models/pageset');
+const Page = require('../../../src/models/page');
+const PageConfig = require('../../../src/models/pageconfig');
+const GlobalConfig = require('../../../src/models/globalconfig');
 
 describe('PageWriter builds the object passed to the Handlebars Templates properly', () => {
   it('builds args as expected when all are present', () => {
     const env = {
       envVar: 'envVar',
     };
+    const path = 'relativePath';
     const pageConfig = {
       pageConfigParam: 'param',
     };
-    const path = 'relativePath';
+    const sdkBundleLocale = 'en';
     const params = {
       param: 'test'
     };
     const globalConfig = {
       apiKey: 'apiKey'
     };
-    const pageNameToConfig = {
-      page1: {
-        config: {
-          prop: 'example'
-        }
-      },
-      page2: {
-        config: {
-          prop: 'example2'
-        }
-      }
-    };
+
+    const pageSet = new PageSet({
+      locale: 'en-US',
+      pages: [
+        new Page({
+          pageConfig: new PageConfig({
+            pageName: 'page1',
+            rawConfig: {
+              prop: 'example'
+            }
+          })
+        }),
+        new Page({
+          pageConfig: new PageConfig({
+            pageName: 'page2',
+            rawConfig: {
+              prop: 'example2'
+            }
+          })
+        })
+      ],
+      globalConfig: new GlobalConfig(globalConfig),
+      params: params,
+      sdkBundleLocale: sdkBundleLocale
+    });
 
     const args = new PageWriter({
       env: env
-    })._buildArgsForTemplate({
-      pageConfig: pageConfig,
-      params: params,
-      relativePath: path,
-      globalConfig: globalConfig,
-      pageNameToConfig: pageNameToConfig
-    });
+    })._buildArgsForTemplate(pageConfig, path, pageSet);
 
     expect(args).toEqual({
       ...pageConfig,
-      verticalConfigs: pageNameToConfig,
+      verticalConfigs: pageSet.getPageNameToConfig(),
       global_config: globalConfig,
-      relativePath: path,
       params: params,
+      sdkBundleLocale: sdkBundleLocale,
+      relativePath: path,
       env: env
     });
   });

--- a/tests/models/generateddata.js
+++ b/tests/models/generateddata.js
@@ -94,7 +94,8 @@ describe('GeneratedData is correctly formed using with static from', () => {
           }),
         ],
         globalConfig: globalConfig,
-        params: {}
+        params: {},
+        sdkBundleLocale: 'en'
       })
     ]);
     expect(generatedData.getLocaleFallbacks(locale)).toEqual([]);
@@ -217,7 +218,8 @@ describe('GeneratedData is correctly formed using with static from', () => {
           ...globalConfig.getConfig(),
           locale: 'en'
         }),
-        params: {}
+        params: {},
+        sdkBundleLocale: 'en'
       }),
       new PageSet({
         locale: 'es',
@@ -266,7 +268,8 @@ describe('GeneratedData is correctly formed using with static from', () => {
           ...globalConfig.getConfig(),
           locale: 'es'
         }),
-        params: {}
+        params: {},
+        sdkBundleLocale: 'es'
       }),
       new PageSet({
         locale: 'fr',
@@ -289,7 +292,8 @@ describe('GeneratedData is correctly formed using with static from', () => {
           ...globalConfig.getConfig(),
           locale: 'fr'
         }),
-        params: {}
+        params: {},
+        sdkBundleLocale: 'fr'
       }),
     ]);
 


### PR DESCRIPTION
Add support for an "sdkBundleLocaleOverride" parameter in the individual locale objects in the locale_config. Jambo then adds a parameter "sdkBundleLocale" to the object for the Handlebars templates, which is the version of the SDK bundle that should be used. 

Right now this PR introduces fallback logic that could arguably belong in the theme -- the `sdkBundleLocale = sdkBundleLocaleOverride || locale || 'en';` We can absolutely move it in there, but it's just so messy to do that kind of fallback logic in-line in Handlebars I put it here for now. As a visual, this is how the theme call looks with the existing Jambo code:
```hbs
<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#unless (eq sdkBundleLocale 'en')}}{{sdkBundleLocale}}-{{/unless}}answerstemplates.compiled.min.js"></script>
```
And if we moved the logic to the theme, this is how it would look: 
```hbs
<script src="https://assets.sitescdn.net/answers/v{{global_config.sdkVersion}}/{{#if sdkBundleLocale}}{{#unless (eq sdkBundleLocale 'en')}}{{sdkBundleLocale}}-{{/unless}}{{else if global_config.locale}}{{#unless (eq global_config.locale 'en')}}{{global_config.locale}}-{{/unless}}answerstemplates.compiled.min.js"></script>
```

TEST=manual
J=SLAP-633

Tested with the changes from PR #120 (https://github.com/yext/jambo/pull/120) and the changes in the theme here: https://github.com/yext/answers-hitchhiker-theme/pull/317. Viewed output .html files for English (no bundle prefix), Spanish (es bundle prefix), and French (Belgium), fr-be (used override here for 'fr') and verified output was as expected.