### PR TITLE
page command: use comment-json to parse locale_config.json

### DIFF
--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { parse } = require('comment-json');
 const PageConfiguration = require ('./pageconfiguration');
 const UserError = require('../../../errors/usererror');
 const { ArgumentMetadata, ArgumentType } = require('../../../models/commands/argumentmetadata');
@@ -100,10 +101,10 @@ class PageCommand {
     }
 
     const pageLocales = [];
-    const localeContentsRaw = fs.readFileSync(localeConfig);
+    const localeContentsRaw = fs.readFileSync(localeConfig, 'utf-8');
     let localeContentsJson;
     try {
-      localeContentsJson = JSON.parse(localeContentsRaw);
+      localeContentsJson = parse(localeContentsRaw);
     } catch(err) {
       throw new UserError('Could not parse locale_config.json ', err.stack);
     }


### PR DESCRIPTION
Makes a change to use the comment-json package's parse function
when parsing locales from locale_config.json.

We need to use the comment-json package because the default
imported locale_config.json contains comments, which the
built-in JSON.parse thinks is invalid.

TEST=manual
Ran `jambo describe` in a repo that has a locale_config.json with
comments and saw that no errors occurred and that the locales
were returned correctly.