### PR TITLE
v1.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -55,17 +55,6 @@ class ThemeUpgrader {
   }
 
   static async describe(jamboConfig) {
-    const branches = await this._getThemeBranches(jamboConfig);
-
-    const branchParam = {
-      displayName: 'Branch of theme to upgrade to',
-      type: 'singleoption',
-      options: branches
-    }
-    if (branches.length) {
-      branchParam.default = 'master';
-    }
-
     return {
       displayName: 'Upgrade Theme',
       params: {
@@ -77,24 +66,13 @@ class ThemeUpgrader {
           displayName: 'Disable Upgrade Script',
           type: 'boolean'
         },
-        branch: branchParam
+        branch: {
+          displayName: 'Branch of theme to upgrade to',
+          type: 'string',
+          default: 'master'
+        }
       }
     }
-  }
-
-  static async _getThemeBranches(jamboConfig) {
-    const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
-    const defaultTheme = jamboConfig.defaultTheme;
-    if (!themesDir || !defaultTheme) {
-      return [];
-    }
-    const branchesGit = simpleGit(
-      path.join(themesDir, defaultTheme));
-    const branches = await branchesGit.branch(['--remote']);
-    return branches.all.map(branch => 
-      // regex replaces 'origin/' only at the beginning of a string
-      branch.replace(/^(origin\/)/, '')
-    );
   }
 
   execute(args) {


### PR DESCRIPTION
## Version 1.10.1
### Bug Fixes
- The `describe` command no longer reports the available `branch` options for an `upgrade`. The logic for fetching the branches was buggy. Additionally, this functionality is outside Jambo's scope of responsibility. Now, the `--branch` flag is described as a simple string, instead of a `singleoption`. (#190)