### PR TITLE
v1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Version 1.10.0
### Changes
- Jambo exposes a hook that allows template data to be modified before it is passed to Handlebars. This hook is run as part of the `build` command. (#181)
- The `import` command accepts a "post import" hook. This hook allows a Theme to specify custom logic to be run after it is cloned into a repo. (#177)
- Themes can now register custom Handlebars helpers with Jambo. These helpers will be made available during `build`. (#174)
### Bug Fixes
- Jambo now has legacy support for the old style of custom command imports. (#185)
- Fixed a bug that broke the `init` command when the `--theme` flag was supplied. (#182)
- The `upgrade` command's description now includes a default of `master` for `--branch`. (#183)
- Fixed a small bug that occurred when using the `upgrade` command on a Theme imported as a submodule. (#178)
- Corrected a logic bug in the `RawConfigValidator`. The validator was not canonicalizing locales before performing its comparison. (#180)
- Added an alias of the `isNonRelativeUrl` helper called `isAbsoluteUrl`. This is needed to maintain compatibility with Theme v1.16. (#176)