### PR TITLE
v1.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {

--- a/src/commands/override/overridecommand.js
+++ b/src/commands/override/overridecommand.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const fileSystem = require('file-system');
 const { ShadowConfiguration, ThemeShadower } = require('./themeshadower');
 const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argumentmetadata');
@@ -50,15 +51,20 @@ class OverrideCommand {
    */
   static _getThemeFiles(jamboConfig) {
     const themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
-    if (!themesDir) {
+    const defaultTheme = jamboConfig.defaultTheme;
+
+    if (!themesDir || !defaultTheme) {
       return [];
     }
     const themeFiles = []
-    fileSystem.recurseSync(themesDir, function(filepath) {
-      if (fs.statSync(filepath).isFile()) {
-        themeFiles.push(filepath);
+    fileSystem.recurseSync(
+      path.join(themesDir, defaultTheme), 
+      function(filepath, relative) {
+        if (fs.statSync(filepath).isFile()) {
+          themeFiles.push(relative);
+        }
       }
-    });
+    );
     return themeFiles;
   }
 

--- a/src/utils/gitutils.js
+++ b/src/utils/gitutils.js
@@ -6,7 +6,7 @@ const UserError = require('../errors/usererror')
 exports.getRepoForTheme = function(themeName) {
   switch (themeName) {
     case 'answers-hitchhiker-theme':
-      return 'git@github.com:yext/answers-hitchhiker-theme.git';
+      return 'https://github.com/yext/answers-hitchhiker-theme.git';
     default:
       throw new UserError('Unrecognized theme');
   }


### PR DESCRIPTION
## Version 1.10.2
### Bug Fixes
- The HTTPS protocol is now used when cloning the Hitchhiker Theme. The Theme was recenty open sourced, so there will be no credential issues. (#195)
- The `describe` command no longer lists incorrect `path` options for the `override` command. Previously, the options had an incorrect root prefix. (#196)