### PR TITLE
Add validation when importing custom commands.

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -26,8 +26,8 @@ if (jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output) {
       jamboConfig.dirs.output,
       path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
     new CommandImporter(jamboConfig.dirs.output);
-
   commandImporter.import().forEach(customCommand => {
+    console.log(customCommand);
     commandRegistry.addCommand(customCommand)
   });
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,6 +26,7 @@ if (jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output) {
       jamboConfig.dirs.output,
       path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
     new CommandImporter(jamboConfig.dirs.output);
+
   commandImporter.import().forEach(customCommand => {
     commandRegistry.addCommand(customCommand)
   });

--- a/src/cli.js
+++ b/src/cli.js
@@ -27,7 +27,6 @@ if (jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output) {
       path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
     new CommandImporter(jamboConfig.dirs.output);
   commandImporter.import().forEach(customCommand => {
-    console.log(customCommand);
     commandRegistry.addCommand(customCommand)
   });
 }


### PR DESCRIPTION
This PR adds a validation step to the `CommandImporter` class. This step
ensures that what is `require`'d adheres to the `Command` interface. If the
imported object is invalid, a warning is printed to the console. The invalid
command is not added to the `CommandRegistry`.

J=SLAP-888
TEST=manual

Tested the following scenarios:

- Created a test repo with Theme 1.16 and the latest Jambo. Ran various
Jambo commands in the repo and they worked as expected. Each time a command
(or `--help` or `version`) was run warnings were printed to the console. These
indicated the Theme's custom commands could not be parsed by Jambo.
- Created a test repo with Theme 1.17 (beta) and the latest Jambo. Ran various
commands and all passed. No warnings about invalid custom commands were
in the console. The expected custom commands were available.
- Created a test repo with some valid custom commands and some invalid ones.
Verified that Jambo could parse the valid ones and warnings were printed about
the invalid ones.