### PR TITLE
Add null check to matches handlebars helper

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -308,7 +308,7 @@ exports.SitesGenerator = class {
 
     hbs.registerHelper('matches', function(str, regexPattern) {
       const regex = new RegExp(regexPattern);
-      return str.match(regex);
+      return str && str.match(regex);
     });
 
     hbs.registerHelper('babel', function(options) {


### PR DESCRIPTION
Currently if we try to use the "matches" helper with a variable that does not exist, it fails. For example:
```hbs
{{#if (matches thisVariableDoesNotExist 'test')}}{{/if}}
```
throws an
```
TypeError: Cannot read property 'match' of undefined
    at Object.<anonymous> 
    ...
```
Error. 

TEST=manual
J=SPR-667

Use handlebars helper with variable that does not exist. Confirm it returns false (rather than causing the jambo build to fail)