### PR TITLE
Support for importing custom Commands and adding them to the Registry.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,8 +18,13 @@ try {
 }
 
 const commandRegistry = new CommandRegistry();
-const commandImporter = new CommandImporter(
-  path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme), jamboConfig.dirs.output);
+
+const commandImporter = jamboConfig.defaultTheme ?
+  new CommandImporter(
+    jamboConfig.dirs.output, 
+    path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
+  new CommandImporter(jamboConfig.dirs.output);
+  
 commandImporter.import().forEach(customCommand => {
   commandRegistry.addCommand(customCommand)
 });

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
 const fs = require('file-system');
+const path = require('path');
 
 const { parseJamboConfig } = require('./utils/jamboconfigutils');
 const { exitWithError } = require('./utils/errorutils');
 const CommandRegistry = require('./commands/commandregistry');
 const YargsFactory = require('./yargsfactory');
+const CommandImporter = require('./commands/commandimporter');
 
 let jamboConfig;
 
@@ -16,6 +18,12 @@ try {
 }
 
 const commandRegistry = new CommandRegistry();
+const commandImporter = new CommandImporter(
+  path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme), jamboConfig.dirs.output);
+commandImporter.import().forEach(customCommand => {
+  commandRegistry.addCommand(customCommand)
+});
+
 const yargsFactory = new YargsFactory(commandRegistry);
 const options = yargsFactory.createCLI(jamboConfig);
 options.argv;

--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -27,7 +27,7 @@ class CommandImporter {
     if (commandDirectories.length > 0) {
       const mergedDirectory = this._mergeCommandDirectories(commandDirectories);
       customCommands = fs.readdirSync(mergedDirectory)
-        .map(directoryPath => path.join(process.cwd(), mergedDirectory, directoryPath))
+        .map(directoryPath => path.resolve(mergedDirectory, directoryPath))
         .filter(directoryPath => fs.lstatSync(directoryPath).isFile())
         .map(require);
 

--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -1,0 +1,61 @@
+const path = require('path');
+const fs = require('fs-extra');
+
+/**
+ * Imports all custom {@link Command}s within a Jambo repository.
+ */
+class CommandImporter {
+  constructor(themeDir, outputDir) {
+    this._themeDir = themeDir;
+    this._outputDir = outputDir;
+  }
+
+  /**
+   * Imports custom commands from the Theme and the top-level of the Jambo
+   * repository. If a custom command is specified in both places, it is deduped, 
+   * with the override in the top-level taking priority. 
+   * 
+   * @returns {Array<Command>} The imported {@link Command}s, ready to be registered
+   *                           with Jambo.
+   */
+  import() {
+    const commandDirectories = [path.join(this._themeDir, 'commands'), 'commands']
+      .filter(fs.existsSync);
+
+    let customCommands = [];
+    if (commandDirectories.length > 0) {
+      const mergedDirectory = this._mergeCommandDirectories(commandDirectories);
+      customCommands = fs.readdirSync(mergedDirectory)
+        .map(directoryPath => path.join(process.cwd(), mergedDirectory, directoryPath))
+        .filter(directoryPath => fs.lstatSync(directoryPath).isFile())
+        .map(require);
+
+      // Remove the merged commands directory from 'public' as it is no longer needed.
+      fs.removeSync(mergedDirectory);
+    }
+
+    return customCommands;
+  }
+
+  /**
+   * Merges the provided custom command directories together. The resulting, merged
+   * directory is in 'public'. The order in which directories are provided matters, 
+   * later ones can overwrite existing files. 
+   * 
+   * @param {Array<string>} directories The directories to merge together.
+   * @returns {string} The path of the merged output directory.
+   */
+  _mergeCommandDirectories(directories) {
+    const mergedDirectory = path.join(this._outputDir, 'commands');
+
+    // In case the merged directory has not been deleted, do so now.
+    if (fs.existsSync(mergedDirectory)) {
+      fs.removeSync(mergedDirectory);
+    }
+    fs.mkdirSync(mergedDirectory);
+    directories.forEach(directory => fs.copySync(directory, mergedDirectory));
+
+    return mergedDirectory;
+  }
+}
+module.exports = CommandImporter;

--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -5,22 +5,23 @@ const fs = require('fs-extra');
  * Imports all custom {@link Command}s within a Jambo repository.
  */
 class CommandImporter {
-  constructor(themeDir, outputDir) {
-    this._themeDir = themeDir;
+  constructor(outputDir, themeDir) {
     this._outputDir = outputDir;
+    this._themeDir = themeDir;
   }
 
   /**
-   * Imports custom commands from the Theme and the top-level of the Jambo
-   * repository. If a custom command is specified in both places, it is deduped, 
-   * with the override in the top-level taking priority. 
+   * Imports custom commands from the Theme (if one has been applied) and the top-level
+   * of the Jambo repository. If a custom command is specified in both places, it is
+   * deduped, with the override in the top-level taking priority. 
    * 
    * @returns {Array<Command>} The imported {@link Command}s, ready to be registered
    *                           with Jambo.
    */
   import() {
-    const commandDirectories = [path.join(this._themeDir, 'commands'), 'commands']
-      .filter(fs.existsSync);
+    let commandDirectories = ['commands'];
+    this._themeDir && commandDirectories.unshift(path.join(this._themeDir, 'commands'));
+    commandDirectories = commandDirectories.filter(fs.existsSync);
 
     let customCommands = [];
     if (commandDirectories.length > 0) {


### PR DESCRIPTION
This PR creates the CommandImporter class. The class imports all custom
Commands in a Jambo repo. A custom Command can be either repo or Theme
specific. Custom Commands from the repo itself are housed in a top-level
'commands' directory. The Theme's custom Commands live in the 'commands' folder
under the Theme. If the same Command is specified in both the repo and the
Theme, Jambo prefers the one from the repo. This way, Theme Commands can be
overriden.

Internally, the CommandImporter merges both 'commands' directories. It then
treats all top-level files in the merged directory as exporting a Command
for Jambo. This is a convention we will make clear in documentation. This
mechanism makes it possible for people to use 'override' to create shadows
of Theme Commands or their helpers. As soon as all the Commands are require'd,
the merged directory is deleted from the file system. In this way, it works
like 'static'. Another convention is that if custom Commands require helper
functions, those either be colocated with the Command or in the
'commands/helpers' directory.

Finally, cli.js was updated so that the imported, custom Commands are added
to the CommandRegistry. From there, the YargsFactory makes yargs commands for
them.

J=SLAP-740
TEST=manual

Tested the following:
- Created a custom Command for the Theme.
- Created a custom Command for a repo.
- Ensured that a custom Command could use helper functions or node_modules.
- If a Command is overriden in the repo, the override is preferred by Jambo.
- If a Command's helper(s) are overridden in the repo, those are preferred
  by Jambo.