### PR TITLE
Only allow the use of custom Commands after Jambo has initialized the…

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,16 +18,17 @@ try {
 }
 
 const commandRegistry = new CommandRegistry();
-
-const commandImporter = jamboConfig.defaultTheme ?
-  new CommandImporter(
-    jamboConfig.dirs.output, 
-    path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
-  new CommandImporter(jamboConfig.dirs.output);
+if (jamboConfig.dirs && jamboConfig.dirs.output) {
+  const commandImporter = jamboConfig.defaultTheme ?
+    new CommandImporter(
+      jamboConfig.dirs.output, 
+      path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
+    new CommandImporter(jamboConfig.dirs.output);
   
-commandImporter.import().forEach(customCommand => {
-  commandRegistry.addCommand(customCommand)
-});
+  commandImporter.import().forEach(customCommand => {
+    commandRegistry.addCommand(customCommand)
+  });
+}
 
 const yargsFactory = new YargsFactory(commandRegistry);
 const options = yargsFactory.createCLI(jamboConfig);

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,7 +18,7 @@ try {
 }
 
 const commandRegistry = new CommandRegistry();
-if (jamboConfig.dirs && jamboConfig.dirs.output) {
+if (jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output) {
   const commandImporter = jamboConfig.defaultTheme ?
     new CommandImporter(
       jamboConfig.dirs.output, 


### PR DESCRIPTION
… repo.

The Command import process relies on the dirs.output directory as a sandbox.
Because of this, we cannot allow custom Commands to be used until the
repository has been initialized by Jambo. Prior to this change, trying to
'jambo init' an empty repository would fail, because we attempted to import
custom Commands simultaneously.

I think it's a reasonable stipulation that you must initialize a Jambo repo
before using any other Command (custom or otherwise).

TEST=manual

Verified that I can now 'jambo init' an empty repo succesfully.