### PR TITLE
Ignore node modules partials

### DIFF
--- a/src/models/partialsregistry.js
+++ b/src/models/partialsregistry.js
@@ -1,6 +1,6 @@
 const fs = require('file-system');
 
-const { isValidFile } = require('../utils/fileutils');
+const { isValidFile, isValidPartialPath } = require('../utils/fileutils');
 const Partial = require('./partial');
 
 /**
@@ -44,7 +44,7 @@ module.exports = class PartialsRegistry {
   }
 
   /**
-   * Builds all partials in the provided path. If the path is a directory,
+   * Builds all valid partials in the provided path. If the path is a directory,
    * the useFullyQualifiedName parameter dictates if the path's root will be
    * included in the partial naming scheme.
    *
@@ -58,7 +58,7 @@ module.exports = class PartialsRegistry {
     const pathExists = fs.existsSync(partialsPath);
     if (pathExists && !fs.lstatSync(partialsPath).isFile()) {
       fs.recurseSync(partialsPath, (path, relative, filename) => {
-        if (isValidFile(filename) && !path.includes('node_modules')) {
+        if (isValidFile(filename) && isValidPartialPath(path)) {
           const partialPath = useFullyQualifiedName
             ? path
             : relative;

--- a/src/models/partialsregistry.js
+++ b/src/models/partialsregistry.js
@@ -58,7 +58,7 @@ module.exports = class PartialsRegistry {
     const pathExists = fs.existsSync(partialsPath);
     if (pathExists && !fs.lstatSync(partialsPath).isFile()) {
       fs.recurseSync(partialsPath, (path, relative, filename) => {
-        if (isValidFile(filename)) {
+        if (isValidFile(filename) && !path.includes('node_modules')) {
           const partialPath = useFullyQualifiedName
             ? path
             : relative;

--- a/src/utils/fileutils.js
+++ b/src/utils/fileutils.js
@@ -29,12 +29,23 @@ exports.getPageName = getPageName;
  * Determines whether a filename is valid
  *
  * @param {string} filename the file name
- * @returns {string}
+ * @returns {boolean}
  */
 isValidFile = function(fileName) {
   return fileName && !fileName.startsWith('.');
 }
 exports.isValidFile = isValidFile;
+
+/**
+ * Determines whether a path is valid for registering it as a partial
+ *
+ * @param {string} path the path to the file
+ * @returns {boolean}
+ */
+isValidPartialPath = function(path) {
+  return path && !path.includes('/node_modules/');
+}
+exports.isValidPartialPath = isValidPartialPath;
 
 /**
  * Search for file with the given name, ignoring extensions.

--- a/src/utils/fileutils.js
+++ b/src/utils/fileutils.js
@@ -43,7 +43,7 @@ exports.isValidFile = isValidFile;
  * @returns {boolean}
  */
 isValidPartialPath = function(path) {
-  return path && !path.includes('/node_modules/');
+  return path && !path.startsWith('node_modules/') && !path.includes('/node_modules/');
 }
 exports.isValidPartialPath = isValidPartialPath;
 

--- a/tests/utils/fileutils.js
+++ b/tests/utils/fileutils.js
@@ -55,7 +55,7 @@ describe('isValidFile properly determines if files are valid', () => {
   });
 });
 
-describe('isValidPartialPath properly determines if pathes are valid', () => {
+describe('isValidPartialPath properly determines if paths are valid', () => {
   it('returns true when a path does not contain /node_modules/', () => {
     let path = '../answers-hitchhiker-theme/partials/index.hbs';
     let isValid = isValidPartialPath(path);

--- a/tests/utils/fileutils.js
+++ b/tests/utils/fileutils.js
@@ -67,6 +67,12 @@ describe('isValidPartialPath properly determines if paths are valid', () => {
     let isValid = isValidPartialPath(path);
     expect(isValid).toEqual(false);
   });
+
+  it('returns false when a path starts with node_modules/', () => {
+    let path = 'node_modules/handlebars/index.js';
+    let isValid = isValidPartialPath(path);
+    expect(isValid).toEqual(false);
+  });
 });
 
 describe('searchDirectoryIgnoringExtensions', () => {

--- a/tests/utils/fileutils.js
+++ b/tests/utils/fileutils.js
@@ -2,6 +2,7 @@ const {
   stripExtension,
   getPageName,
   isValidFile,
+  isValidPartialPath,
   searchDirectoryIgnoringExtensions
 } = require('../../src/utils/fileutils');
 
@@ -51,6 +52,20 @@ describe('isValidFile properly determines if files are valid', () => {
     let filename = 'example.html.hbs';
     let isValid = isValidFile(filename);
     expect(isValid).toEqual(true);
+  });
+});
+
+describe('isValidPartialPath properly determines if pathes are valid', () => {
+  it('returns true when a path does not contain /node_modules/', () => {
+    let path = '../answers-hitchhiker-theme/partials/index.hbs';
+    let isValid = isValidPartialPath(path);
+    expect(isValid).toEqual(true);
+  });
+
+  it('returns false when a path contains /node_modules/', () => {
+    let path = '../../answers-hitchhiker-theme/test-site/node_modules/yargs/index.js';
+    let isValid = isValidPartialPath(path);
+    expect(isValid).toEqual(false);
   });
 });
 


### PR DESCRIPTION
Ignore node_modules when registering partials

When adding the [theme testing site](https://github.com/yext/answers-hitchhiker-theme/pull/555), I ran into a problem as jambo would try to register the files inside node modules. Ignoring paths that contain node modules when registering partials fixes this issue.

J=none
TEST=manual

Build the testing repo and observe a successful build