### PR TITLE
Recognize urls that start with only 1 slash as absolute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -312,10 +312,11 @@ class SitesGenerator {
 
     /**
      * Determine whether a URL is absolute or not.
-     * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com"
+     * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com",
+     * "/my-img.svg"
      */
     hbs.registerHelper('isAbsoluteUrl', function(str) {
-      const absoluteURLRegex = /^(\/\/|[a-zA-Z]+:)/;
+      const absoluteURLRegex = /^(\/|[a-zA-Z]+:)/;
       return str && str.match(absoluteURLRegex);
     });
 


### PR DESCRIPTION
This commit updates the isAbsoluteUrl helper to recognize
urls like "/my-img.svg" as absolute urls. On a random website,
say yext.com, that url will point to yext.com/my-img.svg no matter
what page it is on.

Theme PR this is needed here
https://github.com/yext/answers-hitchhiker-theme/pull/482
will upgrade jambo ver once this is merged in

T=https://yextops.zendesk.com/agent/tickets/366842
J=SLAP-881
TEST=manual

test that the WHO site can specify an iconUrl that points to a static
asset

tested that a fresh site can also specify an iconUrl in a CTA
that points to a static asset, and also can directly put in
img tags with a static asset src