### PR TITLE
Add postimport hook, remove default postimport

### DIFF
--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -1,25 +1,24 @@
-const fs = require('file-system');
+const path = require('path');
 const simpleGit = require('simple-git/promise');
 const git = simpleGit();
-const {
-  stringify,
-  assign
-} = require('comment-json');
-const { ShadowConfiguration, ThemeShadower } = require('../override/themeshadower');
+const { ThemeShadower } = require('../override/themeshadower');
 const { getRepoForTheme } = require('../../utils/gitutils');
 const SystemError = require('../../errors/systemerror');
 const UserError = require('../../errors/usererror');
 const { isCustomError } = require('../../utils/errorutils');
-const { FileNames } = require('../../constants');
 const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argumentmetadata');
+const { CustomCommand } = require('../../utils/customcommands/command');
+const { CustomCommandExecuter } = require('../../utils/customcommands/commandexecuter');
+const { searchDirectoryIgnoringExtensions } = require('../../utils/fileutils');
 
 /**
  * ThemeImporter imports a specified theme into the themes directory.
  */
-class ThemeImporter{
+class ThemeImporter {
   constructor(jamboConfig) {
     this.config = jamboConfig;
     this._themeShadower = new ThemeShadower(jamboConfig);
+    this._postImportHook = 'postimport';
   }
 
   static getAlias() {
@@ -38,7 +37,7 @@ class ThemeImporter{
         isRequired: true
       }),
       addAsSubmodule: new ArgumentMetadata({
-        type: ArgumentType.BOOLEAN, 
+        type: ArgumentType.BOOLEAN,
         description: 'import the theme as a submodule',
         defaultValue: true
       }),
@@ -93,27 +92,16 @@ class ThemeImporter{
     }
     try {
       const themeRepo = getRepoForTheme(themeName);
-      const localPath = `${this.config.dirs.themes}/${themeName}`;
+      const themePath = path.join(this.config.dirs.themes, themeName);
 
       if (addAsSubmodule) {
-        await git.submoduleAdd(themeRepo, localPath);
+        await git.submoduleAdd(themeRepo, themePath);
       } else {
-        await git.clone(themeRepo, localPath);
+        await git.clone(themeRepo, themePath);
       }
+      this._postImport(themePath);
 
-      if (fs.existsSync(`${localPath}/${FileNames.LOCALE_CONFIG}`)) {
-        fs.copyFileSync(
-          `${localPath}/${FileNames.LOCALE_CONFIG}`,
-          `${this.config.dirs.config}/${FileNames.LOCALE_CONFIG}`);
-      }
-      fs.copyFileSync(
-        `${localPath}/${FileNames.GLOBAL_CONFIG}`,
-        `${this.config.dirs.config}/${FileNames.GLOBAL_CONFIG}`);
-      this._copyStaticAssets(localPath);
-      this._updateDefaultTheme(themeName);
-      this._copyLayoutFiles(themeName);
-
-      return localPath;
+      return themePath;
     } catch (err) {
       if (isCustomError(err)) {
         throw err;
@@ -123,89 +111,20 @@ class ThemeImporter{
   }
 
   /**
-   * Copies the static assets from the Theme to the repository, if they exist. If a
-   * Gruntfile, webpack-config, or package.json are included among the assets, those are
-   * moved to the top-level of the repository. If scss/answers.scss,
-   * scss/answers-variables.scss, scss/fonts.scss, scss/header.scss, scss/footer.scss, or
-   * scss/page.scss are included among the assets, those are moved under the static dir
-   * of the repository.
-   *
-   * @param {string} localPath The path of the imported theme in the repository.
+   * Run the post import hook, if one exists.
+   * 
+   * @param {string} themePath path to the default theme
    */
-  _copyStaticAssets(localPath) {
-    const siteStaticDir = 'static';
-
-    const staticAssetsPath = `${localPath}/static`;
-    if (fs.existsSync(staticAssetsPath)) {
-      const copyFileIfExists = (file, destPath) => {
-        if (fs.existsSync(file)) {
-          fs.copyFileSync(file, destPath);
-        }
-      };
-
-      const scssFiles = [
-        'answers.scss',
-        'answers-variables.scss',
-        'fonts.scss',
-        'header.scss',
-        'footer.scss',
-        'page.scss'
-      ];
-
-      scssFiles.forEach(fileName => {
-        copyFileIfExists(
-          `${staticAssetsPath}/scss/${fileName}`,
-          `${siteStaticDir}/scss/${fileName}`);
-      });
-
-      const jsFiles = [
-        'formatters-custom.js'
-      ];
-
-      jsFiles.forEach(fileName => {
-        copyFileIfExists(
-          `${staticAssetsPath}/js/${fileName}`,
-          `${siteStaticDir}/js/${fileName}`);
-      });
-
-      const topLevelStaticFiles = [
-        'Gruntfile.js',
-        'webpack-config.js',
-        'package.json',
-        'package-lock.json'
-      ];
-
-      topLevelStaticFiles.forEach(fileName => {
-        copyFileIfExists(`${staticAssetsPath}/${fileName}`, `${fileName}`);
-      });
+  _postImport(themePath) {
+    const postImportHookFile =
+      searchDirectoryIgnoringExtensions(this._postImportHook, themePath);
+    if (!postImportHookFile) {
+      return;
     }
-  }
-
-  _copyLayoutFiles(themeName) {
-    console.log('importing header');
-    this._themeShadower.createShadow(new ShadowConfiguration({
-      theme: themeName,
-      path: 'layouts/header.hbs',
-    }));
-
-    console.log('importing footer');
-    this._themeShadower.createShadow(new ShadowConfiguration({
-      theme: themeName,
-      path: 'layouts/footer.hbs',
-    }));
-
-    console.log('importing headincludes');
-    this._themeShadower.createShadow(new ShadowConfiguration({
-      theme: themeName,
-      path: 'layouts/headincludes.hbs',
-    }));
-  }
-
-  _updateDefaultTheme(themeName) {
-    if (this.config.defaultTheme !== themeName) {
-      const updatedConfig = assign({ defaultTheme: themeName }, this.config);
-      fs.writeFileSync('jambo.json', stringify(updatedConfig, null, 2));
-    }
+    const customCommand = new CustomCommand({
+      executable: './' + path.join(themePath, postImportHookFile)
+    });
+    new CustomCommandExecuter(this.config).execute(customCommand);
   }
 }
 

--- a/src/commands/override/themeshadower.js
+++ b/src/commands/override/themeshadower.js
@@ -1,5 +1,4 @@
 const fs = require('file-system');
-const path = require('path');
 const { addToPartials } = require('../../utils/jamboconfigutils');
 const UserError = require('../../errors/usererror');
 

--- a/src/utils/customcommands/commandexecuter.js
+++ b/src/utils/customcommands/commandexecuter.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const { spawnSync } = require('child_process');
+const SystemError = require('../../errors/systemerror');
 
 /**
  * This class is responsible for executing a {@link CustomCommand}.
@@ -22,11 +23,22 @@ exports.CustomCommandExecuter = class {
      */
     execute(command) {
         command.addArgs(this._jamboFlags);
-        return spawnSync(
+        const processInfo = spawnSync(
             command.getExecutable(),
             command.getArgs(),
             { cwd: command.getCwd(), shell: true },
         );
+        const { stdout, stderr, error } = processInfo;
+        const stdoutString = stdout.toString().trim();
+        stdoutString && console.log(stdoutString);
+        const stderrString = stderr.toString().trim();
+        stderrString && console.error(stderrString);
+        if (error) {
+            const errMsg =
+                `Error executing script ${command.getExecutable()}: ${error.message}`;
+            throw new SystemError(errMsg, error.stack);
+        }
+        return processInfo;
     }
 
     /**

--- a/src/utils/customcommands/commandexecuter.js
+++ b/src/utils/customcommands/commandexecuter.js
@@ -23,22 +23,15 @@ exports.CustomCommandExecuter = class {
      */
     execute(command) {
         command.addArgs(this._jamboFlags);
-        const processInfo = spawnSync(
+        return spawnSync(
             command.getExecutable(),
             command.getArgs(),
-            { cwd: command.getCwd(), shell: true },
+            {
+                cwd: command.getCwd(),
+                shell: true,
+                stdio: 'inherit'
+            }
         );
-        const { stdout, stderr, error } = processInfo;
-        const stdoutString = stdout.toString().trim();
-        stdoutString && console.log(stdoutString);
-        const stderrString = stderr.toString().trim();
-        stderrString && console.error(stderrString);
-        if (error) {
-            const errMsg =
-                `Error executing script ${command.getExecutable()}: ${error.message}`;
-            throw new SystemError(errMsg, error.stack);
-        }
-        return processInfo;
     }
 
     /**

--- a/src/utils/fileutils.js
+++ b/src/utils/fileutils.js
@@ -49,12 +49,11 @@ exports.isValidFile = isValidFile;
 searchDirectoryIgnoringExtensions = function(desiredFile, directoryPath) {
   const dirEntries = fs.readdirSync(directoryPath);
   for (const dirEntry of dirEntries) {
-    if (desiredFile !== stripExtension(dirEntry)) {
-      continue;
-    }
-    const filePath = path.resolve(directoryPath, dirEntry);
-    if (fs.lstatSync(filePath).isFile()) {
-      return dirEntry;
+    if (desiredFile === stripExtension(dirEntry)) {
+      const filePath = path.resolve(directoryPath, dirEntry);
+      if (fs.lstatSync(filePath).isFile()) {
+        return dirEntry;
+      }
     }
   }
   return undefined;

--- a/src/utils/fileutils.js
+++ b/src/utils/fileutils.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
 /**
  * Returns the given filename without its extension
  *
@@ -32,3 +35,28 @@ isValidFile = function(fileName) {
   return fileName && !fileName.startsWith('.');
 }
 exports.isValidFile = isValidFile;
+
+/**
+ * Search for file with the given name, ignoring extensions.
+ * For example, given a desiredFile 'upgrade', will look for
+ * files like upgrade.js and upgrade.sh, and return the filename
+ * of the first found.
+ * 
+ * @param {string} desiredFile
+ * @param {string} directoryPath
+ * @returns {string|undefined} the fileName, if it exists, otherwise undefined.
+ */
+searchDirectoryIgnoringExtensions = function(desiredFile, directoryPath) {
+  const dirEntries = fs.readdirSync(directoryPath);
+  for (const dirEntry of dirEntries) {
+    if (desiredFile !== stripExtension(dirEntry)) {
+      continue;
+    }
+    const filePath = path.resolve(directoryPath, dirEntry);
+    if (fs.lstatSync(filePath).isFile()) {
+      return dirEntry;
+    }
+  }
+  return undefined;
+}
+exports.searchDirectoryIgnoringExtensions = searchDirectoryIgnoringExtensions;

--- a/tests/utils/fileutils.js
+++ b/tests/utils/fileutils.js
@@ -1,4 +1,9 @@
-const { stripExtension, getPageName, isValidFile } = require('../../src/utils/fileutils');
+const {
+  stripExtension,
+  getPageName,
+  isValidFile,
+  searchDirectoryIgnoringExtensions
+} = require('../../src/utils/fileutils');
 
 describe('stripExtension correctly strips extension from filename', () => {
   it('strips extension when present', () => {
@@ -46,5 +51,17 @@ describe('isValidFile properly determines if files are valid', () => {
     let filename = 'example.html.hbs';
     let isValid = isValidFile(filename);
     expect(isValid).toEqual(true);
+  });
+});
+
+describe('searchDirectoryIgnoringExtensions', () => {
+  it('can find "fileutils.js" when looking for "fileutils"', () => {
+    const fileUtilsFileName = searchDirectoryIgnoringExtensions('fileutils', __dirname);
+    expect(fileUtilsFileName).toEqual('fileutils.js');
+  });
+
+  it('will return undefined when it cannot find the file', () => {
+    const cannotFindFile = searchDirectoryIgnoringExtensions('asdf', __dirname);
+    expect(cannotFindFile).toEqual(undefined);
   });
 });


### PR DESCRIPTION
This commit adds the postimport hook to jambo
import, and removes the default postimport
logic (which has been moved to the theme).
We can remove the logic in this specific case,
because anybody who calls jambo import will
be importing the newest version of the theme,
which will already have the postimport logic
moved into it.

This commit allows users to specify a postimport.js
(or any file extension, e.g. postimport.sh) script
to be run after an import.

This PR also updates the postupgrade script to have
the same capability (i.e. you can now specify an
upgrade.sh, instead of upgrade.js)

Finally it adds stdout, stderr, and error handling
to the commandexecutor, which might be renamed to
something like scriptexecutor in a separate PR,
now that we have custom jambo commands.

J=SLAP-833
TEST=manual

test that I can specify a postimport.sh or postimport.js
test that stdout, stderr, and errors are logged correctly
test that it works when import the theme as either a submodule
or checked in files
test that I can still upgrade the theme to a branch