### PR TITLE
Version 1.9.8.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Fixed a bug that caused `init` to fail when the `--theme` flag was used.
(#182)
- Update the `describe` command so that it correctly lists `master` as the
default of `upgrade.params.branch`. (#183)