### PR TITLE
Upgrade command's `describe` should list a default for `branch`.

### DIFF
--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -47,13 +47,24 @@ class ThemeUpgrader {
       branch: new ArgumentMetadata({
         type: ArgumentType.STRING,
         description: 'the branch of the theme to upgrade to',
-        isRequired: false
+        isRequired: false,
+        defaultValue: 'master'
       })
     }
   }
 
   static async describe(jamboConfig) {
     const branches = await this._getThemeBranches(jamboConfig);
+
+    const branchParam = {
+      displayName: 'Branch of theme to upgrade to',
+      type: 'singleoption',
+      options: branches
+    }
+    if (branches.length) {
+      branchParam.default = 'master';
+    }
+
     return {
       displayName: 'Upgrade Theme',
       params: {
@@ -65,11 +76,7 @@ class ThemeUpgrader {
           displayName: 'Disable Upgrade Script',
           type: 'boolean'
         },
-        branch: {
-          displayName: 'Branch of theme to upgrade to',
-          type: 'singleoption',
-          options: branches
-        }
+        branch: branchParam
       }
     }
   }


### PR DESCRIPTION
The `upgrade` command implicitly assumes a default of `master` for the
`branch` parameter. That was not getting communicated to SGS because we left it
out of the command's `describe`. I added some additional logic so that we don't
list any default for `branch` when the repo has no Theme yet. It looked a bit
weird to have no options listed for `branch`, but a default of `master`.

J=SLAP-978
TEST=manual

Ran `describe` on an empty repo and saw no default listed for `branch`. Ran
`describe` on a repo with a Theme and saw a default of `master` reported. Also
ensured that running `upgrade` with no `branch` resulted in `master` being
used.