### PR TITLE
rename hbs helper isAbsoluteUrl to isNonRelativeUrl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -311,11 +311,12 @@ class SitesGenerator {
     });
 
     /**
-     * Determine whether a URL is absolute or not.
+     * Determine whether a URL is a non relative url, like an absolute, root relative,
+     * or data url.
      * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com",
      * "/my-img.svg"
      */
-    hbs.registerHelper('isAbsoluteUrl', function(str) {
+    hbs.registerHelper('isNonRelativeUrl', function(str) {
       const absoluteURLRegex = /^(\/|[a-zA-Z]+:)/;
       return str && str.match(absoluteURLRegex);
     });


### PR DESCRIPTION
The helper also matches on root relative links,
which are technically not "absolute"