### PR TITLE
Use lodash escapeRegExp on plural translation keys

### DIFF
--- a/src/i18n/translator/translator.js
+++ b/src/i18n/translator/translator.js
@@ -1,4 +1,5 @@
 const i18next = require('i18next');
+const escapeRegExp = require('lodash/escapeRegExp');
 
 /**
  * This class wraps an instance of the i18next library and provides methods supporting
@@ -55,7 +56,7 @@ class Translator {
    *   https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
    */
   translatePlural(phrase, pluralForm) {
-    const escapedPhrase = this._escapeInterpolationBrackets(phrase);
+    const escapedPhrase = escapeRegExp(phrase);
     const pluralKeyRegex = new RegExp(`${escapedPhrase}_([0-9]+|plural)`);
     const i18nextOptions = this._i18next.options;
 
@@ -86,9 +87,9 @@ class Translator {
    *   https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
    */
   translatePluralWithContext(phrase, pluralForm, context) {
-    const escapedPhrase = this._escapeInterpolationBrackets(phrase);
+    const escapedPhraseAndContext = escapeRegExp(`${phrase}_${context}`);
     const pluralWithContextKeyRegex = new RegExp(
-      `${escapedPhrase}_${context}_([0-9]+|plural)`);
+      `${escapedPhraseAndContext}_([0-9]+|plural)`);
     const i18nextOptions = this._i18next.options;
 
     // We first look for the translations in the given locale. If none can be
@@ -148,18 +149,6 @@ class Translator {
           return pluralForms;
         },
         { 0: localeTranslations[translationKey] });
-  }
-
-  /**
-   * Escapes the interpolation brackets in a phrase
-   *
-   * @param {string} phrase
-   * @returns {string}
-   */
-  _escapeInterpolationBrackets(phrase) {
-    return phrase
-      .replace(/\[\[/g, '\\[\\[')
-      .replace(/\]\]/g, '\\]\\]');
   }
 
   /**

--- a/tests/fixtures/translations/fr-FR.po
+++ b/tests/fixtures/translations/fr-FR.po
@@ -82,3 +82,7 @@ msgid_plural "<a href=\"https://www.yext.com\">View our websites [[name]]</a>"
 msgstr[0] "<a href=\"https://www.yext.com\">Voir notre site web [[name]]</a>"
 msgstr[1] "<a href=\"https://www.yext.com\">Voir nos sites web [[name]]</a>"
 
+msgid "([[resultsCount]] result)"
+msgid_plural "([[resultsCount]] results)"
+msgstr[0] "([[resultsCount]] résultat)"
+msgstr[1] "([[resultsCount]] résultats)"

--- a/tests/i18n/translationfetchers/localfileparser.js
+++ b/tests/i18n/translationfetchers/localfileparser.js
@@ -19,6 +19,8 @@ describe('LocalFileParser works correctly', () => {
       'Hello [[name]]': 'Bonjour [[name]]',
       Child_male: 'fils',
       Child_female: 'fille',
+      '([[resultsCount]] result)': '([[resultsCount]] résultat)',
+      '([[resultsCount]] result)_plural': '([[resultsCount]] résultats)',
       [englishLink]: frenchLinkSingular,
       [`${englishLink}_internet web, not spider web`]: frenchLinkSingular,
       [`${englishLink}_internet web, not spider web_plural`]: frenchLinkPlural,

--- a/tests/i18n/translator/translator.js
+++ b/tests/i18n/translator/translator.js
@@ -210,7 +210,7 @@ describe('translations with one plural form (French)', () => {
       const expectedResult = {
         0: '([[resultsCount]] résultat)',
         1: '([[resultsCount]] résultats)'};
-    expect(translation).toEqual(expectedResult);
+      expect(translation).toEqual(expectedResult);
     });
   });
 });

--- a/tests/i18n/translator/translator.js
+++ b/tests/i18n/translator/translator.js
@@ -201,6 +201,18 @@ describe('translations with one plural form (French)', () => {
       expect(translation).toEqual(expectedResult);
     });
   });
+
+  describe('Handles plural translation keys by escaping regex charaters', () => {
+    it('does not confuse parenthesis for a capturing group', () => {
+      const translation = translator.translatePlural(
+        '([[resultsCount]] result)',
+        '([[resultsCount]] results)');
+      const expectedResult = {
+        0: '([[resultsCount]] résultat)',
+        1: '([[resultsCount]] résultats)'};
+    expect(translation).toEqual(expectedResult);
+    });
+  });
 });
 
 describe('translations with multiple plural forms (Lithuanian)', () => {


### PR DESCRIPTION
Use escapeRegExp rather than escapeInterpolationBrackets for plural translation key.

There was a bug where the following translation was not being translated properly:
msgid "([[resultsCount]] result)" msgid_plural "([[resultsCount]] results)" msgstr[0] "[[resultsCount]] resultado" msgstr[1] "[[resultsCount]] resultados"

The translation was failing due to the open and closing parentheses being interpreted as a regex capture group during the key lookup. This was because we manually check translation keys inside i18next with a regex test for plural translations. Use lodash.escapeRegExp to solve this issue and escape all other possible RegExp characters.

J=none
TEST=auto

Add a test that confirms the parentheses are properly escaped. Confirm that all other translations still work properly.