### PR TITLE
add option to import from answers-custom-theme repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npx jambo init
 Initiailizes the current directory as a Jambo repository.
 
 The init command initializes a Jambo repo, and also imports the designated theme.
-Currently, only answers-hitchhiker-theme is supported.
+Currently, answers-hitchhiker-theme and answers-custom-theme are supported.
 
 ###### Optional Arguments
 

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -38,7 +38,7 @@ class ThemeImporter{
         isRequired: true
       }),
       addThemeAsSubmodule: new ArgumentMetadata({
-        type: ArgumentType.BOOLEAN, 
+        type: ArgumentType.BOOLEAN,
         description: 'import the theme as a submodule',
         defaultValue: true
       }),
@@ -69,7 +69,7 @@ class ThemeImporter{
    * @returns {Array<string>} the names of the available themes to be imported
    */
   static _getImportableThemes() {
-    return ['answers-hitchhiker-theme'];
+    return ['answers-hitchhiker-theme', 'answers-custom-theme'];
   }
 
   execute(args) {

--- a/src/commands/init/initcommand.js
+++ b/src/commands/init/initcommand.js
@@ -21,7 +21,7 @@ class InitCommand {
         isRequired: false
       }),
       addThemeAsSubmodule: new ArgumentMetadata({
-        type: ArgumentType.BOOLEAN, 
+        type: ArgumentType.BOOLEAN,
         description: 'if starter theme should be imported as submodule',
         defaultValue: true
       }),
@@ -51,7 +51,7 @@ class InitCommand {
    * @returns {Array<string>} the names of the available themes to be imported
    */
   static _getImportableThemes() {
-    return ['answers-hitchhiker-theme'];
+    return ['answers-hitchhiker-theme', 'answers-custom-theme'];
   }
 
   execute(args) {

--- a/src/utils/gitutils.js
+++ b/src/utils/gitutils.js
@@ -1,12 +1,14 @@
 const UserError = require('../errors/usererror')
 /**
  * Gets the git repo URL for the given theme name.
- * @param {string} themeName 
+ * @param {string} themeName
  */
 exports.getRepoForTheme = function(themeName) {
   switch (themeName) {
     case 'answers-hitchhiker-theme':
       return 'git@github.com:yext/answers-hitchhiker-theme.git';
+    case 'answers-custom-theme':
+      return 'git@github.com:yext/answers-custom-theme.git';
     default:
       throw new UserError('Unrecognized theme');
   }

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -13,7 +13,7 @@ const mockInitCommand = {
         theme: {
           displayName: 'Theme',
           type: 'singleoption',
-          options: ['answers-hitchhiker-theme']
+          options: ['answers-hitchhiker-theme', 'answers-custom-theme']
         },
         addThemeAsSubmodule: {
           displayName: 'Add Theme as Submodule',
@@ -52,7 +52,7 @@ describe('DescribeCommand works correctly', () => {
         theme: {
           displayName: 'Theme',
           type: 'singleoption',
-          options: ['answers-hitchhiker-theme']
+          options: ['answers-hitchhiker-theme', 'answers-custom-theme']
         },
         addThemeAsSubmodule: {
           displayName: 'Add Theme as Submodule',


### PR DESCRIPTION
Making a custom theme available for devs intending to make heavy edits to the original hitchhiker theme. Currently the new answers-custom-theme repo is still mostly hitchhiker theme, but will later be heavily modified.

To test this locally, pull this commit and then run `npm install -g .` within ur local jambo repo to install ur local copy globally.
Then simply run `jambo import --theme answers-custom-them` to import this new theme repo into the 'theme' folder.

J=CR-152