### PR TITLE
Rename output of transpilation calls

### DIFF
--- a/src/handlebars/handlebarspreprocessor.js
+++ b/src/handlebars/handlebarspreprocessor.js
@@ -89,15 +89,15 @@ class HandlebarsPreprocessor {
   }
 
   /**
-   * Constructs a call to the SDK's Javascript method for run-time translation.
-   * This call is constructed using the translation(s) for a phrase and any interpolation
-   * paramters.
+   * Constructs a call to the SDK's Javascript method for run-time translation
+   * processing. This call is constructed using the translation(s) for a phrase and any
+   * interpolation parameters.
    *
    * @param {Object|string} translatorResult The translation(s) for the phrase.
    * @param {Object<string, ?>} interpolationParams The needed interpolation parameters
    *                                                (including 'count').
    * @param {boolean} needsPluralization If pluralization is required when translating.
-   * @returns {string} The string-ified call to ANSWERS.translateJS.
+   * @returns {string} The string-ified call to ANSWERS.processTranslation.
    */
   _createRuntimeCallForJS(translatorResult, interpolationParams, needsPluralization) {
     let parsedParams = JSON.stringify(interpolationParams);
@@ -108,16 +108,16 @@ class HandlebarsPreprocessor {
     if (needsPluralization) {
       const count = interpolationParams.count;
       escapedTranslatorResult = this._escapeDoubleQuotes(escapedTranslatorResult);
-      return `ANSWERS.translateJS('${escapedTranslatorResult}', ${parsedParams}, ${count})`;
+      return `ANSWERS.processTranslation('${escapedTranslatorResult}', ${parsedParams}, ${count})`;
     }
 
-    return `ANSWERS.translateJS('${escapedTranslatorResult}', ${parsedParams})`;
+    return `ANSWERS.processTranslation('${escapedTranslatorResult}', ${parsedParams})`;
   }
 
   /**
-   * Constructs a call to the SDK's Handlebars helper for run-time translation.
-   * This call is constructed using the translation(s) for a phrase and any interpolation
-   * paramters.
+   * Constructs a call to the SDK's Javascript method for run-time translation
+   * processing. This call is constructed using the translation(s) for a phrase and any
+   * interpolation parameters.
    *
    * @param {Object|string} translatorResult The translation(s) for the phrase.
    * @param {Object<string, ?>} interpolationParams The needed interpolation parameters
@@ -126,7 +126,7 @@ class HandlebarsPreprocessor {
    * @param {boolean} shouldEscapeHTML If HTML should be escaped. If false, wrap the call
    *                                   in triple curly braces. If true, wrap in in double
    *                                   double curly braces.
-   * @returns {string} The string-ified call to the 'runtimeTranslation' helper.
+   * @returns {string} The string-ified call to the 'processTranslation' helper.
    */
   _createRuntimeCallForHBS(translatorResult, interpolationParams, needsPluralization, shouldEscapeHTML) {
     const paramsString = Object.entries(interpolationParams)
@@ -141,8 +141,8 @@ class HandlebarsPreprocessor {
     }
 
     return shouldEscapeHTML ?
-      `{{ runtimeTranslation phrase='${escapedTranslatorResult}' ${paramsString}}}` :
-      `{{{ runtimeTranslation phrase='${escapedTranslatorResult}' ${paramsString}}}}`
+      `{{ processTranslation phrase='${escapedTranslatorResult}' ${paramsString}}}` :
+      `{{{ processTranslation phrase='${escapedTranslatorResult}' ${paramsString}}}}`
   }
   
   /**

--- a/src/handlebars/handlebarspreprocessor.js
+++ b/src/handlebars/handlebarspreprocessor.js
@@ -115,7 +115,7 @@ class HandlebarsPreprocessor {
   }
 
   /**
-   * Constructs a call to the SDK's Javascript method for run-time translation
+   * Constructs a call to the SDK's Handlebars helper for run-time translation
    * processing. This call is constructed using the translation(s) for a phrase and any
    * interpolation parameters.
    *

--- a/tests/fixtures/handlebars/processedcomponent.js
+++ b/tests/fixtures/handlebars/processedcomponent.js
@@ -17,17 +17,17 @@ class standardCardComponent extends BaseCard['standard'] {
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      details: ANSWERS.translateJS('{\"0\":\"Un article [[name]]\",\"1\":\"Les articles [[name]]\",\"locale\":\"fr-FR\"}', {name:profile.name,count:profile.count}, profile.count), // The text in the body of the card
-      intermixed: ANSWERS.translateJS('{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}', {count:2,name:name}, 2),
+      details: ANSWERS.processTranslation('{\"0\":\"Un article [[name]]\",\"1\":\"Les articles [[name]]\",\"locale\":\"fr-FR\"}', {name:profile.name,count:profile.count}, profile.count), // The text in the body of the card
+      intermixed: ANSWERS.processTranslation('{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}', {count:2,name:name}, 2),
       singleQuote: 'L\'os du chien',
-      pluralizedSingleQuote: ANSWERS.translateJS('{\"0\":\"L\'homme\",\"1\":\"Les hommes\"}', {count:myCount}, myCount),
+      pluralizedSingleQuote: ANSWERS.processTranslation('{\"0\":\"L\'homme\",\"1\":\"Les hommes\"}', {count:myCount}, myCount),
       showMoreDetails: {
         showMoreLimit: 750, // Character count limit
         showMoreText: 'Show more', // Label when toggle will show truncated text
         showLessText: 'Show less' // Label when toggle will hide truncated text
       },
       CTA1: {
-        label: ANSWERS.translateJS('Mail maintenant [[id1]]', {id1:profile.name}), // The CTA's label
+        label: ANSWERS.processTranslation('Mail maintenant [[id1]]', {id1:profile.name}), // The CTA's label
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened

--- a/tests/fixtures/handlebars/processedtemplate.hbs
+++ b/tests/fixtures/handlebars/processedtemplate.hbs
@@ -1,16 +1,16 @@
 <div>
     <button>Bonjour Bonjour</button>
     <div>
-        {{ runtimeTranslation phrase='{\"0\":\"Un article [[name]]\",\"1\":\"Les articles [[name]]\",\"locale\":\"fr-FR\"}' name=myName count=myCount }}
+        {{ processTranslation phrase='{\"0\":\"Un article [[name]]\",\"1\":\"Les articles [[name]]\",\"locale\":\"fr-FR\"}' name=myName count=myCount }}
     </div>
     <script>
         const profile = { name: 'Tom' };
-        ANSWERS.translateJS('Mail maintenant [[id1]]', {id1:profile.name})
+        ANSWERS.processTranslation('Mail maintenant [[id1]]', {id1:profile.name})
     </script>
-    <button>{{ runtimeTranslation phrase='Mail maintenant [[id1]]' id1=myName }}</button>
+    <button>{{ processTranslation phrase='Mail maintenant [[id1]]' id1=myName }}</button>
     <div>
-        {{ runtimeTranslation phrase='{\"0\":\"Le [[count]] homme est parti en promenade\",\"1\":\"Les [[count]] Hommes fait une promenade\",\"locale\":\"fr-FR\"}' count=myCount }}
-        {{ runtimeTranslation phrase='{\"0\":\"La [[count]] femme a fait une promenade\",\"1\":\"Les [[count]] femmes fait une promenade\",\"locale\":\"fr-FR\"}' count=myCount }}
+        {{ processTranslation phrase='{\"0\":\"Le [[count]] homme est parti en promenade\",\"1\":\"Les [[count]] Hommes fait une promenade\",\"locale\":\"fr-FR\"}' count=myCount }}
+        {{ processTranslation phrase='{\"0\":\"La [[count]] femme a fait une promenade\",\"1\":\"Les [[count]] femmes fait une promenade\",\"locale\":\"fr-FR\"}' count=myCount }}
     </div>
     <button>L&#x27;homme</button>
     L&#x27;homme
@@ -19,9 +19,9 @@
     <span class="yext">L'os du chien</span>
     Le chien.
     Le: chien
-    {{{ runtimeTranslation phrase='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' name=name }}}
-    {{ runtimeTranslation phrase='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' name=name }}
-    {{{ runtimeTranslation phrase='{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}' count=2 name=name }}}
-    {{ runtimeTranslation phrase='{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}' count=2 name=name }}
-    {{{ runtimeTranslation phrase='{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}' count=2 name=name }}}
+    {{{ processTranslation phrase='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' name=name }}}
+    {{ processTranslation phrase='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' name=name }}
+    {{{ processTranslation phrase='{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}' count=2 name=name }}}
+    {{ processTranslation phrase='{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}' count=2 name=name }}
+    {{{ processTranslation phrase='{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}' count=2 name=name }}}
 </div>

--- a/tests/handlebars/handlebarspreprocessor.js
+++ b/tests/handlebars/handlebarspreprocessor.js
@@ -125,14 +125,14 @@ describe('HandlebarsPreprocessor works correctly', () => {
 
     it('passes correct arguments to translatePlural', () => {
       const raw = `{{ translate phrase='singular' pluralForm='plural' }}`;
-      const processed = `{{ runtimeTranslation phrase='{\\"0\\":\\"singular\\",\\"1\\":\\"plural\\",\\"locale\\":\\"en\\"}' }}`;
+      const processed = `{{ processTranslation phrase='{\\"0\\":\\"singular\\",\\"1\\":\\"plural\\",\\"locale\\":\\"en\\"}' }}`;
       expect(handlebarsPreprocessor.process(raw)).toEqual(processed);
     });
 
     it('transpiles commented out "translate" invocations correctly', () => {
       const raw = `{{!-- {{ translate phrase='singular' pluralForm='plural' }} --}}`;
       const processed = 
-        `{{!-- {{ runtimeTranslation phrase='{\\"0\\":\\"singular\\",\\"1\\":\\"plural\\",\\"locale\\":\\"en\\"}' }} --}}`;
+        `{{!-- {{ processTranslation phrase='{\\"0\\":\\"singular\\",\\"1\\":\\"plural\\",\\"locale\\":\\"en\\"}' }} --}}`;
       expect(handlebarsPreprocessor.process(raw)).toEqual(processed);
     });
   });


### PR DESCRIPTION
Rename the output of the transpilation calls to match the new names in the SDK

The translateJS helper now creates calls to ANSWERS.processTranslation() rather than ANSWERS.translateJS(). The translate HBS helper creates calls to a processTranslation helper rather than translate helper in the SDK.

J=SLAP-654
TEST=manual, auto

Update unit tests and confirm they pass. Build an internationalized ANSWERS site with the [corresponding SDK branch](https://github.com/yext/answers/pull/1077) and observe a properly translated site.