### PR TITLE
upgrade: specify submodulePath in git submodule set-branch

### DIFF
--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -166,7 +166,7 @@ class ThemeUpgrader {
    */
   async _upgradeSubmodule(submodulePath, branch) {
     if (branch) {
-      await git.subModule(['set-branch', '--branch', branch]);
+      await git.subModule(['set-branch', '--branch', branch, submodulePath]);
     }
     await git.submoduleUpdate(['--remote', submodulePath]);
   }


### PR DESCRIPTION
Small fix for upgrading a theme that was imported
as a submodule. Will cherry-pick to support/v1.9

TEST=manual

test that I can upgrade submodule themes again