### PR TITLE
Update output of transpilation calls

### DIFF
--- a/src/handlebars/handlebarspreprocessor.js
+++ b/src/handlebars/handlebarspreprocessor.js
@@ -141,7 +141,11 @@ class HandlebarsPreprocessor {
    * @returns {string} The call to the 'processTranslation' helper.
    */
   _createRuntimeCallForHBS(
-  translatorResult, interpolationParams, needsPluralization, shouldEscapeHTML) {
+    translatorResult, 
+    interpolationParams, 
+    needsPluralization, 
+    shouldEscapeHTML) 
+  {
     const translationString = needsPluralization ?
       Object.entries(translatorResult)
         .reduce((params, [paramName, paramValue]) => {

--- a/src/handlebars/handlebarspreprocessor.js
+++ b/src/handlebars/handlebarspreprocessor.js
@@ -106,9 +106,9 @@ class HandlebarsPreprocessor {
 
     if (needsPluralization) {
       const count = interpolationParams.count;
-      const pluralFormPairs = this._getPluralFormPairs(translatorResult);
+      const pluralForms = this._getFormattedPluralForms(translatorResult);
 
-      return `ANSWERS.processTranslation(${pluralFormPairs}, ${parsedParams}, ${count})`;
+      return `ANSWERS.processTranslation(${pluralForms}, ${parsedParams}, ${count})`;
     }
     const escapedTranslatorResult = this._escapeSingleQuotes(translatorResult);
 
@@ -116,14 +116,14 @@ class HandlebarsPreprocessor {
   }
 
   /**
-   * Constructs a string representation of a translatorResult. This output is similar to
-   * JSON.stringiy(), however keys are not surrounded by quotes, and values are
-   * surrounded by single quotes.
+   * Constructs a string representation of a translatorResult Object. This output is
+   * similar to JSON.stringiy(), however keys are not surrounded by quotes, and values
+   * are surrounded by single quotes.
    * 
    * @param {Object<number,string>} translatorResult 
    * @returns {string}
    */
-  _getPluralFormPairs(translatorResult) {
+  _getFormattedPluralForms(translatorResult) {
     const pluralFormPairs = Object.entries(translatorResult)
         .reduce((params, [pluralFormIndex, pluralForm], index, array) => {
           const escapedPluralForm = this._escapeSingleQuotes(pluralForm);

--- a/src/i18n/translator/translator.js
+++ b/src/i18n/translator/translator.js
@@ -50,12 +50,11 @@ class Translator {
    *
    * @param {string} phrase The phrase to translate.
    * @param {string} pluralForm The untranslated, plural form of the phrase.
-   * @param {string} originalLocale The original locale of the passed in phrase.
    * @returns {Object<string|number, string>} A map containing the various forms as
    *   well as the locale. A form is keyed by its gettext plural form count see
    *   https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
    */
-  translatePlural(phrase, pluralForm, originalLocale = 'en') {
+  translatePlural(phrase, pluralForm) {
     const escapedPhrase = this._escapeInterpolationBrackets(phrase);
     const pluralKeyRegex = new RegExp(`${escapedPhrase}_([0-9]+|plural)`);
     const i18nextOptions = this._i18next.options;
@@ -72,7 +71,7 @@ class Translator {
         phrase);
     }
 
-    return this._getUntranslatedPluralizations(phrase, pluralForm, originalLocale);
+    return this._getUntranslatedPluralizations(phrase, pluralForm);
   }
 
   /**
@@ -82,12 +81,11 @@ class Translator {
    * @param {string} phrase The phrase to translate.
    * @param {string} pluralForm The untranslated, plural form of the phrase.
    * @param {string} context The translation context
-   * @param {string} originalLocale The original locale of the passed in phrase.
    * @returns {Object<string|number, string>} A map containing the various forms as
    *   well as the locale. A form is keyed by its gettext plural form count, see
    *   https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
    */
-  translatePluralWithContext(phrase, pluralForm, context, originalLocale = 'en') {
+  translatePluralWithContext(phrase, pluralForm, context) {
     const escapedPhrase = this._escapeInterpolationBrackets(phrase);
     const pluralWithContextKeyRegex = new RegExp(
       `${escapedPhrase}_${context}_([0-9]+|plural)`);
@@ -105,24 +103,24 @@ class Translator {
         `${phrase}_${context}`);
     }
 
-    return this._getUntranslatedPluralizations(phrase, pluralForm, originalLocale);
+    return this._getUntranslatedPluralizations(phrase, pluralForm);
   }
 
 
   /**
    * Constructs a pluralization dictionary without translating any strings
+   * TODO (cea2aj) This will need to be updated if we want to support developing in
+   * languages with more than two plural forms
    *
    * @param {string} phrase
    * @param {string} pluralForm
-   * @param {string} originalLocale
    * @returns {Object<string|number, string>} A map containing the various forms as
    *   well as the locale.
    */
-  _getUntranslatedPluralizations(phrase, pluralForm, originalLocale){
+  _getUntranslatedPluralizations(phrase, pluralForm){
     return {
       0: phrase,
-      1: pluralForm,
-      locale: originalLocale
+      1: pluralForm
     };
   }
 
@@ -149,7 +147,7 @@ class Translator {
           pluralForms[pluralFormIndex] = localeTranslations[translationKey];
           return pluralForms;
         },
-        { 0: localeTranslations[translationKey], locale: locale });
+        { 0: localeTranslations[translationKey] });
   }
 
   /**

--- a/tests/fixtures/handlebars/processedcomponent.js
+++ b/tests/fixtures/handlebars/processedcomponent.js
@@ -17,8 +17,8 @@ class standardCardComponent extends BaseCard['standard'] {
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      details: ANSWERS.processTranslation({0:'Un article [[name]]',1:'Les articles [[name]]',locale:'fr-FR'}, {name:profile.name,count:profile.count}, profile.count), // The text in the body of the card
-      intermixed: ANSWERS.processTranslation({0:'<a href="https://www.yext.com">Voir notre site web [[name]]</a>',1:'<a href="https://www.yext.com">Voir nos sites web [[name]]</a>',locale:'fr-FR'}, {count:2,name:name}, 2),
+      details: ANSWERS.processTranslation({0:'Un article [[name]]',1:'Les articles [[name]]'}, {name:profile.name,count:profile.count}, profile.count), // The text in the body of the card
+      intermixed: ANSWERS.processTranslation({0:'<a href="https://www.yext.com">Voir notre site web [[name]]</a>',1:'<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'}, {count:2,name:name}, 2),
       singleQuote: 'L\'os du chien',
       pluralizedSingleQuote: ANSWERS.processTranslation({0:'L\'homme',1:'Les hommes'}, {count:myCount}, myCount),
       showMoreDetails: {

--- a/tests/fixtures/handlebars/processedcomponent.js
+++ b/tests/fixtures/handlebars/processedcomponent.js
@@ -17,10 +17,10 @@ class standardCardComponent extends BaseCard['standard'] {
       url: profile.website || profile.landingPageUrl, // If the card title is a clickable link, set URL here
       target: '_top', // If the title's URL should open in a new tab, etc.
       titleEventOptions: this.addDefaultEventOptions(),
-      details: ANSWERS.processTranslation('{\"0\":\"Un article [[name]]\",\"1\":\"Les articles [[name]]\",\"locale\":\"fr-FR\"}', {name:profile.name,count:profile.count}, profile.count), // The text in the body of the card
-      intermixed: ANSWERS.processTranslation('{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}', {count:2,name:name}, 2),
+      details: ANSWERS.processTranslation({0:'Un article [[name]]',1:'Les articles [[name]]',locale:'fr-FR'}, {name:profile.name,count:profile.count}, profile.count), // The text in the body of the card
+      intermixed: ANSWERS.processTranslation({0:'<a href="https://www.yext.com">Voir notre site web [[name]]</a>',1:'<a href="https://www.yext.com">Voir nos sites web [[name]]</a>',locale:'fr-FR'}, {count:2,name:name}, 2),
       singleQuote: 'L\'os du chien',
-      pluralizedSingleQuote: ANSWERS.processTranslation('{\"0\":\"L\'homme\",\"1\":\"Les hommes\"}', {count:myCount}, myCount),
+      pluralizedSingleQuote: ANSWERS.processTranslation({0:'L\'homme',1:'Les hommes'}, {count:myCount}, myCount),
       showMoreDetails: {
         showMoreLimit: 750, // Character count limit
         showMoreText: 'Show more', // Label when toggle will show truncated text
@@ -28,6 +28,7 @@ class standardCardComponent extends BaseCard['standard'] {
       },
       CTA1: {
         label: ANSWERS.processTranslation('Mail maintenant [[id1]]', {id1:profile.name}), // The CTA's label
+        label2: ANSWERS.processTranslation('[[name]]\'s mail', {name:myName}),
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened

--- a/tests/fixtures/handlebars/processedtemplate.hbs
+++ b/tests/fixtures/handlebars/processedtemplate.hbs
@@ -1,7 +1,7 @@
 <div>
     <button>Bonjour Bonjour</button>
     <div>
-        {{ processTranslation pluralForm0='Un article [[name]]' pluralForm1='Les articles [[name]]' locale='fr-FR'  name=myName count=myCount }}
+        {{ processTranslation pluralForm0='Un article [[name]]' pluralForm1='Les articles [[name]]'  name=myName count=myCount }}
     </div>
     <script>
         const profile = { name: 'Tom' };
@@ -10,11 +10,11 @@
     <button>{{ processTranslation phrase='Mail maintenant [[id1]]' id1=myName }}</button>
     {{ processTranslation phrase='[[name]]\'s mail' name=myName }}
     <div>
-        {{ processTranslation pluralForm0='Le [[count]] homme est parti en promenade' pluralForm1='Les [[count]] Hommes fait une promenade' locale='fr-FR'  count=myCount }}
-        {{ processTranslation pluralForm0='La [[count]] femme a fait une promenade' pluralForm1='Les [[count]] femmes fait une promenade' locale='fr-FR'  count=myCount }}
+        {{ processTranslation pluralForm0='Le [[count]] homme est parti en promenade' pluralForm1='Les [[count]] Hommes fait une promenade'  count=myCount }}
+        {{ processTranslation pluralForm0='La [[count]] femme a fait une promenade' pluralForm1='Les [[count]] femmes fait une promenade'  count=myCount }}
     </div>
     <button>L&#x27;homme</button>
-    {{!-- {{ processTranslation pluralForm0='singular' pluralForm1='plural' locale='en'  count=mycount }} --}}
+    {{!-- {{ processTranslation pluralForm0='singular' pluralForm1='plural'  count=mycount }} --}}
     L&#x27;homme
     L'homme
     &lt;span class&#x3D;&quot;yext&quot;&gt;L&#x27;os du chien&lt;/span&gt;
@@ -23,7 +23,7 @@
     Le: chien
     {{{ processTranslation phrase='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' name=name }}}
     {{ processTranslation phrase='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' name=name }}
-    {{{ processTranslation pluralForm0='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' pluralForm1='<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' locale='fr-FR'  count=2 name=name }}}
-    {{ processTranslation pluralForm0='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' pluralForm1='<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' locale='fr-FR'  count=2 name=name }}
-    {{{ processTranslation pluralForm0='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' pluralForm1='<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' locale='fr-FR'  count=2 name=name }}}
+    {{{ processTranslation pluralForm0='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' pluralForm1='<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'  count=2 name=name }}}
+    {{ processTranslation pluralForm0='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' pluralForm1='<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'  count=2 name=name }}
+    {{{ processTranslation pluralForm0='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' pluralForm1='<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'  count=2 name=name }}}
 </div>

--- a/tests/fixtures/handlebars/processedtemplate.hbs
+++ b/tests/fixtures/handlebars/processedtemplate.hbs
@@ -1,16 +1,17 @@
 <div>
     <button>Bonjour Bonjour</button>
     <div>
-        {{ processTranslation phrase='{\"0\":\"Un article [[name]]\",\"1\":\"Les articles [[name]]\",\"locale\":\"fr-FR\"}' name=myName count=myCount }}
+        {{ processTranslation pluralForm0='Un article [[name]]' pluralForm1='Les articles [[name]]' locale='fr-FR'  name=myName count=myCount }}
     </div>
     <script>
         const profile = { name: 'Tom' };
         ANSWERS.processTranslation('Mail maintenant [[id1]]', {id1:profile.name})
     </script>
     <button>{{ processTranslation phrase='Mail maintenant [[id1]]' id1=myName }}</button>
+    {{ processTranslation phrase='[[name]]\'s mail' name=myName }}
     <div>
-        {{ processTranslation phrase='{\"0\":\"Le [[count]] homme est parti en promenade\",\"1\":\"Les [[count]] Hommes fait une promenade\",\"locale\":\"fr-FR\"}' count=myCount }}
-        {{ processTranslation phrase='{\"0\":\"La [[count]] femme a fait une promenade\",\"1\":\"Les [[count]] femmes fait une promenade\",\"locale\":\"fr-FR\"}' count=myCount }}
+        {{ processTranslation pluralForm0='Le [[count]] homme est parti en promenade' pluralForm1='Les [[count]] Hommes fait une promenade' locale='fr-FR'  count=myCount }}
+        {{ processTranslation pluralForm0='La [[count]] femme a fait une promenade' pluralForm1='Les [[count]] femmes fait une promenade' locale='fr-FR'  count=myCount }}
     </div>
     <button>L&#x27;homme</button>
     L&#x27;homme
@@ -21,7 +22,7 @@
     Le: chien
     {{{ processTranslation phrase='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' name=name }}}
     {{ processTranslation phrase='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' name=name }}
-    {{{ processTranslation phrase='{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}' count=2 name=name }}}
-    {{ processTranslation phrase='{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}' count=2 name=name }}
-    {{{ processTranslation phrase='{\"0\":\"<a href=\\"https://www.yext.com\\">Voir notre site web [[name]]</a>\",\"1\":\"<a href=\\"https://www.yext.com\\">Voir nos sites web [[name]]</a>\",\"locale\":\"fr-FR\"}' count=2 name=name }}}
+    {{{ processTranslation pluralForm0='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' pluralForm1='<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' locale='fr-FR'  count=2 name=name }}}
+    {{ processTranslation pluralForm0='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' pluralForm1='<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' locale='fr-FR'  count=2 name=name }}
+    {{{ processTranslation pluralForm0='<a href="https://www.yext.com">Voir notre site web [[name]]</a>' pluralForm1='<a href="https://www.yext.com">Voir nos sites web [[name]]</a>' locale='fr-FR'  count=2 name=name }}}
 </div>

--- a/tests/fixtures/handlebars/rawcomponent.js
+++ b/tests/fixtures/handlebars/rawcomponent.js
@@ -28,6 +28,7 @@ class standardCardComponent extends BaseCard['standard'] {
       },
       CTA1: {
         label: {{translateJS phrase='Mail now [[id1]]' context='Mail is a verb' id1=profile.name}}, // The CTA's label
+        label2: {{translateJS phrase='[[name]]\'s mail' name=myName}},
         iconName: 'chevron', // The icon to use for the CTA
         url: Formatter.generateCTAFieldTypeLink(profile.c_primaryCTA), // The URL a user will be directed to when clicking
         target: '_top', // Where the new URL will be opened

--- a/tests/fixtures/handlebars/rawtemplate.hbs
+++ b/tests/fixtures/handlebars/rawtemplate.hbs
@@ -8,6 +8,7 @@
         {{translateJS phrase='Mail now [[id1]]' context='Mail is a verb' id1=profile.name}}
     </script>
     <button>{{translate phrase='Mail now [[id1]]' context='Mail is a verb' id1=myName}}</button>
+    {{translate phrase='[[name]]\'s mail' name=myName}}
     <div>
         {{ translate phrase='The [[count]] person went on a walk' pluralForm='The [[count]] people went on a walk' context='male' count=myCount}}
         {{ translate phrase='The [[count]] person went on a walk' pluralForm='The [[count]] people went on a walk' context='female' count=myCount}}

--- a/tests/handlebars/handlebarspreprocessor.js
+++ b/tests/handlebars/handlebarspreprocessor.js
@@ -40,20 +40,17 @@ describe('HandlebarsPreprocessor works correctly', () => {
           case 'Some item [[name]]':
             return {
               0: 'Un article [[name]]',
-              1: 'Les articles [[name]]',
-              locale: 'fr-FR'
+              1: 'Les articles [[name]]'
             };
           case '<a href="https://www.yext.com">View our website [[name]]</a>':
             return {
               0: '<a href="https://www.yext.com">Voir notre site web [[name]]</a>',
-              1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>',
-              locale: 'fr-FR'
+              1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'
             };
           case 'singular':
             return {
               0: 'singular',
-              1: 'plural',
-              locale: 'en'
+              1: 'plural'
             };
         }
       },
@@ -63,22 +60,19 @@ describe('HandlebarsPreprocessor works correctly', () => {
             if (context === 'male') {
               return {
                 0: 'Le [[count]] homme est parti en promenade',
-                1: 'Les [[count]] Hommes fait une promenade',
-                locale: 'fr-FR'
+                1: 'Les [[count]] Hommes fait une promenade'
               }
             } else if (context === 'female') {
               return {
                 0: 'La [[count]] femme a fait une promenade',
-                1: 'Les [[count]] femmes fait une promenade',
-                locale: 'fr-FR'
+                1: 'Les [[count]] femmes fait une promenade'
               }
             }
           case '<a href="https://www.yext.com">View our website [[name]]</a>':
             if (context === 'internet web, not spider web') {
               return {
                 0: '<a href="https://www.yext.com">Voir notre site web [[name]]</a>',
-                1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>',
-              locale: 'fr-FR'
+                1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'
               }
             }
           case 'The person':

--- a/tests/handlebars/handlebarspreprocessor.js
+++ b/tests/handlebars/handlebarspreprocessor.js
@@ -23,6 +23,8 @@ describe('HandlebarsPreprocessor works correctly', () => {
           return 'Le: chien';
         } else if (phrase === '<a href="https://www.yext.com">View our website [[name]]</a>') {
           return '<a href="https://www.yext.com">Voir notre site web [[name]]</a>';
+        } else if (phrase === '[[name]]\'s mail') {
+          return '[[name]]\'s mail';
         }
       },
       translateWithContext: (phrase, context) => {
@@ -124,15 +126,15 @@ describe('HandlebarsPreprocessor works correctly', () => {
     const handlebarsPreprocessor = new HandlebarsPreprocessor(translator);
 
     it('passes correct arguments to translatePlural', () => {
-      const raw = `{{ translate phrase='singular' pluralForm='plural' }}`;
-      const processed = `{{ processTranslation phrase='{\\"0\\":\\"singular\\",\\"1\\":\\"plural\\",\\"locale\\":\\"en\\"}' }}`;
+      const raw = `{{ translate phrase='singular' pluralForm='plural' count=mycount}}`;
+      const processed = `{{ processTranslation pluralForm0='singular' pluralForm1='plural' locale='en'  count=mycount }}`;
       expect(handlebarsPreprocessor.process(raw)).toEqual(processed);
     });
 
     it('transpiles commented out "translate" invocations correctly', () => {
-      const raw = `{{!-- {{ translate phrase='singular' pluralForm='plural' }} --}}`;
+      const raw = `{{!-- {{ translate phrase='singular' pluralForm='plural' count=mycount}} --}}`;
       const processed = 
-        `{{!-- {{ processTranslation phrase='{\\"0\\":\\"singular\\",\\"1\\":\\"plural\\",\\"locale\\":\\"en\\"}' }} --}}`;
+        `{{!-- {{ processTranslation pluralForm0='singular' pluralForm1='plural' locale='en'  count=mycount }} --}}`;
       expect(handlebarsPreprocessor.process(raw)).toEqual(processed);
     });
   });

--- a/tests/i18n/translator/translator.js
+++ b/tests/i18n/translator/translator.js
@@ -52,8 +52,7 @@ describe('translations with one plural form (French)', () => {
       const translation = translator.translatePlural('Item', 'Items');
       const expectedResult = {
         0: 'Article',
-        1: 'Articles',
-        locale: 'fr-FR'
+        1: 'Articles'
       };
 
       expect(translation).toEqual(expectedResult);
@@ -64,8 +63,7 @@ describe('translations with one plural form (French)', () => {
         'There is [[count]] item [[name]]', 'There are [[count]] items [[name]]');
       const expectedResult = {
         0: 'Il y a [[count]] article [[name]]',
-        1: 'Il y a [[count]] articles [[name]]',
-        locale: 'fr-FR'
+        1: 'Il y a [[count]] articles [[name]]'
       };
 
       expect(translation).toEqual(expectedResult);
@@ -77,8 +75,7 @@ describe('translations with one plural form (French)', () => {
         'Missing [[count]] translations [[name]]');
       const expectedResult = {
         0: 'Missing [[count]] translation [[name]]',
-        1: 'Missing [[count]] translations [[name]]',
-        locale: 'en'
+        1: 'Missing [[count]] translations [[name]]'
       };
 
       expect(translation).toEqual(expectedResult);
@@ -117,13 +114,11 @@ describe('translations with one plural form (French)', () => {
         'female');
       const expectedResultWithMaleContext = {
         0: 'L\'homme',
-        1: 'Les hommes',
-        locale: 'fr-FR'
+        1: 'Les hommes'
       };
       const expectedResultWithFemaleContext = {
         0: 'La femme',
-        1: 'Les femmes',
-        locale: 'fr-FR'
+        1: 'Les femmes'
       };
       expect(translationWithMaleContext).toEqual(expectedResultWithMaleContext);
       expect(translationWithFemaleContext).toEqual(expectedResultWithFemaleContext);
@@ -140,13 +135,11 @@ describe('translations with one plural form (French)', () => {
         'female');
       const expectedResultWithMaleContext = {
         0: 'Le [[count]] homme est parti en promenade',
-        1: 'Les [[count]] Hommes fait une promenade',
-        locale: 'fr-FR'
+        1: 'Les [[count]] Hommes fait une promenade'
       };
       const expectedResultWithFemaleContext = {
         0: 'La [[count]] femme a fait une promenade',
-        1: 'Les [[count]] femmes fait une promenade',
-        locale: 'fr-FR'
+        1: 'Les [[count]] femmes fait une promenade'
       };
       expect(translationWithMaleContext).toEqual(expectedResultWithMaleContext);
       expect(translationWithFemaleContext).toEqual(expectedResultWithFemaleContext);
@@ -160,8 +153,7 @@ describe('translations with one plural form (French)', () => {
           'male');
         const expectedResult = {
           0: 'The [[count]] elephant went on a drive',
-          1: 'The [[count]] elephants went on a drive',
-          locale: 'en'
+          1: 'The [[count]] elephants went on a drive'
         };
         expect(translation).toEqual(expectedResult);
       }
@@ -194,8 +186,7 @@ describe('translations with one plural form (French)', () => {
         '<a href="https://www.yext.com">View our websites [[name]]</a>');
       const expectedResult = {
         0: '<a href="https://www.yext.com">Voir notre site web [[name]]</a>',
-        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>',
-        locale: 'fr-FR'};
+        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'};
       expect(translation).toEqual(expectedResult);
     });
 
@@ -206,8 +197,7 @@ describe('translations with one plural form (French)', () => {
         'internet web, not spider web');
       const expectedResult = {
         0: '<a href="https://www.yext.com">Voir notre site web [[name]]</a>',
-        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>',
-        locale: 'fr-FR'};
+        1: '<a href="https://www.yext.com">Voir nos sites web [[name]]</a>'};
       expect(translation).toEqual(expectedResult);
     });
   });
@@ -233,8 +223,7 @@ describe('translations with multiple plural forms (Lithuanian)', () => {
     const expectedResult = {
       0: 'Nepavyksta nusiųsti apžvalgos el. paštu',
       1: 'Nepavyksta nusiųsti apžvalgų el. paštu',
-      2: 'Nepavyksta nusiųsti apžvalgų el. paštu',
-      locale: 'lt-LT'
+      2: 'Nepavyksta nusiųsti apžvalgų el. paštu'
     };
 
     expect(translation).toEqual(expectedResult);
@@ -248,8 +237,7 @@ describe('translations with multiple plural forms (Lithuanian)', () => {
     const expectedResult = {
       0: 'Pasirinkta [[count]] tinklalapis',
       1: 'Pasirinkta [[count]] tinklalapiai',
-      2: 'Pasirinkta [[count]] tinklalapių',
-      locale: 'lt-LT'
+      2: 'Pasirinkta [[count]] tinklalapių'
     };
 
     expect(translation).toEqual(expectedResult);


### PR DESCRIPTION
Update the transpilation of runtime calls calls to no longer create stringified json

For calls to ANSWERS.processTranslation(), pass an object as the first parameter rather than stringified JSON. For calls to the processTranslation HBS helper, instead of passing pluralizations through the phrase param, pass pluralForms as their own parameters. This simplifies our escaping logic to only require the escaping of single quotes. Also, no longer create a locale parameter when creating transpiled calls.

J=SLAP-638
TEST=auto, manual

Update unit tests and confirm they pass. Run an internationalized jambo build with the corresponding branch in the SDK and verify that the translations are correct. Also inspect the HTML generated through the jambo build to verify that the calls to the helpers are correct.