### PR TITLE
add back isAbsoluteUrl helper (alias of isNonRelativeUrl)

### DIFF
--- a/src/handlebars/registerhbshelpers.js
+++ b/src/handlebars/registerhbshelpers.js
@@ -60,10 +60,14 @@ module.exports = function registerHbsHelpers(hbs) {
    * Common examples: "mailto:slapshot@gmail.com", "//yext.com", "https://yext.com",
    * "/my-img.svg"
    */
-  hbs.registerHelper('isNonRelativeUrl', function(str) {
+  function isNonRelativeUrl(str) {
     const absoluteURLRegex = /^(\/|[a-zA-Z]+:)/;
     return str && str.match(absoluteURLRegex);
-  });
+  }
+
+  hbs.registerHelper('isNonRelativeUrl', isNonRelativeUrl);
+
+  hbs.registerHelper('isAbsoluteUrl', isNonRelativeUrl);
 
   hbs.registerHelper('all', function(...args) {
     return args.filter(item => item).length === args.length;

--- a/tests/handlebars/registerhbshelpers.js
+++ b/tests/handlebars/registerhbshelpers.js
@@ -175,6 +175,25 @@ describe('isNonRelativeUrl', () => {
   });
 });
 
+describe('isAbsoluteUrl (alias of isNonRelativeUrl)', () => {
+  it('works for https://yext.com', () => {
+    const template = hbs.compile('{{#if (isAbsoluteUrl url)}}is absolute!{{/if}}');
+    const data = {
+      url: 'https://yext.com'
+    };
+    expect(template(data)).toEqual('is absolute!');
+  });
+
+  it('works for relative urls', () => {
+    const template =
+      hbs.compile('{{#unless (isAbsoluteUrl url)}}is NOT absolute{{/unless}}');
+    const data = {
+      url: './index.html'
+    };
+    expect(template(data)).toEqual('is NOT absolute');
+  });
+});
+
 describe('simple hbs expressions', () => {
   describe('eq', () => {
     it('works for 1 === 1', () => {


### PR DESCRIPTION
This commit adds back the isAbsoluteUrl helper, which was
renamed to isNonRelativeUrl. This is needed to support
theme 1.16 doing an npm upgrade jambo.

Will cherry pick to support/v1.9

TEST=manual, auto

test that I can build a site using both helpers