### PR TITLE
Remove ability of `upgrade` command to fetch Theme branches.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -55,17 +55,6 @@ class ThemeUpgrader {
   }
 
   static async describe(jamboConfig) {
-    const branches = await this._getThemeBranches(jamboConfig);
-
-    const branchParam = {
-      displayName: 'Branch of theme to upgrade to',
-      type: 'singleoption',
-      options: branches
-    }
-    if (branches.length) {
-      branchParam.default = 'master';
-    }
-
     return {
       displayName: 'Upgrade Theme',
       params: {
@@ -77,24 +66,13 @@ class ThemeUpgrader {
           displayName: 'Disable Upgrade Script',
           type: 'boolean'
         },
-        branch: branchParam
+        branch: {
+          displayName: 'Branch of theme to upgrade to',
+          type: 'string',
+          default: 'master'
+        }
       }
     }
-  }
-
-  static async _getThemeBranches(jamboConfig) {
-    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
-    const defaultTheme = jamboConfig.defaultTheme;
-    if (!themesDir || !defaultTheme) {
-      return [];
-    }
-    const branchesGit = simpleGit(
-      path.join(themesDir, defaultTheme));
-    const branches = await branchesGit.branch(['--remote']);
-    return branches.all.map(branch => 
-      // regex replaces 'origin/' only at the beginning of a string
-      branch.replace(/^(origin\/)/, '')
-    );
   }
 
   execute(args) {


### PR DESCRIPTION
The `ThemeUpgrader.describe` method would attempt to fetch the branches for the
default Theme. The branches would be listed as the various options for the
`--branch` flag. The problem was that the method for fetching the branches
did not work unless the Theme was imported as a sub-module. Rather than fix
the logic to work for all cases, we decided this was outside Jambo's realm of
responsibility. If someone is using a Theme, they should be able to tell Jambo
which branch to use. Jambo does not need to supply them with a list of the
valid options. As such, `describe` now lists the `branch` param as a normal
string, not asingleoption.

This is considered a bug fix, so the Jambo version was incremented by x.x.1.

J=SLAP-1047
TEST=auto,manual

Reran all Jambo unit tests. Verified the following on a sample site:
- The `describe` command has the expected output for `upgrade`.
- The `upgrade --help` command produces the expected output.
- Running `upgrade` without `--branch` pulls the latest commit off master.
- Running `upgrade` with a `--branch` pulls the latest commit off the branch.