### PR TITLE
page cmd: add locales argument

### DIFF
--- a/src/commands/commandregistry.js
+++ b/src/commands/commandregistry.js
@@ -45,7 +45,7 @@ class CommandRegistry {
 
   /**
    * Initializes the registry with the built-in Jambo commands: init, import, page,
-   * override, build, and upgrade.
+   * override, build, upgrade, describe, and extract-tranlations.
    *
    * @returns {Map<string, Command>} The built-in commmands, keyed by name.
    */

--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -34,12 +34,19 @@ class PageCommand {
         type: ArgumentType.STRING,
         description: 'template to use within theme',
         isRequired: false
+      }),
+      locales: new ArgumentMetadata({
+        type: ArgumentType.ARRAY,
+        itemType: ArgumentType.STRING,
+        description: 'locales the page should support',
+        isRequired: false
       })
     }
   }
 
   describe() {
     const pageTemplates = this._getPageTemplates();
+    const pageLocales = this._getPageLocales();
     return {
       displayName: 'Add Page',
       params: {
@@ -52,13 +59,18 @@ class PageCommand {
           displayName: 'Page Template',
           type: 'singleoption',
           options: pageTemplates
+        },
+        locales: {
+          displayName: 'Page Locales',
+          type: 'multioption',
+          options: pageLocales
         }
       }
     }
   }
 
   /**
-   * @returns {Array<string>}
+   * @returns {Array<string>} The page templates available in the theme
    */
   _getPageTemplates() {
     if (!this.defaultTheme || !this.themesDir) {
@@ -66,6 +78,28 @@ class PageCommand {
     }
     const pageTemplatesDir = path.resolve(this.themesDir, this.defaultTheme, 'templates');
     return fs.readdirSync(pageTemplatesDir);
+  }
+  
+  /**
+   * @returns {Array<string>} The locales that are configured in locale_configs.json
+   */
+  _getPageLocales() {
+    const configDir = this.jamboConfig.dirs.config;
+    const localeConfig = path.resolve(configDir, 'locale_config.json');
+    if (!configDir || ! localeConfig) {
+      return [];
+    }
+
+    const pageLocales = [];
+    const localeContentsRaw = fs.readFileSync(localeConfig);
+    const localeContentsJson = JSON.parse(localeContentsRaw);
+    for (const locale in localeContentsJson.localeConfig) {
+      // a page has 'en' locale by default, so it won't be listed as an option
+      if (locale !== 'en') {
+        pageLocales.push(locale);
+      }
+    }
+    return pageLocales;
   }
 
   execute(args) {

--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -46,7 +46,7 @@ class PageCommand {
 
   describe() {
     const pageTemplates = this._getPageTemplates();
-    const pageLocales = this._getPageLocales();
+    const pageLocales = this._getAdditionalPageLocales();
     return {
       displayName: 'Add Page',
       params: {
@@ -81,29 +81,32 @@ class PageCommand {
   }
   
   /**
-   * @returns {Array<string>} The locales that are configured in locale_config.json
+   * @returns {Array<string>} The additional locales that are configured in 
+   *                          locale_config.json
    */
-  _getPageLocales() {
+  _getAdditionalPageLocales() {
     const configDir = this.jamboConfig.dirs.config;
     if (!configDir) {
       return [];
     }
     const localeConfig = path.resolve(configDir, 'locale_config.json');
-    if (!localeConfig) {
+    try {
+      if (fs.existsSync(localeConfig)) {
+        const pageLocales = [];
+        const localeContentsRaw = fs.readFileSync(localeConfig);
+        const localeContentsJson = JSON.parse(localeContentsRaw);
+        const defaultLocale = localeContentsJson.default;
+        for (const locale in localeContentsJson.localeConfig) {
+          // don't list the default locale as an option
+          if (locale !== defaultLocale) {
+            pageLocales.push(locale);
+          }
+        }
+        return pageLocales;
+      }
+    } catch(err) {
       return [];
     }
-
-    const pageLocales = [];
-    const localeContentsRaw = fs.readFileSync(localeConfig);
-    const localeContentsJson = JSON.parse(localeContentsRaw);
-    const defaultLocale = localeContentsJson.default;
-    for (const locale in localeContentsJson.localeConfig) {
-      // don't list the default locale as an option
-      if (locale !== defaultLocale) {
-        pageLocales.push(locale);
-      }
-    }
-    return pageLocales;
   }
 
   execute(args) {

--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -38,7 +38,7 @@ class PageCommand {
       locales: new ArgumentMetadata({
         type: ArgumentType.ARRAY,
         itemType: ArgumentType.STRING,
-        description: 'locales to generate the page for',
+        description: 'additional locales to generate the page for',
         isRequired: false
       })
     }
@@ -61,7 +61,7 @@ class PageCommand {
           options: pageTemplates
         },
         locales: {
-          displayName: 'Page Locales',
+          displayName: 'Additional Page Locales',
           type: 'multioption',
           options: pageLocales
         }

--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -38,7 +38,7 @@ class PageCommand {
       locales: new ArgumentMetadata({
         type: ArgumentType.ARRAY,
         itemType: ArgumentType.STRING,
-        description: 'locales the page should support',
+        description: 'locales to generate the page for',
         isRequired: false
       })
     }
@@ -81,7 +81,7 @@ class PageCommand {
   }
   
   /**
-   * @returns {Array<string>} The locales that are configured in locale_configs.json
+   * @returns {Array<string>} The locales that are configured in locale_config.json
    */
   _getPageLocales() {
     const configDir = this.jamboConfig.dirs.config;

--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -85,17 +85,21 @@ class PageCommand {
    */
   _getPageLocales() {
     const configDir = this.jamboConfig.dirs.config;
+    if (!configDir) {
+      return [];
+    }
     const localeConfig = path.resolve(configDir, 'locale_config.json');
-    if (!configDir || ! localeConfig) {
+    if (!localeConfig) {
       return [];
     }
 
     const pageLocales = [];
     const localeContentsRaw = fs.readFileSync(localeConfig);
     const localeContentsJson = JSON.parse(localeContentsRaw);
+    const defaultLocale = localeContentsJson.default;
     for (const locale in localeContentsJson.localeConfig) {
-      // a page has 'en' locale by default, so it won't be listed as an option
-      if (locale !== 'en') {
+      // don't list the default locale as an option
+      if (locale !== defaultLocale) {
         pageLocales.push(locale);
       }
     }

--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -105,7 +105,7 @@ class PageCommand {
     try {
       localeContentsJson = JSON.parse(localeContentsRaw);
     } catch(err) {
-      throw new UserError('locale_config.json is not formatted properly ', err.stack);
+      throw new UserError('Could not parse locale_config.json ', err.stack);
     }
     const defaultLocale = localeContentsJson.default;
     for (const locale in localeContentsJson.localeConfig) {

--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -85,28 +85,36 @@ class PageCommand {
    *                          locale_config.json
    */
   _getAdditionalPageLocales() {
+    if (!this.jamboConfig) {
+      return [];
+    }
+
     const configDir = this.jamboConfig.dirs.config;
     if (!configDir) {
       return [];
     }
+
     const localeConfig = path.resolve(configDir, 'locale_config.json');
-    try {
-      if (fs.existsSync(localeConfig)) {
-        const pageLocales = [];
-        const localeContentsRaw = fs.readFileSync(localeConfig);
-        const localeContentsJson = JSON.parse(localeContentsRaw);
-        const defaultLocale = localeContentsJson.default;
-        for (const locale in localeContentsJson.localeConfig) {
-          // don't list the default locale as an option
-          if (locale !== defaultLocale) {
-            pageLocales.push(locale);
-          }
-        }
-        return pageLocales;
-      }
-    } catch(err) {
+    if (!fs.existsSync(localeConfig)) {
       return [];
     }
+
+    const pageLocales = [];
+    const localeContentsRaw = fs.readFileSync(localeConfig);
+    let localeContentsJson;
+    try {
+      localeContentsJson = JSON.parse(localeContentsRaw);
+    } catch(err) {
+      throw new UserError('locale_config.json is not formatted properly ', err.stack);
+    }
+    const defaultLocale = localeContentsJson.default;
+    for (const locale in localeContentsJson.localeConfig) {
+      // don't list the default locale as an option
+      if (locale !== defaultLocale) {
+        pageLocales.push(locale);
+      }
+    }
+    return pageLocales;
   }
 
   execute(args) {

--- a/src/commands/page/add/pageconfiguration.js
+++ b/src/commands/page/add/pageconfiguration.js
@@ -3,11 +3,13 @@
  * needed to create a new page in a Jambo repository.
  */
 class PageConfiguration {
-  constructor({ name, layout, theme, template }) {
+  
+constructor({ name, layout, theme, template, locales }) {
     this._name = name;
     this._layout = layout;
     this._theme = theme;
     this._template = template;
+    this._locales = locales;
   }
 
   getName() {
@@ -24,6 +26,10 @@ class PageConfiguration {
 
   getTemplate() {
     return this._template;
+  }
+
+  getLocales() {
+    return this._locales;
   }
 }
 

--- a/src/commands/page/add/pagescaffolder.js
+++ b/src/commands/page/add/pagescaffolder.js
@@ -15,6 +15,7 @@ class PageScaffolder {
     const theme = pageConfiguration.getTheme();
     const template = pageConfiguration.getTemplate();
     const layout = pageConfiguration.getLayout();
+    const locales = pageConfiguration.getLocales();
 
     const htmlFilePath = `${this.config.dirs.pages}/${name}.html.hbs`;
     const configFilePath = `${this.config.dirs.config}/${name}.json`;
@@ -32,6 +33,15 @@ class PageScaffolder {
       fs.writeFileSync(htmlFilePath, '');
     }
     fs.writeFileSync(configFilePath, stringify(configContents, null, 2));
+
+    if (locales) {
+      locales.forEach(locale => this._createConfigForLocale(name, locale));
+    }
+  }
+
+  _createConfigForLocale(name, locale) {
+    const configFilePath = `${this.config.dirs.config}/${name}.${locale}.json`;
+    fs.writeFileSync(configFilePath, '{}');
   }
 }
 module.exports = PageScaffolder;


### PR DESCRIPTION
Adds a locales argument that can be passed into the page command.
The locales argument takes an array of locales, e.g. es, fr, it.

The page command's describe method returns an array of locales
found in config/locale_config.json.

J=SLAP-793
TEST=manual
When I run `jambo page` with the locales arg, such as
`jambo page --name test-locales --template vertical-standard --locales es fr`,
I see that es and fr configs are created for the test-locales in page in
addition to test-locales.json.
When I run `jambo describe` in a repo that has a locale_config.json
file with es and fr locales, I see that the page command returns
es and fr as options for the locales arg.