### PR TITLE
commands: give upgrade command optional branch arg

### DIFF
--- a/src/commands/describe/describecommand.js
+++ b/src/commands/describe/describecommand.js
@@ -55,8 +55,6 @@ module.exports = class DescribeCommand {
         }
       }
     );
-    return Promise.all(describePromises).then(
-      () => descriptions
-    );
+    return Promise.all(describePromises).then(() => descriptions);
   }
 }

--- a/src/commands/describe/describecommand.js
+++ b/src/commands/describe/describecommand.js
@@ -29,8 +29,8 @@ module.exports = class DescribeCommand {
     return {};
   }
 
-  execute() {
-    console.dir(this._getCommandDescriptions(), {
+  async execute() {
+    console.dir(await this._getCommandDescriptions(), {
       depth: null,
       maxArrayLength: null
     });
@@ -41,11 +41,22 @@ module.exports = class DescribeCommand {
    */
   _getCommandDescriptions() {
     const descriptions = {};
-    for (const command of this.getCommands()) {
-      if (command.getAlias() !== 'describe') {
-        descriptions[command.getAlias()] = command.describe();
+    const describePromises = this.getCommands().map(
+      command => {
+        const describeValue = command.describe();
+        if (describeValue.then && typeof describeValue.then === 'function') {
+          return describeValue.then(
+            (value) => { descriptions[command.getAlias()] = value; }
+          );
+        } else {
+          if (command.getAlias() !== 'describe') {
+            descriptions[command.getAlias()] = describeValue;
+          }
+        }
       }
-    }
-    return descriptions;
+    );
+    return Promise.all(describePromises).then(
+      () => descriptions
+    );
   }
 }

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -78,7 +78,10 @@ class ThemeUpgrader {
     const branchesGit = simpleGit(
       path.join(this._themesDir, this.jamboConfig.defaultTheme));
     const branches = await branchesGit.branch(['--remote']);
-    return branches.all.map(branch => branch.replace('origin/', ''))
+    return branches.all.map(branch => 
+      // regex replaces 'origin/' only at the beginning of a string
+      branch.replace(/^(origin\/)/, '')
+    );
   }
 
   execute(args) {

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -151,8 +151,8 @@ class ThemeUpgrader {
   /**
    * Calls "git update --remote" on the given submodule path, which
    * updates the given submodule to the most recent version of the branch
-   * it is set to track (defaults to master). If a branch is specified,
-   * the given submodule will be updated to the provided branch.
+   * it is set to track. If a branch is specified, the given submodule 
+   * will be updated to the provided branch.
    * @param {string} submodulePath
    * @param {string} branch
    */

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -100,7 +100,7 @@ class ThemeUpgrader {
    * @param {string} themeName The name of the theme
    * @param {boolean} disableScript Whether to run the upgrade script
    * @param {boolean} isLegacy Whether to use the isLegacy flag in the upgrade script
-   * @param {string} branch The nameo of the branch to upgrade to
+   * @param {string} branch The name of the branch to upgrade to
    */
   async _upgrade({ themeName, disableScript, isLegacy, branch }) {
     const themePath = path.join(this._themesDir, themeName);

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -25,12 +25,15 @@ const mockInitCommand = {
 }
 
 describe('DescribeCommand works correctly', () => {
-  new DescribeCommand(
-    () => [
-      mockInitCommand,
-    ],
-  ).execute();
-  const descriptions = consoleSpy.mock.calls[0][0];
+  let descriptions;
+  beforeAll(async () => {
+    await new DescribeCommand(
+      () => [
+        mockInitCommand,
+      ],
+    ).execute();
+    descriptions = consoleSpy.mock.calls[0][0];
+  })
 
   it('describes all provided commands and nothing more', () => {
     const expectedCommandNames = [


### PR DESCRIPTION
Makes changes to provide the `jambo upgrade` command an optional
`branch` argument. This argument will specify a branch to upgrade
the theme to, instead of always upgrading to the HEAD of master.

J=SLAP-789
TEST=manual
Performed a `jambo upgrade --branch [branch_name]` using several
different branches to verify that the theme was upgraded to have
changes from the specified branch.