### PR TITLE
Ensure that the 'describe' command outputs JSON

### DIFF
--- a/src/commands/describe/describecommand.js
+++ b/src/commands/describe/describecommand.js
@@ -31,10 +31,8 @@ class DescribeCommand {
   }
 
   async execute() {
-    console.dir(await this._getCommandDescriptions(), {
-      depth: null,
-      maxArrayLength: null
-    });
+    const descriptions = await this._getCommandDescriptions();
+    console.log(JSON.stringify(descriptions));
   }
 
   /**

--- a/src/commands/describe/describecommand.js
+++ b/src/commands/describe/describecommand.js
@@ -32,11 +32,7 @@ class DescribeCommand {
 
   async execute() {
     const descriptions = await this._getCommandDescriptions();
-<<<<<<< Updated upstream
-    console.log(JSON.stringify(descriptions));
-=======
     console.log(JSON.stringify(descriptions, null, 2));
->>>>>>> Stashed changes
   }
 
   /**

--- a/src/commands/describe/describecommand.js
+++ b/src/commands/describe/describecommand.js
@@ -32,7 +32,11 @@ class DescribeCommand {
 
   async execute() {
     const descriptions = await this._getCommandDescriptions();
+<<<<<<< Updated upstream
     console.log(JSON.stringify(descriptions));
+=======
+    console.log(JSON.stringify(descriptions, null, 2));
+>>>>>>> Stashed changes
   }
 
   /**

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -1,6 +1,6 @@
 const DescribeCommand = require('../../../src/commands/describe/describecommand');
 
-const consoleSpy = jest.spyOn(console, 'dir').mockImplementation();
+const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 const mockJamboConfig = {};
 const mockInitCommand = {
   getAlias() {
@@ -34,7 +34,7 @@ describe('DescribeCommand works correctly', () => {
         mockInitCommand,
       ],
     ).execute();
-    descriptions = consoleSpy.mock.calls[0][0];
+    descriptions = JSON.parse(consoleSpy.mock.calls[0][0]);
   })
 
   it('describes all provided commands and nothing more', () => {


### PR DESCRIPTION
The `describe` command was logging a JS object to the console. This format was not parsable by SGS. This PR updates `describe` so that JSON is logged instead. 

J=SLAP-854
TEST=auto, manual

Updated the `describe` unit tests. Also ran the command on a test repo and saw the expected output.