### PR TITLE
Add legacy support for the older style of custom command importing.

### DIFF
--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -108,7 +108,7 @@ class CommandImporter {
    * @return {boolean} Boolean indicating if this is a legacy command import.
    */
   _isLegacyImport(requiredModule) {
-    return requiredModule.toString().startsWith('jamboConfig =>');
+    return !('prototype' in requiredModule);
   }
 
   /**


### PR DESCRIPTION
Jambo should support both the current and old style of importing a custom
command. The legacy style, which can be seen in Theme v1.16, didn't export a
class, but a function. The function took in a jambo config and provided an
instance of the custom command's class. Further, back then, the command class
did not have any static members.

The `CommandImporter` is now able to detect legacy command imports. It wraps
them in an implementation of the latest `Command` interface. Note that all
legacy imports were characterized by a function starting with 'jamboConfig =>'.

J=SLAP-942
TEST=manual

Tested the following for sites on Theme v1.16 and Theme v1.18:
- `jambo --help` produced the expected output.
- The `--help` flag on the `card` and `directanswercard` commands worked as
  expected.
- The `describe` command had the correct output for `card` and
  `directanswercard`.
- The `directansercard` command worked as expected.
- The `card` command worked as expected.