### PR TITLE
Add jambo matches Handlebars helper

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -303,7 +303,7 @@ exports.SitesGenerator = class {
       return (prefix + id);
     });
 
-    hbs.registerHelper('contains', function(str, regexPattern) {
+    hbs.registerHelper('matches', function(str, regexPattern) {
       const regex = new RegExp(regexPattern);
       return str.match(regex);
     });

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -303,6 +303,11 @@ exports.SitesGenerator = class {
       return (prefix + id);
     });
 
+    hbs.registerHelper('contains', function(str, regexPattern) {
+      const regex = new RegExp(regexPattern);
+      return str.match(regex);
+    });
+
     hbs.registerHelper('babel', function(options) {
       const srcCode = options.fn(this);
       return babel.transformSync(srcCode, {


### PR DESCRIPTION
TEST=manual
J=SLAP-626

Use helper in a jambo site, test adding param to the global_config: `"alexis-text-param": "static/assets/image.png"` then putting this snippet in the Handlebars.
```hbs
{{#if (matches global_config.alexis-text-param 'static\/assets\/[^"]*' )}}
    works!
{{/if}}
```
Inspect output HTML and see "works!" in the file. Change "if" to "unless" and see that "works!" is no longer in the output file.