### PR TITLE
Canonicalize locales

### DIFF
--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -1,4 +1,5 @@
 const { NO_LOCALE } = require('../constants');
+const { canonicalizeLocale } = require('../utils/i18nutils');
 const UserError = require('../errors/usererror');
 
 /**
@@ -25,7 +26,11 @@ module.exports = class LocalizationConfig {
      *   ...
      * }
      */
-    this._localeToConfig = config.localeConfig || {};
+    this._localeToConfig = {};
+    for (const [localeCode, localeConfig] of Object.entries(config.localeConfig || {})) {
+      const normalizedLocale = canonicalizeLocale(localeCode);
+      this._localeToConfig[normalizedLocale] = localeConfig;
+    };
 
     if (this.hasConfig() && !this._localeToConfig[this._defaultLocale]) {
       throw new UserError(

--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -84,9 +84,8 @@ module.exports = class LocalizationConfig {
    * @returns {function}
    */
   getUrlFormatter(locale) {
-    // TODO (agrow) this assumes language and region are separated by a "-" (e.g. en-us)
     const language = locale
-      ? locale.substring(0, locale.lastIndexOf('-')) || locale
+      ? locale.substring(0, locale.indexOf('-')) || locale
       : '';
     const basicUrlPattern = locale === this._defaultLocale
       ? this._defaultUrlPattern

--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -84,7 +84,7 @@ module.exports = class LocalizationConfig {
    * @returns {function}
    */
   getUrlFormatter(locale) {
-    const language = locale.split('-')[0];
+    const language = locale.split('_')[0];
     const basicUrlPattern = locale === this._defaultLocale
       ? this._defaultUrlPattern
       : this._baseLocalePattern;

--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -84,7 +84,7 @@ module.exports = class LocalizationConfig {
    * @returns {function}
    */
   getUrlFormatter(locale) {
-    // TODO (agrow) this assumes language and region are separated by a "-" (e.g. en-US)
+    // TODO (agrow) this assumes language and region are separated by a "-" (e.g. en-us)
     const language = locale
       ? locale.substring(0, locale.lastIndexOf('-')) || locale
       : '';

--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -84,9 +84,7 @@ module.exports = class LocalizationConfig {
    * @returns {function}
    */
   getUrlFormatter(locale) {
-    const language = locale
-      ? locale.substring(0, locale.indexOf('-')) || locale
-      : '';
+    const language = locale.split('-')[0];
     const basicUrlPattern = locale === this._defaultLocale
       ? this._defaultUrlPattern
       : this._baseLocalePattern;

--- a/src/models/pagetemplate.js
+++ b/src/models/pagetemplate.js
@@ -1,4 +1,5 @@
 const { stripExtension } = require('../utils/fileutils');
+const { canonicalizeLocale } = require('../utils/i18nutils');
 const { NO_LOCALE } = require('../constants');
 
 /**
@@ -96,6 +97,7 @@ module.exports = class PageTemplate {
    */
   static parseLocale(filename) {
     const pageParts = stripExtension(stripExtension(filename)).split('.');
-    return pageParts.length > 1 && pageParts[1];
+    const locale = pageParts.length > 1 && pageParts[1];
+    return canonicalizeLocale(locale);
   }
 }

--- a/src/utils/configutils.js
+++ b/src/utils/configutils.js
@@ -1,3 +1,4 @@
+const { canonicalizeLocale } = require('./i18nutils');
 /**
  * Parses the locale from a given configName
  *
@@ -6,13 +7,14 @@
  */
 parseLocale = function(configName) {
   const configNameParts = configName.split('.');
-  return configNameParts.length > 1 && configNameParts[1];
+  const locale = configNameParts.length > 1 && configNameParts[1];
+  return canonicalizeLocale(locale);
 }
 exports.parseLocale = parseLocale;
 
 /**
  * Returns true if the provided configName contains a locale
- * 
+ *
  * @param {String} configName the file name of the config, without the extension
  * @returns {Boolean}
  */

--- a/src/utils/i18nutils.js
+++ b/src/utils/i18nutils.js
@@ -8,6 +8,18 @@ canonicalizeLocale = function(localeCode) {
   if (!localeCode) {
     return;
   }
-  return localeCode.toLowerCase();
+  const localeCodeSections = localeCode.replace('_', '-')
+    .split('-');
+
+  const languageIndex = 0;
+  const regionIndex = 1;
+
+  localeCodeSections[languageIndex] = localeCodeSections[languageIndex].toLowerCase();
+
+  if (localeCodeSections.length > regionIndex) {
+    localeCodeSections[regionIndex] = localeCodeSections[regionIndex].toUpperCase();
+  }
+
+  return localeCodeSections.join('-');
 }
 exports.canonicalizeLocale = canonicalizeLocale;

--- a/src/utils/i18nutils.js
+++ b/src/utils/i18nutils.js
@@ -8,8 +8,8 @@ canonicalizeLocale = function(localeCode) {
   if (!localeCode) {
     return;
   }
-  const localeCodeSections = localeCode.replace('_', '-')
-    .split('-');
+  const localeCodeSections = localeCode.replace('-', '_')
+    .split('_');
 
   const languageIndex = 0;
   const regionIndex = 1;
@@ -20,6 +20,6 @@ canonicalizeLocale = function(localeCode) {
     localeCodeSections[regionIndex] = localeCodeSections[regionIndex].toUpperCase();
   }
 
-  return localeCodeSections.join('-');
+  return localeCodeSections.join('_');
 }
 exports.canonicalizeLocale = canonicalizeLocale;

--- a/src/utils/i18nutils.js
+++ b/src/utils/i18nutils.js
@@ -4,7 +4,7 @@
  * @param {string} localeCode
  * @returns {string}
  */
-canonicalizeLocale = function (localeCode) {
+canonicalizeLocale = function(localeCode) {
   if (!localeCode) {
     return;
   }

--- a/src/utils/i18nutils.js
+++ b/src/utils/i18nutils.js
@@ -1,0 +1,13 @@
+/**
+ * Normalizes a locale code
+ *
+ * @param {string} localeCode
+ * @returns {string}
+ */
+canonicalizeLocale = function (localeCode) {
+  if (!localeCode) {
+    return;
+  }
+  return localeCode.toLowerCase();
+}
+exports.canonicalizeLocale = canonicalizeLocale;

--- a/tests/models/localizationconfig.js
+++ b/tests/models/localizationconfig.js
@@ -95,7 +95,7 @@ describe('Getting URL Formatting function works properly', () => {
       default: 'en',
       localeConfig: {
         en: {},
-        'en-US': {
+        en_US: {
           urlOverride: '{language}/{locale}/{pageName}.{pageExt}'
         }
       },
@@ -104,8 +104,8 @@ describe('Getting URL Formatting function works properly', () => {
         default: 'pages/{locale}/{pageName}.{pageExt}'
       }
     });
-    const complicatedFormatter = config.getUrlFormatter('en-US');
+    const complicatedFormatter = config.getUrlFormatter('en_US');
     expect(complicatedFormatter('pageName', 'pageExt'))
-      .toEqual('en/en-US/pageName.pageExt');
+      .toEqual('en/en_US/pageName.pageExt');
   });
 });

--- a/tests/models/localizationconfig.js
+++ b/tests/models/localizationconfig.js
@@ -95,7 +95,7 @@ describe('Getting URL Formatting function works properly', () => {
       default: 'en',
       localeConfig: {
         en: {},
-        'en-us': {
+        'en-US': {
           urlOverride: '{language}/{locale}/{pageName}.{pageExt}'
         }
       },
@@ -104,8 +104,8 @@ describe('Getting URL Formatting function works properly', () => {
         default: 'pages/{locale}/{pageName}.{pageExt}'
       }
     });
-    const complicatedFormatter = config.getUrlFormatter('en-us');
+    const complicatedFormatter = config.getUrlFormatter('en-US');
     expect(complicatedFormatter('pageName', 'pageExt'))
-      .toEqual('en/en-us/pageName.pageExt');
+      .toEqual('en/en-US/pageName.pageExt');
   });
 });

--- a/tests/models/localizationconfig.js
+++ b/tests/models/localizationconfig.js
@@ -95,7 +95,7 @@ describe('Getting URL Formatting function works properly', () => {
       default: 'en',
       localeConfig: {
         en: {},
-        'en-US': {
+        'en-us': {
           urlOverride: '{language}/{locale}/{pageName}.{pageExt}'
         }
       },
@@ -104,8 +104,8 @@ describe('Getting URL Formatting function works properly', () => {
         default: 'pages/{locale}/{pageName}.{pageExt}'
       }
     });
-    const complicatedFormatter = config.getUrlFormatter('en-US');
+    const complicatedFormatter = config.getUrlFormatter('en-us');
     expect(complicatedFormatter('pageName', 'pageExt'))
-      .toEqual('en/en-US/pageName.pageExt');
+      .toEqual('en/en-us/pageName.pageExt');
   });
 });

--- a/tests/models/pagetemplate.js
+++ b/tests/models/pagetemplate.js
@@ -27,7 +27,7 @@ describe('PageTemplate parses locale from filename', () => {
   });
 
   it('parses correctly when there is a locale', () => {
-    const locale = PageTemplate.parseLocale('test.fr-CH.html.hbs');
-    expect(locale).toEqual('fr-CH');
+    const locale = PageTemplate.parseLocale('test.fr_CH.html.hbs');
+    expect(locale).toEqual('fr_CH');
   });
 });

--- a/tests/models/pagetemplate.js
+++ b/tests/models/pagetemplate.js
@@ -27,7 +27,7 @@ describe('PageTemplate parses locale from filename', () => {
   });
 
   it('parses correctly when there is a locale', () => {
-    const locale = PageTemplate.parseLocale('test.fr-ch.html.hbs');
-    expect(locale).toEqual('fr-ch');
+    const locale = PageTemplate.parseLocale('test.fr-CH.html.hbs');
+    expect(locale).toEqual('fr-CH');
   });
 });

--- a/tests/models/pagetemplate.js
+++ b/tests/models/pagetemplate.js
@@ -23,11 +23,11 @@ describe('Correctly forms PageTemplate object from constructor', () => {
 describe('PageTemplate parses locale from filename', () => {
   it('parses correctly when locale is absent', () => {
     const locale = PageTemplate.parseLocale('test.html.hbs');
-    expect(locale).toEqual(false);
+    expect(locale).toBeFalsy();
   });
 
   it('parses correctly when there is a locale', () => {
-    const locale = PageTemplate.parseLocale('test.fr-CH.html.hbs');
-    expect(locale).toEqual('fr-CH');
+    const locale = PageTemplate.parseLocale('test.fr-ch.html.hbs');
+    expect(locale).toEqual('fr-ch');
   });
 });

--- a/tests/utils/i18nutils.js
+++ b/tests/utils/i18nutils.js
@@ -1,0 +1,9 @@
+const { canonicalizeLocale } = require('../../src/utils/i18nutils');
+
+describe('canonicalizeLocale correctly normalizes locales', () => {
+  it('converts to lower case', () => {
+    const locale = 'FR_CH';
+    const canonicalizedLocale = canonicalizeLocale(locale);
+    expect(canonicalizedLocale).toEqual('fr_ch');
+  });
+});

--- a/tests/utils/i18nutils.js
+++ b/tests/utils/i18nutils.js
@@ -1,7 +1,7 @@
 const { canonicalizeLocale } = require('../../src/utils/i18nutils');
 
 describe('canonicalizeLocale correctly normalizes locales', () => {
-  it('converts to language to lower case and region to upper case', () => {
+  it('converts language to lower case and region to upper case', () => {
     const locale = 'FR_ch';
     const canonicalizedLocale = canonicalizeLocale(locale);
     expect(canonicalizedLocale).toEqual('fr_CH');

--- a/tests/utils/i18nutils.js
+++ b/tests/utils/i18nutils.js
@@ -2,14 +2,14 @@ const { canonicalizeLocale } = require('../../src/utils/i18nutils');
 
 describe('canonicalizeLocale correctly normalizes locales', () => {
   it('converts to language to lower case and region to upper case', () => {
-    const locale = 'FR-ch';
+    const locale = 'FR_ch';
     const canonicalizedLocale = canonicalizeLocale(locale);
-    expect(canonicalizedLocale).toEqual('fr-CH');
+    expect(canonicalizedLocale).toEqual('fr_CH');
   });
 
-  it('converts underscores to dashes', () => {
-    const locale = 'fr_CH';
+  it('converts dashes to underscores', () => {
+    const locale = 'fr-CH';
     const canonicalizedLocale = canonicalizeLocale(locale);
-    expect(canonicalizedLocale).toEqual('fr-CH');
+    expect(canonicalizedLocale).toEqual('fr_CH');
   });
 });

--- a/tests/utils/i18nutils.js
+++ b/tests/utils/i18nutils.js
@@ -1,9 +1,15 @@
 const { canonicalizeLocale } = require('../../src/utils/i18nutils');
 
 describe('canonicalizeLocale correctly normalizes locales', () => {
-  it('converts to lower case', () => {
-    const locale = 'FR_CH';
+  it('converts to language to lower case and region to upper case', () => {
+    const locale = 'FR-ch';
     const canonicalizedLocale = canonicalizeLocale(locale);
-    expect(canonicalizedLocale).toEqual('fr_ch');
+    expect(canonicalizedLocale).toEqual('fr-CH');
+  });
+
+  it('converts underscores to dashes', () => {
+    const locale = 'fr_CH';
+    const canonicalizedLocale = canonicalizeLocale(locale);
+    expect(canonicalizedLocale).toEqual('fr-CH');
   });
 });


### PR DESCRIPTION
Adds canonicalization logic to normalize casing and locale code separators. This logic converts the language in the locale to lowercase and the region (if provided) to uppercase. Replaces dashes with underscores.

TEST=manual
J=SLAP-705

Test with varied casing in config names and page names. 