### PR TITLE
themeimporter: fix not being able to init with theme

### DIFF
--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -73,7 +73,7 @@ class ThemeImporter{
   }
 
   execute(args) {
-    this._import(args.theme, args.addAsSubmodule)
+    this.import(args.theme, args.addAsSubmodule)
       .then(console.log);
   }
 

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -87,7 +87,7 @@ class ThemeImporter{
    *                            containing the new submodule's local path. If the addition
    *                            failed, a Promise containing the error.
    */
-  async _import(themeName, addAsSubmodule) {
+  async import(themeName, addAsSubmodule) {
     if (!this.config) {
       throw new UserError('No jambo.json found. Did you `jambo init` yet?');
     }

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -1,4 +1,4 @@
-const themeCommand = require('../import/themeimporter');
+const ThemeImporter = require('../import/themeimporter');
 
 const fs = require('file-system');
 const simpleGit = require('simple-git/promise');
@@ -51,7 +51,7 @@ exports.RepositoryScaffolder = class {
 
       const theme = repositorySettings.getTheme();
       if (theme) {
-        const themeImporter = new themeCommand.ThemeImporter(jamboConfig);
+        const themeImporter = new ThemeImporter(jamboConfig);
         await themeImporter.import(
           theme, 
           repositorySettings.shouldAddThemeAsSubmodule());


### PR DESCRIPTION
Fixes the issue where a user cannot run a `jambo init` with the
theme specified.

The usage of the theme importer as a constructor was originally
incorrect in the repository scaffolder; the change is made here
to use it correctly.

TEST=manual
Created a new directory locally, `cd`-ed into it, and ran
`jambo init --theme answers-hitchhiker-theme`. Saw that the
jambo repo was initialized correctly and that the theme was
also imported into the repo.