### PR TITLE
Swap order of params in CommandImporter constructor

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -21,11 +21,11 @@ const commandRegistry = new CommandRegistry(jamboConfig);
 if (jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output) {
   const commandImporter = jamboConfig.defaultTheme ?
     new CommandImporter(
-      jamboConfig.dirs.output, 
-      path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme),
-      jamboConfig) :
+      jamboConfig.dirs.output,
+      jamboConfig,
+      path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
     new CommandImporter(jamboConfig.dirs.output, jamboConfig);
-  
+
   commandImporter.import().forEach(customCommand => {
     commandRegistry.addCommand(customCommand)
   });

--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra');
  * Imports all custom {@link Command}s within a Jambo repository.
  */
 class CommandImporter {
-  constructor(outputDir, themeDir, jamboConfig) {
+  constructor(outputDir, jamboConfig, themeDir) {
     this._outputDir = outputDir;
     this._themeDir = themeDir;
     this._jamboConfig = jamboConfig;


### PR DESCRIPTION
For cases when commands are run pre-theme import, the CommandImporter would fail (an example of this is the `jambo import --theme` command). This is because the second case in [this ternary](https://github.com/yext/jambo/blob/master/src/cli.js#L27) doesn't have a theme to pass into the constructor. The theme param should be last since it's optional.

TEST=manual

Run `jambo import --theme answers-hitchhiker-theme` before this, see error. Run again after, see theme import successfully.