### PR TITLE
Revert import --addAsSubmodule param name change

### DIFF
--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -37,7 +37,7 @@ class ThemeImporter{
         description: 'theme to import',
         isRequired: true
       }),
-      addThemeAsSubmodule: new ArgumentMetadata({
+      addAsSubmodule: new ArgumentMetadata({
         type: ArgumentType.BOOLEAN, 
         description: 'import the theme as a submodule',
         defaultValue: true


### PR DESCRIPTION
It looks like this param was accidentally changed to
--addThemeAsSubmodule some time ago, this commit
reverts this change so that theme importer is consistent
with its describe output (and also the theme sync script).

TEST=manual

try importing a theme with --addAsSubmodule false, no error
try importing a theme with --addThemeAsSubmodule false, jambo
complains about unknown argument