### PR TITLE
Correct logic for determining if custom commands should be imported.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -54,9 +54,13 @@ function buildJamboCLI() {
  * @returns {boolean} If custom {@link Command}s need to be added to the CLI instance.    
  */
 function shouldImportCustomCommands(invokedCommand, commandRegistry) {
+  const isCustomCommand = 
+    !commandRegistry.getAliases().includes(invokedCommand) &&
+    !invokedCommand.startsWith('--');
+
   return invokedCommand === '--help' ||
     invokedCommand === 'describe' ||
-    !commandRegistry.getAliases().includes(invokedCommand);
+    isCustomCommand;
 }
 
 /**


### PR DESCRIPTION
The logic for determining if custom commands should be imported had a small
bug. When `jambo --version` was invoked, Jambo attempted to import custom
commands and register them with the CLI. This behavior was incorrect.

TEST=manual

Made sure that `--version` did not cause custom commands to be imported and
added to the registry.