### PR TITLE
Update getRepoForTheme to use HTTPS instead of SSH.

### DIFF
--- a/src/utils/gitutils.js
+++ b/src/utils/gitutils.js
@@ -6,7 +6,7 @@ const UserError = require('../errors/usererror')
 exports.getRepoForTheme = function(themeName) {
   switch (themeName) {
     case 'answers-hitchhiker-theme':
-      return 'git@github.com:yext/answers-hitchhiker-theme.git';
+      return 'https://github.com/yext/answers-hitchhiker-theme.git';
     default:
       throw new UserError('Unrecognized theme');
   }


### PR DESCRIPTION
This PR updates the getRepoForTheme method to use the HTTPS protocol instead
of SSH. Recently, the Theme was made public. The hope was that this meant
the Preview containers in CBD would not need an SSH key anymore. But, if the
SSH protocol is used, an SSH key is still required, even though the Theme
repo is now public.

TEST=manual

Removed my local machine's SSH key from Github and verified that I could still
import and upgrade the Theme in a Jambo site.