### PR TITLE
Only add custom commands to the CLI instance when necessary.

### DIFF
--- a/src/commands/commandregistry.js
+++ b/src/commands/commandregistry.js
@@ -11,8 +11,7 @@ const ThemeUpgrader = require('./upgrade/themeupgrader');
  * A registry that maintains the built-in and custom commands for the Jambo CLI.
  */
 class CommandRegistry {
-  constructor(jamboConfig) {
-    this._jamboConfig = jamboConfig;
+  constructor() {
     this._commandsByName = this._initialize();
   }
 
@@ -38,6 +37,13 @@ class CommandRegistry {
    */
   getCommands() {
     return Object.values(this._commandsByName);
+  }
+
+  /**
+   * @returns {Array<string>} The alias of each registered {@link Command}.
+   */
+  getAliases() {
+    return Object.keys(this._commandsByName);
   }
 
   /**


### PR DESCRIPTION
Previously, Jambo would always import custom commands, even if they weren't
necessary. Importing these commands and adding them to the CLI is only required
if `--help`, `describe`, or a command not part of the built-in set, is run.
This PR updates the `cli.js` file to only import and add custom commands to the
registry under these three circumstances.

I also took this oppurtunity to refactor the `cli.js` file. There are now
methods for each step of the CLI initialization process.

J=SLAP-888
TEST=manual

Tested these scenarios:

- Invoked Jambo without adding an actual command.
- Invoked `--help` and saw the expected output. This was done in an initialized
  and uninitialized repo.
- Invoked `describe` and saw the expected output. This was done in an
  initialized and uninitialized repo.
- Invoked a couple of built-in commands and verified they worked as expected.
- Invoked a custom command and verified it worked as expected.
- Used `--help` on both a built-in and custom command and verified that it
  worked as expected.