### PR TITLE
Add 'any' and 'all' Handlebars helpers

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -308,6 +308,14 @@ exports.SitesGenerator = class {
       return str.match(regex);
     });
 
+    hbs.registerHelper('all', function (...args) {
+      return args.filter(item => item).length === args.length;
+    });
+
+    hbs.registerHelper('any', function (...args) {
+      return args.filter(item => item).length > 1;
+    });
+
     hbs.registerHelper('babel', function(options) {
       const srcCode = options.fn(this);
       return babel.transformSync(srcCode, {

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -308,11 +308,11 @@ exports.SitesGenerator = class {
       return str.match(regex);
     });
 
-    hbs.registerHelper('all', function (...args) {
+    hbs.registerHelper('all', function(...args) {
       return args.filter(item => item).length === args.length;
     });
 
-    hbs.registerHelper('any', function (...args) {
+    hbs.registerHelper('any', function(...args) {
       return args.filter(item => item).length > 1;
     });
 


### PR DESCRIPTION
These helpers are present in the Theme's cards, but since they aren't registered with Jambo's Handlebars renderer we are unable to use them outside of templates for Answers components. 

TEST=manual