### PR TITLE
Add support for incremental Typescript migration.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     "parserOptions": {
         "ecmaVersion": 12
     },
-    "ignorePatterns": ["tests/fixtures/**/*.js"],
+    "ignorePatterns": ["tests/fixtures/**/*.js", "lib/**/*.js"],
     "rules": {
         "quotes": ["error", "single"],
         "space-before-function-paren": ["error", {

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+lib/
 public/
 node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+src/
+tests/

--- a/package-lock.json
+++ b/package-lock.json
@@ -3587,9 +3587,9 @@
       }
     },
     "@types/node": {
-      "version": "14.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz",
-      "integrity": "sha512-syUgf67ZQpaJj01/tRTknkMNoBBLWJOBODF0Zm4NrXmiSuxjymFrxnTu1QVYRubhVkRcZLYZG8STTwJRdVm/WQ==",
+      "version": "14.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
+      "integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -8078,6 +8078,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "jambo",
   "version": "1.6.2",
   "description": "A JAMStack implementation using Handlebars",
-  "main": "index.js",
+  "main": "lib/cli.js",
   "scripts": {
+    "build": "tsc -p .",
+    "prepublish": "npm run build",
     "test": "eslint . && jest"
   },
   "repository": {
@@ -11,9 +13,9 @@
     "url": "git+https://github.com/yext/jambo.git"
   },
   "bin": {
-    "jambo": "src/cli.js"
+    "jambo": "lib/cli.js"
   },
-  "author": "nbramblett@yext.com",
+  "author": "slapshot@yext.com",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/yext/jambo/issues"
@@ -34,8 +36,10 @@
     "yargs": "^15.1.0"
   },
   "devDependencies": {
+    "@types/node": "^14.11.5",
     "eslint": "^7.8.1",
-    "jest": "^25.4.0"
+    "jest": "^25.4.0",
+    "typescript": "^4.0.3"
   },
   "jest": {
     "verbose": true,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 
-const fs = require('file-system');
-const path = require('path');
+import fs from 'fs';
+import path from 'path';
 
+import Command from './models/commands/command';
+
+// As we cut things over to TS, we will gradually replace these with ES6 imports.
 const { parseJamboConfig } = require('./utils/jamboconfigutils');
 const { exitWithError } = require('./utils/errorutils');
 const CommandRegistry = require('./commands/commandregistry');
@@ -25,7 +28,7 @@ if (jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output) {
       path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
     new CommandImporter(jamboConfig.dirs.output);
   
-  commandImporter.import().forEach(customCommand => {
+  commandImporter.import().forEach((customCommand: Command) => {
     commandRegistry.addCommand(customCommand)
   });
 }

--- a/src/commands/card/cardcreator.js
+++ b/src/commands/card/cardcreator.js
@@ -61,7 +61,7 @@ exports.CardCreator = class {
   _getRenamedCardComponent(content, customCardName) {
     const cardNameSuffix = 'CardComponent';
     const registerComponentTypeRegex = /\([\w_]+CardComponent\)/g;
-    const regexArray = [ ...content.matchAll(/componentName\s*=\s*'(.*)'/g) ];
+    const regexArray = Array.from(content.matchAll(/componentName\s*=\s*'(.*)'/g));
     if (regexArray.length === 0 || regexArray[0].length < 2) {
       return content;
     }

--- a/src/commands/directanswercard/directanswercardcreator.js
+++ b/src/commands/directanswercard/directanswercardcreator.js
@@ -63,7 +63,7 @@ exports.DirectAnswerCardCreator = class {
   _getRenamedCardComponent(content, customCardName) {
     const cardNameSuffix = 'Component';
     const registerComponentTypeRegex = /\([\w_]+Component\)/g;
-    const regexArray = [ ...content.matchAll(/componentName\s*=\s*'(.*)'/g) ];
+    const regexArray = Array.from(content.matchAll(/componentName\s*=\s*'(.*)'/g));
     if (regexArray.length === 0 || regexArray[0].length < 2) {
       return content;
     }

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -1,30 +1,28 @@
 /**
  * An interface that represents a command in the Jambo CLI. 
  */
-class Command {
+export default interface Command {
+  /**
+   * The alias for the command, used to invoke it in the CLI.
+   */
+  getAlias(): string;
 
   /**
-   * @returns {string} The alias for the command.
+   * A short, one sentence description of the command. This description appears as part
+   * of the help text in the CLI. 
    */
-  getAlias() { }
-
-  /**
-   * @returns {string} A short, one sentence description of the command. This
-   *                   description appears as part of the help text in the CLI. 
-   */
-  getShortDescription() { }
+  getShortDescription(): string;
 
   /**
    * Executes the command with the provided arguments.
    * 
    * @param {Object<string, ?>} args The arguments, keyed by name.
    */
-  execute(args) { }
+  execute(args: Object): void;
 
   /**
    * @returns {Object<string, ArgumentMetadata>} Descriptions of each argument,
    *                                             keyed by name.
    */
-  args() { }
+  args(): Object;
 }
-module.exports = Command;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+      "target": "ES5",
+      "module": "commonjs",
+      "outDir": "lib",
+      "types": ["node"],
+      "esModuleInterop": true,
+      "allowJs": true
+    },
+    "include": ["./src/**/*"]
+  }


### PR DESCRIPTION
This PR introduces Typescript to Jambo and makes it possible for us to do an
incremental migration. We begin the migration by converting the entry point,
cli.js, to TS. The 'allowJS' option in our tsconfig makes it so that TS will
still compile our vanilla JS. Once we've fully migrated, we can get rid of this
option.

Typescript is compiled out into regular JS. In Jambo, there is a new 'lib'
directory containing the compiled app. People who get Jambo from npm should
depend only on 'lib/cli.js'. They don't need our 'src'. I added a 'prepublish'
script and an '.npmignore' to ensure our publishes work as expected.

As an example of how to define and use types in TS, I converted the Command
class to an actual TS interface.