### PR TITLE
Remove the 'themes/answers-hitchhiker-theme' prefix from override's d…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/commands/override/overridecommand.js
+++ b/src/commands/override/overridecommand.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const fileSystem = require('file-system');
 const { ShadowConfiguration, ThemeShadower } = require('./themeshadower');
 const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argumentmetadata');
@@ -50,15 +51,20 @@ class OverrideCommand {
    */
   static _getThemeFiles(jamboConfig) {
     const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
-    if (!themesDir) {
+    const defaultTheme = jamboConfig.defaultTheme;
+
+    if (!themesDir || !defaultTheme) {
       return [];
     }
     const themeFiles = []
-    fileSystem.recurseSync(themesDir, function(filepath) {
-      if (fs.statSync(filepath).isFile()) {
-        themeFiles.push(filepath);
+    fileSystem.recurseSync(
+      path.join(themesDir, defaultTheme), 
+      function(filepath, relative) {
+        if (fs.statSync(filepath).isFile()) {
+          themeFiles.push(relative);
+        }
       }
-    });
+    );
     return themeFiles;
   }
 


### PR DESCRIPTION
…escribe.

The override command's describe method prefixed all the options with the path
to the HH Theme. This is inaccurate, the options should all be relative to the
HH Theme. This was causing nobody to be able to create an override in CBD.

This is the last change that will go into Jambo v1.10.2, so the version was
also updated.

J=SLAP-1129
TEST=manual

Ran describe on a local repo and verified the HH Theme directory prefix was
no longer present in the override options. Made sure I could copy one of the
options exactly and pass it to the override command. The expected shadow was
created. Ran describe on a repo with no Theme imported and verified that the
correct output was returned.