### PR TITLE
Add missing spaces to page config validator error msg

### DIFF
--- a/src/validation/pageconfigsvalidator.js
+++ b/src/validation/pageconfigsvalidator.js
@@ -79,11 +79,11 @@ module.exports = class PageConfigsValidator {
   _throwErrorForLocalesMissingConfigs(locales) {
     if (locales.length == 1) {
       throw new UserError(
-        `The locale '${locales}' is referenced but is not configured` +
+        `The locale '${locales}' is referenced but is not configured ` +
         `inside ${FileNames.LOCALE_CONFIG}`);
     } else if (locales.length > 1) {
       throw new UserError(
-        `The locales '${locales}' are referenced but are not defined` +
+        `The locales '${locales}' are referenced but are not defined ` +
         `inside ${FileNames.LOCALE_CONFIG}`);
     }
   }


### PR DESCRIPTION
Noticed in a slack post it was missing spaces.

TEST=none