### PR TITLE
Add extract-translations command

### DIFF
--- a/src/commands/commandregistry.js
+++ b/src/commands/commandregistry.js
@@ -1,5 +1,6 @@
 const DescribeCommand = require('../commands/describe/describecommand');
 const DescribeCommandRepoReader = require('../commands/describe/describecommandreporeader');
+const JamboTranslationExtractor = require('./extract-translations/jambotranslationextractor');
 
 /**
  * A registry that maintains the built-in and custom commands for the Jambo CLI.
@@ -12,9 +13,9 @@ class CommandRegistry {
 
   /**
    * Registers a new {@link Command} with the CLI.
-   * 
-   * @param {string} name 
-   * @param {Command} command 
+   *
+   * @param {string} name
+   * @param {Command} command
    */
   addCommand(command) {
     this._commandsByName[command.getAlias()] = command;
@@ -38,7 +39,7 @@ class CommandRegistry {
   /**
    * Initializes the registry with the built-in Jambo commands: init, import, page,
    * override, build, and upgrade.
-   * 
+   *
    * @returns {Map<string, Command>} The built-in commmands, keyed by name.
    */
   _initialize() {
@@ -46,8 +47,11 @@ class CommandRegistry {
     const describeRepoReader = new DescribeCommandRepoReader(this._jamboConfig);
     const describeCommand =
       new DescribeCommand(() => this.getCommands(), describeRepoReader);
+    const extractTranslationsCommand =
+      new JamboTranslationExtractor(this._jamboConfig);
     return {
-      [ describeCommand.getAlias() ]: describeCommand
+      [ describeCommand.getAlias() ]: describeCommand,
+      [ extractTranslationsCommand.getAlias() ]: extractTranslationsCommand
     };
   }
 }

--- a/src/commands/extract-translations/jambotranslationextractor.js
+++ b/src/commands/extract-translations/jambotranslationextractor.js
@@ -1,4 +1,5 @@
 const TranslationExtractor = require('../../i18n/extractor/translationextractor');
+const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argumentmetadata');
 const fsExtra = require('fs-extra');
 const fs = require('fs');
 
@@ -11,11 +12,41 @@ class JamboTranslationExtractor {
     this.extractor = new TranslationExtractor();
   }
 
+  getAlias() {
+    return 'extract-translations';
+  }
+
+  getShortDescription() {
+    return 'extract translated strings from .hbs and .js files';
+  }
+
+  args() {
+    return {
+      output: new ArgumentMetadata(
+        ArgumentType.STRING,
+        'the output path to extract the .pot file to',
+        false,
+        'messages.pot'
+      )
+    };
+  }
+
+  describe() {
+    return {
+      displayName: 'Extract Translations',
+      params: this.args()
+    };
+  }
+
+  execute(args) {
+    this._extract(args.output);
+  }
+
   /**
    * Extracts i18n strings from a jambo repo to a designed output file.
    * @param {string} outputPath
    */
-  async extract(outputPath) {
+  async _extract(outputPath) {
     const { files, directories } = this._getFilesAndDirsFromJamboConfig();
     const gitignorePaths = this._parseGitignorePaths();
     console.log(`Extracting translations to ${outputPath}`);

--- a/src/commands/extract-translations/jambotranslationextractor.js
+++ b/src/commands/extract-translations/jambotranslationextractor.js
@@ -37,7 +37,7 @@ class JamboTranslationExtractor {
     return {
       displayName: 'Extract Translations',
       params: Object.keys(args).reduce((params, alias) => {
-        params[alias] = args[alias].serialize();
+        params[alias] = args[alias].toDescribeFormat();
         return params;
       }, {})
     };

--- a/src/commands/extract-translations/jambotranslationextractor.js
+++ b/src/commands/extract-translations/jambotranslationextractor.js
@@ -22,19 +22,24 @@ class JamboTranslationExtractor {
 
   args() {
     return {
-      output: new ArgumentMetadata(
-        ArgumentType.STRING,
-        'the output path to extract the .pot file to',
-        false,
-        'messages.pot'
-      )
+      output: new ArgumentMetadata({
+        displayName: 'Output Path',
+        type: ArgumentType.STRING,
+        description: 'the output path to extract the .pot file to',
+        isRequired: false,
+        defaultValue: 'messages.pot'
+      })
     };
   }
 
   describe() {
+    const args = this.args();
     return {
       displayName: 'Extract Translations',
-      params: this.args()
+      params: Object.keys(args).reduce((params, alias) => {
+        params[alias] = args[alias].serialize();
+        return params;
+      }, {})
     };
   }
 

--- a/src/models/commands/argumentmetadata.js
+++ b/src/models/commands/argumentmetadata.js
@@ -13,7 +13,8 @@ Object.freeze(ArgumentType);
  * the type of the argument's values, if it is required, and an optional default.
  */
 class ArgumentMetadata {
-  constructor(type, description, isRequired, defaultValue) {
+  constructor({ type, description, isRequired, defaultValue, displayName }) {
+    this._displayName = displayName;
     this._type = type;
     this._isRequired = isRequired;
     this._defaultValue = defaultValue;
@@ -42,11 +43,29 @@ class ArgumentMetadata {
   }
 
   /**
-   * @returns {string|boolean|number} Optional, a default value for the argument. 
+   * @returns {string|boolean|number} Optional, a default value for the argument.
    */
   defaultValue() {
     return this._defaultValue;
   }
 
+  /**
+   * @returns {string} The display name for the argument.
+   */
+  getDisplayName() {
+    return this._displayName;
+  }
+
+  /**
+   * @returns {Object} The serialized ArgumentMetadata
+   */
+  serialize() {
+    return {
+      displayName: this.getDisplayName(),
+      type: this.getType(),
+      required: this.isRequired(),
+      default: this.defaultValue(),
+    }
+  }
 }
 module.exports = { ArgumentMetadata, ArgumentType };

--- a/src/models/commands/argumentmetadata.js
+++ b/src/models/commands/argumentmetadata.js
@@ -57,15 +57,17 @@ class ArgumentMetadata {
   }
 
   /**
-   * @returns {Object} The serialized ArgumentMetadata
+   * Returns an Object with the keys expected by the Jambo describe command
+   *
+   * @returns {Object}
    */
-  serialize() {
+  toDescribeFormat() {
     return {
       displayName: this.getDisplayName(),
       type: this.getType(),
       required: this.isRequired(),
       default: this.defaultValue(),
-    }
+    };
   }
 }
 module.exports = { ArgumentMetadata, ArgumentType };

--- a/src/models/commands/argumentmetadata.js
+++ b/src/models/commands/argumentmetadata.js
@@ -49,4 +49,4 @@ class ArgumentMetadata {
   }
 
 }
-exports = { ArgumentMetadata, ArgumentType };
+module.exports = { ArgumentMetadata, ArgumentType };

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -81,10 +81,29 @@ const mockDirectAnswerCardCommand = {
   }
 }
 
+const mockExtractTranslationsCommand = {
+  getAlias() {
+    return 'extract-translations';
+  },
+  describe() {
+    return {
+      displayName: 'Extract Translations',
+      params: {
+        output: { displayName: 'Output Path' }
+      }
+    };
+  }
+};
 
 describe('DescribeCommand works correctly', () => {
   new DescribeCommand(
-    () => [ mockCardCommand, mockDirectAnswerCardCommand ], mockRepoReader).execute();
+    () => [
+      mockExtractTranslationsCommand,
+      mockCardCommand,
+      mockDirectAnswerCardCommand
+    ],
+    mockRepoReader
+  ).execute();
   const descriptions = consoleSpy.mock.calls[0][0];
 
   it('describes all jambo commands and nothing more', () => {
@@ -96,7 +115,8 @@ describe('DescribeCommand works correctly', () => {
       'override',
       'upgrade',
       'card',
-      'directanswercard'
+      'directanswercard',
+      'extract-translations'
     ].sort();
     const actualCommandNames = Object.keys(descriptions).sort();
     expect(actualCommandNames).toEqual(expectedCommandNames);

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -1,4 +1,5 @@
 const DescribeCommand = require('../../../src/commands/describe/describecommand');
+const JamboTranslationExtractor = require('../../../src/commands/extract-translations/jambotranslationextractor');
 
 const mockRepoReader = {
   getImportableThemes() {
@@ -81,24 +82,12 @@ const mockDirectAnswerCardCommand = {
   }
 }
 
-const mockExtractTranslationsCommand = {
-  getAlias() {
-    return 'extract-translations';
-  },
-  describe() {
-    return {
-      displayName: 'Extract Translations',
-      params: {
-        output: { displayName: 'Output Path' }
-      }
-    };
-  }
-};
+const extractTranslationsCommand = new JamboTranslationExtractor({});
 
 describe('DescribeCommand works correctly', () => {
   new DescribeCommand(
     () => [
-      mockExtractTranslationsCommand,
+      extractTranslationsCommand,
       mockCardCommand,
       mockDirectAnswerCardCommand
     ],
@@ -255,6 +244,20 @@ describe('DescribeCommand works correctly', () => {
             'themes/answers-hitchhiker-theme/directanswercards/card1',
             'themes/answers-hitchhiker-theme/directanswercards/card2'
           ]
+        }
+      }
+    });
+  });
+
+  it('describes extract-translations', () => {
+    expect(descriptions['extract-translations']).toEqual({
+      displayName: 'Extract Translations',
+      params: {
+        output: {
+          displayName: 'Output Path',
+          required: false,
+          default: 'messages.pot',
+          type: 'string'
         }
       }
     });


### PR DESCRIPTION
Convert existing extract-translations command into a class that implements Jambo's new 'Command' interface.

TEST=manual

Run `jambo --help`, see `jambo extract-translations  extract translated strings from .hbs and .js files` in the list of commands.
Run `jambo extract-translations --help` and see the following printed:
```
jambo extract-translations

extract translated strings from .hbs and .js files

Options:
  --help     Show help                                                 [boolean]
  --version  Show version number                                       [boolean]
  --output   the output path to extract the .pot file to
                                              [string] [default: "messages.pot"]
```
Run `jambo describe` and see the following in the list of commands described:
```
'extract-translations': {
    displayName: 'Extract Translations',
    params: {
      output: {
        displayName: 'Output Path',
        type: 'string',
        required: false,
        default: 'messages.pot'
      }
    }
  }
```
Run `jambo extract-translations` and see `messages.pot` file generated.