### PR TITLE
Translation loading improvements

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -389,10 +389,7 @@ exports.SitesGenerator = class {
     const translations = {};
 
     for (const locale of locales) {
-      const translationFileOverride = localizationConfig.getTranslationFile(locale);
-      const translationFileName = translationFileOverride
-        ? translationFileOverride
-        : `${locale}.po`
+      const translationFileName = localizationConfig.getTranslationFile(locale) || `${locale}.po`;
       const translationFilePath = path.join(translationsDir, translationFileName);
       const isDefaultLocale = (locale === localizationConfig.getDefaultLocale());
       if (!isDefaultLocale && fs.existsSync(translationFilePath)) {

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -423,8 +423,8 @@ exports.SitesGenerator = class {
       const translationFileName = `${locale}.po`;
       const translationFilePath = path.join(themeTranslationsDir, translationFileName);
       if (fs.existsSync(translationFilePath)) {
-        const localeTranslations = 
-          await localFileParser.fetch(locale, translationFileName);
+        const localeTranslations = await localFileParser
+          .fetch(locale, translationFileName);
         translations[locale] = { translation: localeTranslations };
       }
     }

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -127,9 +127,8 @@ exports.SitesGenerator = class {
 
     console.log('Extracting translations');
     const locales = GENERATED_DATA.getLocales();
-    const translations = config.dirs.translations
-      ? await this._extractTranslations(locales, configRegistry.getLocalizationConfig())
-      : {};
+    const translations = 
+      await this._extractTranslations(locales, configRegistry.getLocalizationConfig());
 
     // Register needed Handlebars helpers.
     console.log('Registering Jambo Handlebars helpers');
@@ -380,11 +379,16 @@ exports.SitesGenerator = class {
    * @returns {Object<string, Object>} A map of locale to formatted translations.
    */
   async _extractCustomTranslations(locales, localizationConfig) {
-    const localFileParser = new LocalFileParser(this.config.dirs.translations);
+    const translationsDir = this.config.dirs.translations
+      ? this.config.dirs.translations
+      : 'translations';
+
+    const localFileParser = new LocalFileParser(translationsDir);
     const translations = {};
 
     for (const locale of locales) {
-      if (locale !== localizationConfig.getDefaultLocale()) {
+      const isDefaultLocale = (locale === localizationConfig.getDefaultLocale());
+      if (!isDefaultLocale) {
         const localeTranslations = await localFileParser
           .fetch(locale, localizationConfig.getTranslationFile(locale));
         translations[locale] = { translation: localeTranslations };

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -389,7 +389,8 @@ exports.SitesGenerator = class {
     const translations = {};
 
     for (const locale of locales) {
-      const translationFileName = localizationConfig.getTranslationFile(locale) || `${locale}.po`;
+      const translationFileName = 
+        localizationConfig.getTranslationFile(locale) || `${locale}.po`;
       const translationFilePath = path.join(translationsDir, translationFileName);
       const isDefaultLocale = (locale === localizationConfig.getDefaultLocale());
       if (!isDefaultLocale && fs.existsSync(translationFilePath)) {

--- a/src/i18n/translationfetchers/localfileparser.js
+++ b/src/i18n/translationfetchers/localfileparser.js
@@ -21,28 +21,22 @@ class LocalFileParser {
   }
 
   /**
-   * Extracts a locale's translations from the local filesystem. If just locale is passed
-   * and the translation file doesn't exist, an empty object is returned. If a
-   * translationFilePath is specified and the translation files doesn't exist, the
-   * function rejects with a promise
+   * Extracts a locale's translations from the local filesystem. If the translation file
+   * doesn't exist, the function rejects with an error
    *
    * @param {string} locale The desired locale.
    * @param {string} translationFilePath The path to the translation file locale within
-   *                                     the translations directory; if not present,
-   *                                     defaults to [locale].po
+   *                                     the translations directory
    * @returns {Promise<Object>} A Promise containing the parsed translations in
    *                            i18next format.
   */
   async fetch(locale, translationFilePath) {
-    const fileName = translationFilePath || `${locale}.po`;
-    const translationFile = path.join(this._translationsDir, fileName);
+    const translationFile = path.join(this._translationsDir, translationFilePath);
     const translationFileExists = existsSync(translationFile);
 
-    if (!translationFileExists && !!translationFilePath) {
+    if (!translationFileExists) {
       throw new UserError(
         `Cannot find translation file for '${locale}' at '${translationFile}'`);
-    } else if (!translationFileExists) {
-      return {};
     }
 
     const localeTranslations =

--- a/src/i18n/translationfetchers/localfileparser.js
+++ b/src/i18n/translationfetchers/localfileparser.js
@@ -21,8 +21,10 @@ class LocalFileParser {
   }
 
   /**
-   * Extracts a locale's translations from the local filesystem. If no such
-   * translations exist, an empty object is returned.
+   * Extracts a locale's translations from the local filesystem. If just locale is passed
+   * and the translation file doesn't exist, an empty object is returned. If a
+   * translationFilePath is specified and the translation files doesn't exist, the
+   * function rejects with a promise
    *
    * @param {string} locale The desired locale.
    * @param {string} translationFilePath The path to the translation file locale within
@@ -34,9 +36,13 @@ class LocalFileParser {
   async fetch(locale, translationFilePath) {
     const fileName = translationFilePath || `${locale}.po`;
     const translationFile = path.join(this._translationsDir, fileName);
-    if (!existsSync(translationFile)) {
+    const translationFileExists = existsSync(translationFile);
+
+    if (!translationFileExists && !!translationFilePath) {
       throw new UserError(
         `Cannot find translation file for '${locale}' at '${translationFile}'`);
+    } else if (!translationFileExists) {
+      return {};
     }
 
     const localeTranslations =

--- a/tests/i18n/translationfetchers/localfileparser.js
+++ b/tests/i18n/translationfetchers/localfileparser.js
@@ -47,12 +47,12 @@ describe('LocalFileParser works correctly', () => {
       'The: dog': 'Le: chien'
     };
 
-    return localFileParser.fetch('fr-FR').then(translations => {
+    return localFileParser.fetch('fr-FR', 'fr-FR.po').then(translations => {
       expect(translations).toStrictEqual(expectedTranslations);
     })
   });
 
   it('Rejects with an error when no translation file exists for the locale', () => {
-    expect(localFileParser.fetch('es')).rejects.toThrow(UserError);
+    expect(localFileParser.fetch('es', 'es.po')).rejects.toThrow(UserError);
   })
 });

--- a/tests/i18n/translator/translator.js
+++ b/tests/i18n/translator/translator.js
@@ -9,8 +9,8 @@ describe('translations with one plural form (French)', () => {
     const translationsPath = path.join(__dirname, '../../fixtures/translations');
     const localFileParser = new LocalFileParser(translationsPath);
 
-    const frFRTranslations = await localFileParser.fetch('fr-FR');
-    const frTranslations = await localFileParser.fetch('fr');
+    const frFRTranslations = await localFileParser.fetch('fr-FR', 'fr-FR.po');
+    const frTranslations = await localFileParser.fetch('fr', 'fr.po');
     const translations = {
       fr: { translation: frTranslations },
       'fr-FR': { translation: frFRTranslations },
@@ -221,7 +221,7 @@ describe('translations with multiple plural forms (Lithuanian)', () => {
     const translationsPath = path.join(__dirname, '../../fixtures/translations');
     const localFileParser = new LocalFileParser(translationsPath);
 
-    const ltLT_Translations = await localFileParser.fetch('lt-LT');
+    const ltLT_Translations = await localFileParser.fetch('lt-LT', 'lt-LT.po');
     const translations = {
       'lt-LT': { translation: ltLT_Translations }
     }


### PR DESCRIPTION
Modify translation file loading so that all custom translation files are not strictly necessary

Modify localFileParser so that it no longer tries to default the file name if just a locale is provided. Modify the site generator to always load theme translations, and to only load custom translations if the "translations" dir is configured. A custom translation file for each configured locale is no longer required.

J=SLAP-706
TEST=manual

Test a jambo build with and without custom translation dirs and custom translations file paths. Confirm translations are correct. Test that only some of the translation files for the configured locales can be present when building a site.