### PR TITLE
Only load javascript files for custom commands

### DIFF
--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -29,7 +29,6 @@ class CommandImporter {
       fs.readdirSync(mergedDirectory)
         .map(directoryPath => path.resolve(mergedDirectory, directoryPath))
         .filter(directoryPath => directoryPath.endsWith('.js'))
-        .filter(directoryPath => fs.lstatSync(directoryPath).isFile())
         .forEach(filePath => {
           const requiredModule = require(filePath);
 

--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -28,6 +28,7 @@ class CommandImporter {
       const mergedDirectory = this._mergeCommandDirectories(commandDirectories);
       fs.readdirSync(mergedDirectory)
         .map(directoryPath => path.resolve(mergedDirectory, directoryPath))
+        .filter(directoryPath => directoryPath.endsWith('.js'))
         .filter(directoryPath => fs.lstatSync(directoryPath).isFile())
         .forEach(filePath => {
           const requiredModule = require(filePath);

--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -29,6 +29,7 @@ class CommandImporter {
       fs.readdirSync(mergedDirectory)
         .map(directoryPath => path.resolve(mergedDirectory, directoryPath))
         .filter(directoryPath => directoryPath.endsWith('.js'))
+        .filter(directoryPath => fs.lstatSync(directoryPath).isFile())
         .forEach(filePath => {
           const requiredModule = require(filePath);
 


### PR DESCRIPTION
Ensure that files end with '.js' before trying to load the module

This fixes a bug where jambo would crash if a .DS_Store file was present in the commands folder.

J=none
TEST=manual

Test that jambo no longer crashes if a .DS_Store file is present in the command folder. Test the `jambo --help` command, the `jambo describe` command, and the custom vertical command from the theme.