### PR TITLE
Canonicalize the default locale

### DIFF
--- a/src/models/localizationconfig.js
+++ b/src/models/localizationconfig.js
@@ -12,7 +12,7 @@ module.exports = class LocalizationConfig {
    */
   constructor(rawLocalizationConfig) {
     const config = rawLocalizationConfig || {};
-    this._defaultLocale = config.default || NO_LOCALE;
+    this._defaultLocale = canonicalizeLocale(config.default) || NO_LOCALE;
 
     /**
      * localeToConfig is an Object mapping locale to configuration


### PR DESCRIPTION
Was running into this issue on SGS, using a the locale_config
from the diageo repo, which had a non canonical default locale.

J=SLAP-776
TEST=manual

see that builds run again