### PR TITLE
fix run-tests workflow not running

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,9 +4,7 @@
 
 name: Run Tests
 
-on:
-  pull_request:
-    branches: [ master ]
+on: pull_request
 
 jobs:
   build:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@
 
 name: Run Tests
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,6 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# test commit
 
 name: Run Tests
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,5 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-# test commit
 
 name: Run Tests
 


### PR DESCRIPTION
Previously, this was set to only run on pull request into master.
Instead, it should run on pull requests into any branch, and also on any subsequent pushes
to a pull request (this is the same as we have it on other repos).
This way we run tests both on what the repo would look like after the branch is merged,
and also on the branch itself.

TEST=auto

test that PRs and additional pushes to PR won't run tests without this change