### PR TITLE
upgrade command: return empty array for branches if no jambo config

### DIFF
--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -75,6 +75,9 @@ class ThemeUpgrader {
   }
 
   async _getThemeBranches() {
+    if (!this._themesDir) {
+      return [];
+    }
     const branchesGit = simpleGit(
       path.join(this._themesDir, this.jamboConfig.defaultTheme));
     const branches = await branchesGit.branch(['--remote']);


### PR DESCRIPTION
When there is no jambo config present and we are attempting to get
a theme's branches, the method should return an empty array.

This prevents an issue of running `jambo describe` and getting an
error before `jambo init` is run in a directory.

TEST=manual
Ran a `jambo describe` in an empty directory and see that results
are returned instead of an error.