### PR TITLE
rawconfigvalidator: canonicalize locales when pre-validating

### DIFF
--- a/src/validation/rawconfigvalidator.js
+++ b/src/validation/rawconfigvalidator.js
@@ -3,6 +3,7 @@ const LocaleConfigValidator = require('./localeconfigvalidator');
 const PageConfigsValidator = require('./pageconfigsvalidator');
 const { ConfigKeys } = require('../constants');
 const cloneDeep = require('lodash/cloneDeep');
+const { canonicalizeLocale } = require('../utils/i18nutils');
 
 /**
  * Performs validation on the raw configuration files
@@ -66,11 +67,13 @@ module.exports = class RawConfigValidator {
   }
 
   /**
-   * Gets the locale keys inside localeConfig of locale_config.json
+   * Gets the locale keys inside localeConfig of locale_config.json,
+   * and canonicalizes them.
    *
    * @type {string[]}
    */
   _getConfiguredLocales() {
-    return Object.keys(this._getLocaleConfig()['localeConfig']);
+    return Object.keys(this._getLocaleConfig()['localeConfig'])
+      .map(canonicalizeLocale);
   }
 }


### PR DESCRIPTION
PageConfigsValidator checks that all page configs have
a corresponding locale in the locale_config.
When parsing locales from page config file names, it was
calling parseLocales in i18nutils, which will canonicalize
the locale. However it was no canonicalizing the locale
when pulling them down from the locale_config.json

will cherry-pick to support/v1.9

J=SLAP-936
TEST=manual

test that I can specify a locale like en_gb or en_Gb
on the weight watchers repo and jambo will build the en_GB
page correctly