### PR TITLE
commands: all methods except execute are static

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -33,6 +33,6 @@ if (jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output) {
   });
 }
 
-const yargsFactory = new YargsFactory(commandRegistry);
+const yargsFactory = new YargsFactory(commandRegistry, jamboConfig);
 const options = yargsFactory.createCLI();
 options.argv;

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,9 +24,8 @@ if (jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output) {
   const commandImporter = jamboConfig.defaultTheme ?
     new CommandImporter(
       jamboConfig.dirs.output,
-      jamboConfig,
       path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
-    new CommandImporter(jamboConfig.dirs.output, jamboConfig);
+    new CommandImporter(jamboConfig.dirs.output);
 
   commandImporter.import().forEach(customCommand => {
     commandRegistry.addCommand(customCommand)

--- a/src/commands/build/buildcommand.js
+++ b/src/commands/build/buildcommand.js
@@ -11,15 +11,15 @@ class BuildCommand {
     this.sitesGenerator = sitesGenerator;
   }
 
-  getAlias() {
+  static getAlias() {
     return 'build';
   }
 
-  getShortDescription() {
+  static getShortDescription() {
     return 'build the static pages for the site';
   }
 
-  args() {
+  static args() {
     return {
       jsonEnvVars: new ArgumentMetadata({
         type: ArgumentType.ARRAY,
@@ -30,7 +30,7 @@ class BuildCommand {
     }
   }
 
-  describe() {
+  static describe() {
     return {
       displayName: 'Build Pages'
     }

--- a/src/commands/build/buildcommand.js
+++ b/src/commands/build/buildcommand.js
@@ -1,6 +1,6 @@
-const { SitesGenerator } = require('./sitesgenerator');
 const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argumentmetadata');
 const UserError = require('../../errors/usererror');
+const { isCustomError } = require('../../utils/errorutils');
 
 /**
  * BuildCommand builds all pages in the Jambo repo and places them in the

--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -31,7 +31,6 @@ class CommandImporter {
         .map(directoryPath => path.resolve(mergedDirectory, directoryPath))
         .filter(directoryPath => fs.lstatSync(directoryPath).isFile())
         .map(require)
-        .map(commandFn => commandFn(this._jamboConfig));
 
       // Remove the merged commands directory from 'public' as it is no longer needed.
       fs.removeSync(mergedDirectory);

--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -5,10 +5,9 @@ const fs = require('fs-extra');
  * Imports all custom {@link Command}s within a Jambo repository.
  */
 class CommandImporter {
-  constructor(outputDir, jamboConfig, themeDir) {
+  constructor(outputDir, themeDir) {
     this._outputDir = outputDir;
     this._themeDir = themeDir;
-    this._jamboConfig = jamboConfig;
   }
 
   /**

--- a/src/commands/commandregistry.js
+++ b/src/commands/commandregistry.js
@@ -19,10 +19,10 @@ class CommandRegistry {
   /**
    * Registers a new {@link Command} class with the CLI.
    *
-   * @param {Class} commandClazz 
+   * @param {Class} commandClass 
    */
-  addCommand(commandClazz) {
-    this._commandsByName[commandClazz.getAlias()] = commandClazz;
+  addCommand(commandClass) {
+    this._commandsByName[commandClass.getAlias()] = commandClass;
   }
 
   /**

--- a/src/commands/commandregistry.js
+++ b/src/commands/commandregistry.js
@@ -1,8 +1,6 @@
 const InitCommand = require('../commands/init/initcommand');
-const PageScaffolder = require('./page/add/pagescaffolder');
 const PageCommand = require('./page/add/pagecommand');
 const OverrideCommand = require('./override/overridecommand');
-const SitesGenerator = require('./build/sitesgenerator');
 const BuildCommand = require('./build/buildcommand');
 const DescribeCommand = require('../commands/describe/describecommand');
 const JamboTranslationExtractor = require('./extract-translations/jambotranslationextractor');
@@ -21,11 +19,10 @@ class CommandRegistry {
   /**
    * Registers a new {@link Command} with the CLI.
    *
-   * @param {Object} command an object containing a command's class and a way
-   *                         to instantiate the class
+   * @param {Command} command 
    */
   addCommand(command) {
-    this._commandsByName[command.clazz.getAlias()] = command;
+    this._commandsByName[command.getAlias()] = command;
   }
 
   /**
@@ -50,43 +47,15 @@ class CommandRegistry {
    * @returns {Map<string, Command>} The built-in commmands, keyed by name.
    */
   _initialize() {
-    const pageScaffolder = new PageScaffolder(this._jamboConfig);
-    const sitesGenerator = new SitesGenerator(this._jamboConfig);
     return {
-      [ InitCommand.getAlias() ]: {
-        clazz: InitCommand, 
-        factory: () => new InitCommand()
-      },
-      [ ThemeImporter.getAlias() ]: {
-        clazz: ThemeImporter, 
-        factory: jamboConfig => new ThemeImporter(jamboConfig)
-      },
-      [ PageCommand.getAlias() ]: {
-        clazz: PageCommand, 
-        factory: jamboConfig => new PageCommand(jamboConfig, pageScaffolder)
-      },
-      [ OverrideCommand.getAlias() ]: {
-        clazz: OverrideCommand, 
-        factory: jamboConfig => new OverrideCommand(jamboConfig)
-      },
-      [ BuildCommand.getAlias() ]: {
-        clazz: BuildCommand, 
-        factory: () => new BuildCommand(sitesGenerator)
-      },
-      [ ThemeUpgrader.getAlias() ]: {
-        clazz: ThemeUpgrader, 
-        factory: jamboConfig => new ThemeUpgrader(jamboConfig)
-      },
-      [ DescribeCommand.getAlias() ]: {
-        clazz: DescribeCommand, 
-        factory: jamboConfig => new DescribeCommand(
-          jamboConfig, 
-          () => this.getCommands())
-      },
-      [ JamboTranslationExtractor.getAlias() ]: {
-        clazz: JamboTranslationExtractor, 
-        factory: jamboConfig => new JamboTranslationExtractor(jamboConfig)
-      }
+      [ InitCommand.getAlias() ]: InitCommand,
+      [ ThemeImporter.getAlias() ]: ThemeImporter,
+      [ PageCommand.getAlias() ]: PageCommand,
+      [ OverrideCommand.getAlias() ]: OverrideCommand,
+      [ BuildCommand.getAlias() ]: BuildCommand,
+      [ ThemeUpgrader.getAlias() ]: ThemeUpgrader,
+      [ DescribeCommand.getAlias() ]: DescribeCommand,
+      [ JamboTranslationExtractor.getAlias() ]: JamboTranslationExtractor
     };
   }
 }

--- a/src/commands/commandregistry.js
+++ b/src/commands/commandregistry.js
@@ -17,34 +17,34 @@ class CommandRegistry {
   }
 
   /**
-   * Registers a new {@link Command} with the CLI.
+   * Registers a new {@link Command} class with the CLI.
    *
-   * @param {Command} command 
+   * @param {Class} commandClazz 
    */
-  addCommand(command) {
-    this._commandsByName[command.getAlias()] = command;
+  addCommand(commandClazz) {
+    this._commandsByName[commandClazz.getAlias()] = commandClazz;
   }
 
   /**
    * @param {string} name The command's alias.
-   * @returns {Command} The {@link Command} with the provided alias.
+   * @returns {Class} The {@link Command} class with the provided alias.
    */
   getCommand(name) {
     return this._commandsByName[name];
   }
 
   /**
-   * @returns {Array<Command>} All {@link Command}s registered with Jambo.
+   * @returns {Array<Class>} All {@link Command} classes registered with Jambo.
    */
   getCommands() {
     return Object.values(this._commandsByName);
   }
 
   /**
-   * Initializes the registry with the built-in Jambo commands: init, import, page,
+   * Initializes the registry with classes of built-in Jambo commands: init, import, page,
    * override, build, upgrade, describe, and extract-tranlations.
    *
-   * @returns {Map<string, Command>} The built-in commmands, keyed by name.
+   * @returns {Map<string, Command>} The built-in commmands' classes, keyed by name.
    */
   _initialize() {
     return {

--- a/src/commands/commandregistry.js
+++ b/src/commands/commandregistry.js
@@ -25,7 +25,7 @@ class CommandRegistry {
    * @param {Command} command
    */
   addCommand(command) {
-    this._commandsByName[command.getAlias()] = command;
+    this._commandsByName[command.obj.getAlias()] = command;
   }
 
   /**
@@ -50,27 +50,43 @@ class CommandRegistry {
    * @returns {Map<string, Command>} The built-in commmands, keyed by name.
    */
   _initialize() {
-    const initCommand = new InitCommand();
-    const importCommand = new ThemeImporter(this._jamboConfig);
     const pageScaffolder = new PageScaffolder(this._jamboConfig);
-    const pageCommand = new PageCommand(this._jamboConfig, pageScaffolder);
-    const overrideCommand = new OverrideCommand(this._jamboConfig);
     const sitesGenerator = new SitesGenerator(this._jamboConfig);
-    const buildCommand = new BuildCommand(sitesGenerator);
-    const upgradeCommand = new ThemeUpgrader(this._jamboConfig);
-    const describeCommand =
-      new DescribeCommand(() => this.getCommands());
-    const extractTranslationsCommand =
-      new JamboTranslationExtractor(this._jamboConfig);
     return {
-      [ initCommand.getAlias() ]: initCommand,
-      [ importCommand.getAlias() ]: importCommand,
-      [ pageCommand.getAlias() ]: pageCommand,
-      [ overrideCommand.getAlias() ]: overrideCommand,
-      [ buildCommand.getAlias() ]: buildCommand,
-      [ upgradeCommand.getAlias() ]: upgradeCommand,
-      [ describeCommand.getAlias() ]: describeCommand,
-      [ extractTranslationsCommand.getAlias() ]: extractTranslationsCommand
+      [ InitCommand.getAlias() ]: {
+        obj: InitCommand, 
+        constructor: () => new InitCommand()
+      },
+      [ ThemeImporter.getAlias() ]: {
+        obj: ThemeImporter, 
+        constructor: jamboConfig => new ThemeImporter(jamboConfig)
+      },
+      [ PageCommand.getAlias() ]: {
+        obj: PageCommand, 
+        constructor: jamboConfig => new PageCommand(jamboConfig, pageScaffolder)
+      },
+      [ OverrideCommand.getAlias() ]: {
+        obj: OverrideCommand, 
+        constructor: jamboConfig => new OverrideCommand(jamboConfig)
+      },
+      [ BuildCommand.getAlias() ]: {
+        obj: BuildCommand, 
+        constructor: () => new BuildCommand(sitesGenerator)
+      },
+      [ ThemeUpgrader.getAlias() ]: {
+        obj: ThemeUpgrader, 
+        constructor: jamboConfig => new ThemeUpgrader(jamboConfig)
+      },
+      [ DescribeCommand.getAlias() ]: {
+        obj: DescribeCommand, 
+        constructor: jamboConfig => new DescribeCommand(
+          jamboConfig, 
+          () => this.getCommands())
+      },
+      [ JamboTranslationExtractor.getAlias() ]: {
+        obj: JamboTranslationExtractor, 
+        constructor: jamboConfig => new JamboTranslationExtractor(jamboConfig)
+      }
     };
   }
 }

--- a/src/commands/commandregistry.js
+++ b/src/commands/commandregistry.js
@@ -21,11 +21,11 @@ class CommandRegistry {
   /**
    * Registers a new {@link Command} with the CLI.
    *
-   * @param {string} name
-   * @param {Command} command
+   * @param {Object} command an object containing a command's class and a way
+   *                         to instantiate the class
    */
   addCommand(command) {
-    this._commandsByName[command.obj.getAlias()] = command;
+    this._commandsByName[command.clazz.getAlias()] = command;
   }
 
   /**
@@ -54,38 +54,38 @@ class CommandRegistry {
     const sitesGenerator = new SitesGenerator(this._jamboConfig);
     return {
       [ InitCommand.getAlias() ]: {
-        obj: InitCommand, 
-        constructor: () => new InitCommand()
+        clazz: InitCommand, 
+        factory: () => new InitCommand()
       },
       [ ThemeImporter.getAlias() ]: {
-        obj: ThemeImporter, 
-        constructor: jamboConfig => new ThemeImporter(jamboConfig)
+        clazz: ThemeImporter, 
+        factory: jamboConfig => new ThemeImporter(jamboConfig)
       },
       [ PageCommand.getAlias() ]: {
-        obj: PageCommand, 
-        constructor: jamboConfig => new PageCommand(jamboConfig, pageScaffolder)
+        clazz: PageCommand, 
+        factory: jamboConfig => new PageCommand(jamboConfig, pageScaffolder)
       },
       [ OverrideCommand.getAlias() ]: {
-        obj: OverrideCommand, 
-        constructor: jamboConfig => new OverrideCommand(jamboConfig)
+        clazz: OverrideCommand, 
+        factory: jamboConfig => new OverrideCommand(jamboConfig)
       },
       [ BuildCommand.getAlias() ]: {
-        obj: BuildCommand, 
-        constructor: () => new BuildCommand(sitesGenerator)
+        clazz: BuildCommand, 
+        factory: () => new BuildCommand(sitesGenerator)
       },
       [ ThemeUpgrader.getAlias() ]: {
-        obj: ThemeUpgrader, 
-        constructor: jamboConfig => new ThemeUpgrader(jamboConfig)
+        clazz: ThemeUpgrader, 
+        factory: jamboConfig => new ThemeUpgrader(jamboConfig)
       },
       [ DescribeCommand.getAlias() ]: {
-        obj: DescribeCommand, 
-        constructor: jamboConfig => new DescribeCommand(
+        clazz: DescribeCommand, 
+        factory: jamboConfig => new DescribeCommand(
           jamboConfig, 
           () => this.getCommands())
       },
       [ JamboTranslationExtractor.getAlias() ]: {
-        obj: JamboTranslationExtractor, 
-        constructor: jamboConfig => new JamboTranslationExtractor(jamboConfig)
+        clazz: JamboTranslationExtractor, 
+        factory: jamboConfig => new JamboTranslationExtractor(jamboConfig)
       }
     };
   }

--- a/src/commands/describe/describecommand.js
+++ b/src/commands/describe/describecommand.js
@@ -3,29 +3,30 @@
  * and their possible arguments.
  */
 module.exports = class DescribeCommand {
-  constructor(getCommands) {
+  constructor(jamboConfig, getCommands) {
     /**
      * @type {Function}
      */
+    this._jamboConfig = jamboConfig;
     this.getCommands = getCommands;
   }
 
-  getAlias() {
+  static getAlias() {
     return 'describe';
   }
 
-  getShortDescription() {
+  static getShortDescription() {
     return 'describe all the registered jambo commands and their possible arguments';
   }
 
-  args() {
+  static args() {
     return {};
   }
 
   /**
    * The describe command filters its own describe out of the jambo describe output.
    */
-  describe() {
+  static describe() {
     return {};
   }
 
@@ -43,14 +44,15 @@ module.exports = class DescribeCommand {
     const descriptions = {};
     const describePromises = this.getCommands().map(
       command => {
-        const describeValue = command.describe();
+        const commandClass = command.obj;
+        const describeValue = commandClass.describe(this._jamboConfig);
         if (describeValue.then && typeof describeValue.then === 'function') {
           return describeValue.then(
-            (value) => { descriptions[command.getAlias()] = value; }
+            (value) => { descriptions[commandClass.getAlias()] = value; }
           );
         } else {
-          if (command.getAlias() !== 'describe') {
-            descriptions[command.getAlias()] = describeValue;
+          if (commandClass.getAlias() !== 'describe') {
+            descriptions[commandClass.getAlias()] = describeValue;
           }
         }
       }

--- a/src/commands/describe/describecommand.js
+++ b/src/commands/describe/describecommand.js
@@ -44,7 +44,7 @@ module.exports = class DescribeCommand {
     const descriptions = {};
     const describePromises = this.getCommands().map(
       command => {
-        const commandClass = command.obj;
+        const commandClass = command.clazz;
         const describeValue = commandClass.describe(this._jamboConfig);
         if (describeValue.then && typeof describeValue.then === 'function') {
           return describeValue.then(

--- a/src/commands/describe/describecommand.js
+++ b/src/commands/describe/describecommand.js
@@ -2,7 +2,7 @@
  * DescribeCommand outputs JSON that describes all registered Jambo commands
  * and their possible arguments.
  */
-module.exports = class DescribeCommand {
+class DescribeCommand {
   constructor(jamboConfig, getCommands) {
     /**
      * @type {Function}
@@ -44,15 +44,14 @@ module.exports = class DescribeCommand {
     const descriptions = {};
     const describePromises = this.getCommands().map(
       command => {
-        const commandClass = command.clazz;
-        const describeValue = commandClass.describe(this._jamboConfig);
+        const describeValue = command.describe(this._jamboConfig);
         if (describeValue.then && typeof describeValue.then === 'function') {
           return describeValue.then(
-            (value) => { descriptions[commandClass.getAlias()] = value; }
+            (value) => { descriptions[command.getAlias()] = value; }
           );
         } else {
-          if (commandClass.getAlias() !== 'describe') {
-            descriptions[commandClass.getAlias()] = describeValue;
+          if (command.getAlias() !== 'describe') {
+            descriptions[command.getAlias()] = describeValue;
           }
         }
       }
@@ -60,3 +59,5 @@ module.exports = class DescribeCommand {
     return Promise.all(describePromises).then(() => descriptions);
   }
 }
+
+module.exports = DescribeCommand;

--- a/src/commands/extract-translations/jambotranslationextractor.js
+++ b/src/commands/extract-translations/jambotranslationextractor.js
@@ -12,15 +12,15 @@ class JamboTranslationExtractor {
     this.extractor = new TranslationExtractor();
   }
 
-  getAlias() {
+  static getAlias() {
     return 'extract-translations';
   }
 
-  getShortDescription() {
+  static getShortDescription() {
     return 'extract translated strings from .hbs and .js files';
   }
 
-  args() {
+  static args() {
     return {
       output: new ArgumentMetadata({
         displayName: 'Output Path',
@@ -32,7 +32,7 @@ class JamboTranslationExtractor {
     };
   }
 
-  describe() {
+  static describe() {
     const args = this.args();
     return {
       displayName: 'Extract Translations',

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -22,15 +22,15 @@ class ThemeImporter{
     this._themeShadower = new ThemeShadower(jamboConfig);
   }
 
-  getAlias() {
+  static getAlias() {
     return 'import';
   }
 
-  getShortDescription() {
+  static getShortDescription() {
     return 'import a theme';
   }
 
-  args() {
+  static args() {
     return {
       theme: new ArgumentMetadata({
         type: ArgumentType.STRING,
@@ -45,7 +45,7 @@ class ThemeImporter{
     }
   }
 
-  describe() {
+  static describe() {
     const importableThemes = this._getImportableThemes();
     return {
       displayName: 'Import Theme',
@@ -68,7 +68,7 @@ class ThemeImporter{
   /**
    * @returns {Array<string>} the names of the available themes to be imported
    */
-  _getImportableThemes() {
+  static _getImportableThemes() {
     return ['answers-hitchhiker-theme'];
   }
 

--- a/src/commands/init/initcommand.js
+++ b/src/commands/init/initcommand.js
@@ -5,15 +5,15 @@ const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argume
  * InitCommand initializes the current directory as a Jambo repository.
  */
 class InitCommand {
-  getAlias() {
+  static getAlias() {
     return 'init';
   }
 
-  getShortDescription() {
+  static getShortDescription() {
     return 'initialize the repository';
   }
 
-  args() {
+  static args() {
     return {
       theme: new ArgumentMetadata({
         type: ArgumentType.STRING,
@@ -28,7 +28,7 @@ class InitCommand {
     }
   }
 
-  describe() {
+  static describe() {
     const importableThemes = this._getImportableThemes();
     return {
       displayName: 'Initialize Jambo',
@@ -50,7 +50,7 @@ class InitCommand {
   /**
    * @returns {Array<string>} the names of the available themes to be imported
    */
-  _getImportableThemes() {
+  static _getImportableThemes() {
     return ['answers-hitchhiker-theme'];
   }
 

--- a/src/commands/override/overridecommand.js
+++ b/src/commands/override/overridecommand.js
@@ -9,19 +9,18 @@ const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argume
 class OverrideCommand {
   constructor(jamboConfig = {}) {
     this.jamboConfig = jamboConfig;
-    this.themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
     this.defaultTheme = jamboConfig.defaultTheme;
   }
 
-  getAlias() {
+  static getAlias() {
     return 'override';
   }
 
-  getShortDescription() {
+  static getShortDescription() {
     return 'override a path within the theme';
   }
 
-  args() {
+  static args() {
     return{
       path: new ArgumentMetadata({
         type: ArgumentType.STRING,
@@ -31,8 +30,8 @@ class OverrideCommand {
     }
   }
 
-  describe() {
-    const themeFiles = this._getThemeFiles();
+  static describe(jamboConfig) {
+    const themeFiles = this._getThemeFiles(jamboConfig);
     return {
       displayName: 'Override Theme',
       params: {
@@ -49,12 +48,13 @@ class OverrideCommand {
   /**
    * @returns {Array<string>} all theme files that can be overridden
    */
-  _getThemeFiles() {
-    if (!this.themesDir) {
+  static _getThemeFiles(jamboConfig) {
+    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
+    if (!themesDir) {
       return [];
     }
     const themeFiles = []
-    fileSystem.recurseSync(this.themesDir, function(filepath) {
+    fileSystem.recurseSync(themesDir, function(filepath) {
       if (fs.statSync(filepath).isFile()) {
         themeFiles.push(filepath);
       }

--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { parse } = require('comment-json');
 const PageConfiguration = require ('./pageconfiguration');
 const UserError = require('../../../errors/usererror');
 const { ArgumentMetadata, ArgumentType } = require('../../../models/commands/argumentmetadata');
@@ -100,10 +101,10 @@ class PageCommand {
     }
 
     const pageLocales = [];
-    const localeContentsRaw = fs.readFileSync(localeConfig);
+    const localeContentsRaw = fs.readFileSync(localeConfig, 'utf-8');
     let localeContentsJson;
     try {
-      localeContentsJson = JSON.parse(localeContentsRaw);
+      localeContentsJson = parse(localeContentsRaw);
     } catch(err) {
       throw new UserError('Could not parse locale_config.json ', err.stack);
     }

--- a/src/commands/page/add/pagecommand.js
+++ b/src/commands/page/add/pagecommand.js
@@ -11,20 +11,19 @@ const { ArgumentMetadata, ArgumentType } = require('../../../models/commands/arg
 class PageCommand {
   constructor(jamboConfig = {}, pageScaffolder) {
     this.jamboConfig = jamboConfig;
-    this.themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
     this.defaultTheme = jamboConfig.defaultTheme;
     this.pageScaffolder = pageScaffolder;
   }
 
-  getAlias() {
+  static getAlias() {
     return 'page';
   }
 
-  getShortDescription() {
+  static getShortDescription() {
     return 'add a new page to the site';
   }
 
-  args() {
+  static args() {
     return {
       name: new ArgumentMetadata({
         type: ArgumentType.STRING,
@@ -45,9 +44,9 @@ class PageCommand {
     }
   }
 
-  describe() {
-    const pageTemplates = this._getPageTemplates();
-    const pageLocales = this._getAdditionalPageLocales();
+  static describe(jamboConfig) {
+    const pageTemplates = this._getPageTemplates(jamboConfig);
+    const pageLocales = this._getAdditionalPageLocales(jamboConfig);
     return {
       displayName: 'Add Page',
       params: {
@@ -73,11 +72,13 @@ class PageCommand {
   /**
    * @returns {Array<string>} The page templates available in the theme
    */
-  _getPageTemplates() {
-    if (!this.defaultTheme || !this.themesDir) {
+  static _getPageTemplates(jamboConfig) {
+    const defaultTheme = jamboConfig.defaultTheme;
+    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
+    if (!defaultTheme || !themesDir) {
       return [];
     }
-    const pageTemplatesDir = path.resolve(this.themesDir, this.defaultTheme, 'templates');
+    const pageTemplatesDir = path.resolve(themesDir, defaultTheme, 'templates');
     return fs.readdirSync(pageTemplatesDir);
   }
   
@@ -85,12 +86,12 @@ class PageCommand {
    * @returns {Array<string>} The additional locales that are configured in 
    *                          locale_config.json
    */
-  _getAdditionalPageLocales() {
-    if (!this.jamboConfig) {
+  static _getAdditionalPageLocales(jamboConfig) {
+    if (!jamboConfig) {
       return [];
     }
 
-    const configDir = this.jamboConfig.dirs.config;
+    const configDir = jamboConfig.dirs.config;
     if (!configDir) {
       return [];
     }

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -20,19 +20,18 @@ const git = simpleGit();
 class ThemeUpgrader {
   constructor(jamboConfig = {}) {
     this.jamboConfig = jamboConfig;
-    this._themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
     this.upgradeScript = 'upgrade.js';
   }
 
-  getAlias() {
+  static getAlias() {
     return 'upgrade';
   }
 
-  getShortDescription() {
+  static getShortDescription() {
     return 'upgrade the default theme to the latest version';
   }
 
-  args() {
+  static args() {
     return {
       disableScript: new ArgumentMetadata({
         type: ArgumentType.BOOLEAN,
@@ -52,8 +51,8 @@ class ThemeUpgrader {
     }
   }
 
-  async describe() {
-    const branches = await this._getThemeBranches();
+  static async describe(jamboConfig) {
+    const branches = await this._getThemeBranches(jamboConfig);
     return {
       displayName: 'Upgrade Theme',
       params: {
@@ -74,12 +73,14 @@ class ThemeUpgrader {
     }
   }
 
-  async _getThemeBranches() {
-    if (!this._themesDir) {
+  static async _getThemeBranches(jamboConfig) {
+    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
+    const defaultTheme = jamboConfig.defaultTheme;
+    if (!themesDir || !defaultTheme) {
       return [];
     }
     const branchesGit = simpleGit(
-      path.join(this._themesDir, this.jamboConfig.defaultTheme));
+      path.join(themesDir, defaultTheme));
     const branches = await branchesGit.branch(['--remote']);
     return branches.all.map(branch => 
       // regex replaces 'origin/' only at the beginning of a string

--- a/src/models/commands/command.js
+++ b/src/models/commands/command.js
@@ -6,13 +6,13 @@ class Command {
   /**
    * @returns {string} The alias for the command.
    */
-  getAlias() { }
+  static getAlias() { }
 
   /**
    * @returns {string} A short, one sentence description of the command. This
    *                   description appears as part of the help text in the CLI. 
    */
-  getShortDescription() { }
+  static getShortDescription() { }
 
   /**
    * Executes the command with the provided arguments.
@@ -25,12 +25,13 @@ class Command {
    * @returns {Object<string, ArgumentMetadata>} Descriptions of each argument,
    *                                             keyed by name.
    */
-  args() { }
+  static args() { }
 
   /**
+   * @param {Object} jamboConfig the config of the jambo repository
    * @returns {Object} description of the card command, including paths to 
    *                   all available cards
    */
-  describe() { }
+  static describe(jamboConfig) { }
 }
 module.exports = Command;

--- a/src/yargsfactory.js
+++ b/src/yargsfactory.js
@@ -4,8 +4,9 @@ const yargs = require('yargs');
  * Creates the {@link yargs} instance that powers the Jambo CLI.
  */
 class YargsFactory {
-  constructor(commandRegistry) {
+  constructor(commandRegistry, jamboConfig) {
     this._commandRegistry = commandRegistry;
+    this._jamboConfig = jamboConfig;
   }
 
   /**
@@ -28,11 +29,13 @@ class YargsFactory {
    * @returns {Object<string, ?>} The {@link yargs} CommandModule for the {@link Command}.
    */
   _createCommandModule(command) {
+    const commandClass = command.obj;
+    const commandInstance = command.constructor(this._jamboConfig);
     return {
-      command: command.getAlias(),
-      desc: command.getShortDescription(),
+      command: commandClass.getAlias(),
+      desc: commandClass.getShortDescription(),
       builder: yargs => {
-        Object.entries(command.args()).forEach(([name, metadata]) => {
+        Object.entries(commandClass.args()).forEach(([name, metadata]) => {
           yargs.option(
             name,
             {
@@ -43,7 +46,9 @@ class YargsFactory {
             });
         });
       },
-      handler: argv => command.execute(argv)
+      handler: argv => {
+        commandInstance.execute(argv);
+      }
     }
   }
 }

--- a/src/yargsfactory.js
+++ b/src/yargsfactory.js
@@ -55,7 +55,7 @@ class YargsFactory {
   }
 
   /**
-   * @param {Class} commandCLass the class of the Jambo command
+   * @param {Class} commandClass the class of the Jambo command
    * @returns {Command} the instantiated Jambo command
    */
   _createCommandInstance(commandClass) {

--- a/src/yargsfactory.js
+++ b/src/yargsfactory.js
@@ -29,8 +29,7 @@ class YargsFactory {
    * @returns {Object<string, ?>} The {@link yargs} CommandModule for the {@link Command}.
    */
   _createCommandModule(command) {
-    const commandClass = command.obj;
-    const commandInstance = command.constructor(this._jamboConfig);
+    const commandClass = command.clazz;
     return {
       command: commandClass.getAlias(),
       desc: commandClass.getShortDescription(),
@@ -47,6 +46,7 @@ class YargsFactory {
         });
       },
       handler: argv => {
+        const commandInstance = command.factory(this._jamboConfig);
         commandInstance.execute(argv);
       }
     }

--- a/src/yargsfactory.js
+++ b/src/yargsfactory.js
@@ -19,8 +19,8 @@ class YargsFactory {
   createCLI() {
     const cli = yargs.usage('Usage: $0 <cmd> <operation> [options]');
 
-    this._commandRegistry.getCommands().forEach(commandClazz => {
-      cli.command(this._createCommandModule(commandClazz));
+    this._commandRegistry.getCommands().forEach(commandClass => {
+      cli.command(this._createCommandModule(commandClass));
     });
     cli.strict()
 
@@ -28,15 +28,15 @@ class YargsFactory {
   }
 
   /**
-   * @param {Class} commandClazz A Jambo {@link Command}'s class'.
+   * @param {Class} commandClass A Jambo {@link Command}'s class.
    * @returns {Object<string, ?>} The {@link yargs} CommandModule for the {@link Command}.
    */
-  _createCommandModule(commandClazz) {
+  _createCommandModule(commandClass) {
     return {
-      command: commandClazz.getAlias(),
-      desc: commandClazz.getShortDescription(),
+      command: commandClass.getAlias(),
+      desc: commandClass.getShortDescription(),
       builder: yargs => {
-        Object.entries(commandClazz.args()).forEach(([name, metadata]) => {
+        Object.entries(commandClass.args()).forEach(([name, metadata]) => {
           yargs.option(
             name,
             {
@@ -48,37 +48,36 @@ class YargsFactory {
         });
       },
       handler: argv => {
-        const commandName = commandClazz.name;
-        const commandInstance = this._getCommandInstance(commandName, commandClazz);
+        const commandInstance = this._createCommandInstance(commandClass);
         commandInstance.execute(argv);
       }
     }
   }
 
   /**
-   * @param {String} commandName the name of the Jambo command's class
-   * @param {Class} commandCLazz the class of the Jambo command
+   * @param {Class} commandCLass the class of the Jambo command
    * @returns {Command} the instantiated Jambo command
    */
-  _getCommandInstance(commandName, commandClazz) {
+  _createCommandInstance(commandClass) {
+    const className = commandClass.name;
     let commandInstance;
-    switch (commandName) {
+    switch (className) {
       case 'DescribeCommand':
-        commandInstance = new commandClazz(
+        commandInstance = new commandClass(
           this._jamboConfig, 
           () => this._commandRegistry.getCommands()
         );
         break;
       case 'PageCommand':
         const pageScaffolder = new PageScaffolder(this._jamboConfig);
-        commandInstance = new commandClazz(this._jamboConfig, pageScaffolder);
+        commandInstance = new commandClass(this._jamboConfig, pageScaffolder);
         break;
       case 'BuildCommand':
         const sitesGenerator = new SitesGenerator(this._jamboConfig);
-        commandInstance = new commandClazz(sitesGenerator);
+        commandInstance = new commandClass(sitesGenerator);
         break;
       default:
-        commandInstance = new commandClazz(this._jamboConfig);
+        commandInstance = new commandClass(this._jamboConfig);
     }
     return commandInstance;
   }

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -3,7 +3,7 @@ const DescribeCommand = require('../../../src/commands/describe/describecommand'
 const consoleSpy = jest.spyOn(console, 'dir').mockImplementation();
 const mockJamboConfig = {};
 const mockInitCommand = {
-  obj: {
+  clazz: {
     getAlias() {
       return 'init';
     },

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -1,23 +1,26 @@
 const DescribeCommand = require('../../../src/commands/describe/describecommand');
 
 const consoleSpy = jest.spyOn(console, 'dir').mockImplementation();
+const mockJamboConfig = {};
 const mockInitCommand = {
-  getAlias() {
-    return 'init';
-  },
-  describe() {
-    return {
-      displayName: 'Initialize Jambo',
-      params: {
-        theme: {
-          displayName: 'Theme',
-          type: 'singleoption',
-          options: ['answers-hitchhiker-theme']
-        },
-        addThemeAsSubmodule: {
-          displayName: 'Add Theme as Submodule',
-          type: 'boolean',
-          default: true
+  obj: {
+    getAlias() {
+      return 'init';
+    },
+    describe() {
+      return {
+        displayName: 'Initialize Jambo',
+        params: {
+          theme: {
+            displayName: 'Theme',
+            type: 'singleoption',
+            options: ['answers-hitchhiker-theme']
+          },
+          addThemeAsSubmodule: {
+            displayName: 'Add Theme as Submodule',
+            type: 'boolean',
+            default: true
+          }
         }
       }
     }
@@ -28,6 +31,7 @@ describe('DescribeCommand works correctly', () => {
   let descriptions;
   beforeAll(async () => {
     await new DescribeCommand(
+      mockJamboConfig,
       () => [
         mockInitCommand,
       ],

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -3,24 +3,22 @@ const DescribeCommand = require('../../../src/commands/describe/describecommand'
 const consoleSpy = jest.spyOn(console, 'dir').mockImplementation();
 const mockJamboConfig = {};
 const mockInitCommand = {
-  clazz: {
-    getAlias() {
-      return 'init';
-    },
-    describe() {
-      return {
-        displayName: 'Initialize Jambo',
-        params: {
-          theme: {
-            displayName: 'Theme',
-            type: 'singleoption',
-            options: ['answers-hitchhiker-theme']
-          },
-          addThemeAsSubmodule: {
-            displayName: 'Add Theme as Submodule',
-            type: 'boolean',
-            default: true
-          }
+  getAlias() {
+    return 'init';
+  },
+  describe() {
+    return {
+      displayName: 'Initialize Jambo',
+      params: {
+        theme: {
+          displayName: 'Theme',
+          type: 'singleoption',
+          options: ['answers-hitchhiker-theme']
+        },
+        addThemeAsSubmodule: {
+          displayName: 'Add Theme as Submodule',
+          type: 'boolean',
+          default: true
         }
       }
     }


### PR DESCRIPTION
Changes all Jambo commands so that every method except `execute`
is static.

This change is so that the cli will not need to instantiate a
command unless it actually needs to execute it.

Also updates the command interface so that all methods except
execute are static.

J=SLAP-817
TEST=manual
Ran all jambo commands and saw that there were no changes in behavior.