### PR TITLE
Add customHbsHelpers to jambo.json and new theme/jambo_theme.json

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -18,7 +18,6 @@ const { stripExtension, isValidFile, getPageName } = require('../../utils/fileut
 const { parseConfigFile } = require('../../utils/configutils');
 const { ConfigKeys } = require('../../constants');
 const registerHbsHelpers = require('../../handlebars/registerhbshelpers');
-const registerCustomHbsHelpers = require('../../handlebars/registercustomhbshelpers');
 const SystemError = require('../../errors/systemerror');
 const Translator = require('../../i18n/translator/translator');
 const UserError = require('../../errors/usererror');

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -94,6 +94,9 @@ exports.RepositoryScaffolder = class {
         pages: 'pages',
         partials: ['partials'],
         preservedFiles: []
+      },
+      build: {
+        customHbsHelpersFile: ''
       }
     };
     if (includeTranslations) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,4 +8,5 @@ exports.FileNames = {
 exports.ConfigKeys = {
   GLOBAL_CONFIG: 'global_config',
   LOCALE_CONFIG: 'locale_config',
+  THEME_CONFIG: 'jambo_theme'
 }

--- a/src/models/configurationregistry.js
+++ b/src/models/configurationregistry.js
@@ -3,6 +3,7 @@ const { parseLocale } = require('../utils/configutils');
 const GlobalConfig = require('./globalconfig');
 const LocalizationConfig = require('./localizationconfig');
 const PageConfig = require('./pageconfig');
+const ThemeConfig = require('./themeconfig');
 const { FileNames, ConfigKeys } = require('../constants');
 const RawConfigValidator = require('../validation/rawconfigvalidator');
 
@@ -16,8 +17,9 @@ module.exports = class ConfigurationRegistry {
    * @param {GlobalConfig} globalConfig
    * @param {LocalizationConfig} localizationConfig
    * @param {Array<PageConfig>} pageConfigs
+   * @param {ThemeConfig} themeConfig
    */
-  constructor({ globalConfig, localizationConfig, pageConfigs }) {
+  constructor({ globalConfig, localizationConfig, pageConfigs, themeConfig }) {
     /**
      * @type {GlobalConfig}
      */
@@ -32,6 +34,11 @@ module.exports = class ConfigurationRegistry {
      * @type {Array<PageConfig>}
      */
     this._pageConfigs = pageConfigs;
+
+    /**
+     * @type {ThemeConfig}
+     */
+    this._themeConfig = themeConfig;
   }
 
   /**
@@ -51,6 +58,16 @@ module.exports = class ConfigurationRegistry {
   getLocalizationConfig() {
     return this._localizationConfig;
   }
+
+  /**
+   * Returns the theme config
+   *
+   * @returns {ThemeConfig}
+   */
+  getThemeConfig() {
+    return this._themeConfig;
+  }
+
 
   /**
    * Returns the page configs
@@ -78,10 +95,11 @@ module.exports = class ConfigurationRegistry {
    * configuration in any way.
    *
    * @param {Object<String, Object>} configNameToRawConfig
+   * @param {Object} rawThemeConfig
    * @returns {ConfigurationRegistry}
    * @throws {UserError} Thrown if configNameToRawConfig is invalid
    */
-  static from(configNameToRawConfig) {
+  static from(configNameToRawConfig, rawThemeConfig = {}) {
     this.validate(configNameToRawConfig);
 
     const rawGlobalConfig = configNameToRawConfig[ConfigKeys.GLOBAL_CONFIG];
@@ -115,6 +133,7 @@ module.exports = class ConfigurationRegistry {
       globalConfig: new GlobalConfig(rawGlobalConfig),
       localizationConfig: localizationConfig,
       pageConfigs: pageConfigs,
+      themeConfig: new ThemeConfig(rawThemeConfig)
     });
   }
 }

--- a/src/models/globalconfig.js
+++ b/src/models/globalconfig.js
@@ -1,5 +1,5 @@
 /**
- * GlobalConfig is a representation of the a global_config file.
+ * GlobalConfig is a representation of the global_config file.
  */
 module.exports = class GlobalConfig {
 	/**

--- a/src/models/themeconfig.js
+++ b/src/models/themeconfig.js
@@ -1,0 +1,23 @@
+/**
+ * ThemeConfig is a representation of a jambo_theme.json file.
+ */
+module.exports = class ThemeConfig {
+  /**
+   * @param {Object} rawConfig
+   */
+  constructor(rawConfig = {}) {
+    /**
+     * @type {Object}
+     */
+    this.build = rawConfig.build || {};
+  }
+
+  /**
+   * Returns the locale
+   *
+   * @returns {String}
+   */
+  getCustomHbsHelpersFile() {
+    return this.build.customHbsHelpersFile;
+  }
+}

--- a/src/utils/configutils.js
+++ b/src/utils/configutils.js
@@ -1,4 +1,7 @@
 const { canonicalizeLocale } = require('./i18nutils');
+const { parse } = require('comment-json');
+const fs = require('file-system');
+
 /**
  * Parses the locale from a given configName
  *
@@ -23,3 +26,22 @@ containsLocale = function(configName) {
   return configNameParts.length > 1;
 }
 exports.containsLocale = containsLocale;
+
+/**
+ * Parse a comment-json config file.
+ * 
+ * @param {string} path e.g. config/global_config.json
+ * @returns {Object} the raw config object
+ */
+parseConfigFile = function(path) {
+  try {
+    return parse(fs.readFileSync(path, 'utf8'), null, true);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new UserError( `JSON SyntaxError: could not parse file ${path}`, err.stack);
+    } else {
+      throw err;
+    }
+  }
+}
+exports.parseConfigFile = parseConfigFile;


### PR DESCRIPTION
This PR adds support for a new theme config file,
jambo_theme.json, which lives in the theme's root,
and contains information on where the themes custom hbs helpers
live. It also adds that same setting to jambo.json, for
user defined custom hbs helpers.

J=SLAP-894
TEST=manual

Test that after removing the isNonRelativeUrl
helper, and adding in the custom hbs helper registration code
(next PR) I can specify custom helpers in either jambo.json
or themes/answers-hh-theme/jambo_theme.json and
build the page successfully

check that jambo init adds the new build.customHbsHelpersFile setting