### PR TITLE
add isAbsoluteUrl helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -310,6 +310,15 @@ class SitesGenerator {
       return str && str.match(regex);
     });
 
+    /**
+     * Determine whether a URL is absolute or not.
+     * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com"
+     */
+    hbs.registerHelper('isAbsoluteUrl', function(str) {
+      const absoluteURLRegex = /(\/\/|^[a-zA-Z]+:)/;
+      return str && str.match(absoluteURLRegex);
+    });
+
     hbs.registerHelper('all', function(...args) {
       return args.filter(item => item).length === args.length;
     });

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -315,7 +315,7 @@ class SitesGenerator {
      * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com"
      */
     hbs.registerHelper('isAbsoluteUrl', function(str) {
-      const absoluteURLRegex = /(^\/\/|^[a-zA-Z]+:)/;
+      const absoluteURLRegex = /^(\/\/|[a-zA-Z]+:)/;
       return str && str.match(absoluteURLRegex);
     });
 

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -315,7 +315,7 @@ class SitesGenerator {
      * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com"
      */
     hbs.registerHelper('isAbsoluteUrl', function(str) {
-      const absoluteURLRegex = /(\/\/|^[a-zA-Z]+:)/;
+      const absoluteURLRegex = /(^\/\/|^[a-zA-Z]+:)/;
       return str && str.match(absoluteURLRegex);
     });
 


### PR DESCRIPTION
This is needed in the theme. When custom hbs helpers are implemented,
this can be cut over.

J=SLAP-861
TEST=manual

test that urls like //yext.com will still be recognized as absolute
test using a data:image/gif;base64, url for favicon