### PR TITLE
themeimporter: Add formatters-custom.js as static file

### DIFF
--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -158,6 +158,16 @@ class ThemeImporter{
           `${siteStaticDir}/scss/${fileName}`);
       });
 
+      const jsFiles = [
+        'formatters-custom.js'
+      ];
+
+      jsFiles.forEach(fileName => {
+        copyFileIfExists(
+          `${staticAssetsPath}/js/${fileName}`,
+          `${siteStaticDir}/js/${fileName}`);
+      });
+
       const topLevelStaticFiles = [
         'Gruntfile.js',
         'webpack-config.js',


### PR DESCRIPTION
We add formatters-custom.js so HHs can update the file without having to
override the theme.

In the future, hopefully changes like this will only have to be in the
theme with the power of our new custom commands

J=SLAP-810
TEST=manual

On a new site that's been `jambo init`ed, import the HH theme. Make sure
that the js folder exists in the top-level static folder and that it has
the formatter-custom.js file. (In my case, formatters-custom didn't
already exist yet so I tested with formatters.js).