### PR TITLE
Fix bug preventing 'init' from working properly.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -20,7 +20,7 @@ const git = simpleGit();
 class ThemeUpgrader {
   constructor(jamboConfig) {
     this.jamboConfig = jamboConfig;
-    this._themesDir = jamboConfig.dirs.themes;
+    this._themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
     this.upgradeScript = 'upgrade.js';
   }
 


### PR DESCRIPTION
The Jambo 'init' command was not working properly after cutting over all
built-in commands to the CommandRegistry. When 'init' (or any other command)
is run, Jambo first attempts to instantiate all the built-in commands. This
is done in the CommandRegistry. Unfortunately, the ThemeUpgrader command could
not be created without a 'jambo.json', leading to a Catch 22. This then led
to the registry erroring out and the 'init' command failing to proceed. To fix
this, we make it so that the ThemeUpgrader can be safely created before 'init'
is run.

The current pattern in CommandRegistry._initialize is okay for now. When run,
the commands already graceully handle failures like a missing 'jambo.json'.
Long term, I think the real fix here is to change our pattern. In the Command
interface, we can change all methods besides 'execute' to be static. That way,
the registry doesn't actually need to instantiate a command until it's run.

TEST=manual

Made sure that I could succesfully run a 'jambo init'.