### PR TITLE
Default relativePath to "." instead of ""

### DIFF
--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -94,6 +94,6 @@ module.exports = class PageWriter {
    * @returns {String}
    */
   _calculateRelativePath(filePath) {
-    return path.relative(path.dirname(filePath), '');
+    return path.relative(path.dirname(filePath), '') || '.';
   }
 }


### PR DESCRIPTION
This commit updates relativePath to be "." instead of ""
when the page output path is the root output dir.

J=SLAP-773
TEST=manual

check that on a new hh-theme page with no locale_config,
bundle.js and a favicon can load correctly