### PR TITLE
Use ensureDirSync for merging jambo custom commands

### DIFF
--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -55,7 +55,7 @@ class CommandImporter {
     if (fs.existsSync(mergedDirectory)) {
       fs.removeSync(mergedDirectory);
     }
-    fs.mkdirSync(mergedDirectory);
+    fs.ensureDirSync(mergedDirectory);
     directories.forEach(directory => fs.copySync(directory, mergedDirectory));
 
     return mergedDirectory;


### PR DESCRIPTION
Updates the command importer to use ensureDirSync
from fs-extra instead of regular mkdirSync. The
live preview containers don't have a output
directory, since it's not tracked.

J=SLAP-776
TEST=manual

tested that SGS live preview works again