### PR TITLE
Support importing by specifying a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Import a theme after initializing the repo.
 #### Import
 
 ```bash
-npx jambo import --url https://github.com/yext/answers-hitchhiker-theme.git
+npx jambo import --themeUrl https://github.com/yext/answers-hitchhiker-theme.git
 ```
 
 The import command imports the designated theme into the 'themes' folder.
 
-**--url** _theme_url_
+**--themeUrl** _theme_url_
 
 The URL of the theme to import.
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ Import a theme after initializing the repo.
 #### Import
 
 ```bash
-npx jambo import --theme answers-hitchhiker-theme
+npx jambo import --url https://github.com/yext/answers-hitchhiker-theme.git
 ```
 
 The import command imports the designated theme into the 'themes' folder.
 
-**--theme** _theme_name_
+**--url** _theme_url_
 
-The name of the theme to import.
+The URL of the theme to import.
 
 ###### Optional Arguments
 

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -2,7 +2,8 @@ const path = require('path');
 const simpleGit = require('simple-git/promise');
 const git = simpleGit();
 const { ThemeShadower } = require('../override/themeshadower');
-const { getRepoForTheme } = require('../../utils/gitutils');
+const ThemeManager = require('../../utils/thememanager');
+const { getRepoNameFromURL } = require('../../utils/gitutils');
 const SystemError = require('../../errors/systemerror');
 const UserError = require('../../errors/usererror');
 const { isCustomError } = require('../../utils/errorutils');
@@ -31,10 +32,14 @@ class ThemeImporter {
 
   static args() {
     return {
+      url: new ArgumentMetadata({
+        type: ArgumentType.STRING,
+        description: 'url of the theme\'s git repo',
+      }),
       theme: new ArgumentMetadata({
         type: ArgumentType.STRING,
-        description: 'theme to import',
-        isRequired: true
+        description: '(deprecated: specify the url instead)'
+          + ' the name of the theme to import',
       }),
       addAsSubmodule: new ArgumentMetadata({
         type: ArgumentType.BOOLEAN,
@@ -45,14 +50,17 @@ class ThemeImporter {
   }
 
   static describe() {
-    const importableThemes = this._getImportableThemes();
+    const importableThemes = ThemeManager.getKnownThemes();
     return {
       displayName: 'Import Theme',
       params: {
+        url: {
+          displayName: 'URL',
+          type: 'string',
+        },
         theme: {
           displayName: 'Theme',
           type: 'singleoption',
-          required: true,
           options: importableThemes
         },
         addAsSubmodule: {
@@ -64,15 +72,8 @@ class ThemeImporter {
     }
   }
 
-  /**
-   * @returns {Array<string>} the names of the available themes to be imported
-   */
-  static _getImportableThemes() {
-    return ['answers-hitchhiker-theme'];
-  }
-
   execute(args) {
-    this.import(args.theme, args.addAsSubmodule)
+    this.import(args.url, args.theme, args.addAsSubmodule)
       .then(console.log);
   }
 
@@ -80,19 +81,25 @@ class ThemeImporter {
    * Imports the requested theme into Jambo's Themes directory. Note that the theme can
    * either be cloned directly into this directory or added there as a submodule.
    *
-   * @param {string} themeName The name of the theme
+   * @param {string} url The URL of the theme to import. Takes precedence over the 'theme'
+   *                     param.
+   * @param {string} themeName The name of a known theme.
    * @param {boolean} addAsSubmodule If the theme should be imported as a submodule.
    * @returns {Promise<string>} If the addition of the submodule was successful, a Promise
    *                            containing the new submodule's local path. If the addition
    *                            failed, a Promise containing the error.
    */
-  async import(themeName, addAsSubmodule) {
+  async import(url, themeName, addAsSubmodule) {
     if (!this.config) {
       throw new UserError('No jambo.json found. Did you `jambo init` yet?');
     }
+    if (!url && !themeName) {
+      throw new UserError('A URL or a theme must be specifed for an import');
+    }
     try {
-      const themeRepo = getRepoForTheme(themeName);
-      const themePath = path.join(this.config.dirs.themes, themeName);
+      const themeRepo = url || ThemeManager.getRepoForTheme(themeName);
+      const themeRepoName = url ? getRepoNameFromURL(url) : themeName;
+      const themePath = path.join(this.config.dirs.themes, themeRepoName);
 
       if (addAsSubmodule) {
         await git.submoduleAdd(themeRepo, themePath);

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -81,8 +81,8 @@ class ThemeImporter {
    * Imports the requested theme into Jambo's Themes directory. Note that the theme can
    * either be cloned directly into this directory or added there as a submodule.
    *
-   * @param {string} url The URL of the theme to import. Takes precedence over the 'theme'
-   *                     param.
+   * @param {string} url The URL of the theme to import. Takes precedence over the
+   *                     'themeName' param.
    * @param {string} themeName The name of a known theme.
    * @param {boolean} addAsSubmodule If the theme should be imported as a submodule.
    * @returns {Promise<string>} If the addition of the submodule was successful, a Promise

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -32,13 +32,13 @@ class ThemeImporter {
 
   static args() {
     return {
-      url: new ArgumentMetadata({
+      themeUrl: new ArgumentMetadata({
         type: ArgumentType.STRING,
         description: 'url of the theme\'s git repo',
       }),
       theme: new ArgumentMetadata({
         type: ArgumentType.STRING,
-        description: '(deprecated: specify the url instead)'
+        description: '(deprecated: specify the themeUrl instead)'
           + ' the name of the theme to import',
       }),
       addAsSubmodule: new ArgumentMetadata({
@@ -54,7 +54,7 @@ class ThemeImporter {
     return {
       displayName: 'Import Theme',
       params: {
-        url: {
+        themeUrl: {
           displayName: 'URL',
           type: 'string',
         },
@@ -73,7 +73,7 @@ class ThemeImporter {
   }
 
   execute(args) {
-    this.import(args.url, args.theme, args.addAsSubmodule)
+    this.import(args.themeUrl, args.theme, args.addAsSubmodule)
       .then(console.log);
   }
 
@@ -81,7 +81,7 @@ class ThemeImporter {
    * Imports the requested theme into Jambo's Themes directory. Note that the theme can
    * either be cloned directly into this directory or added there as a submodule.
    *
-   * @param {string} url The URL of the theme to import. Takes precedence over the
+   * @param {string} themeUrl The URL of the theme to import. Takes precedence over the
    *                     'themeName' param.
    * @param {string} themeName The name of a known theme.
    * @param {boolean} addAsSubmodule If the theme should be imported as a submodule.
@@ -89,16 +89,16 @@ class ThemeImporter {
    *                            containing the new submodule's local path. If the addition
    *                            failed, a Promise containing the error.
    */
-  async import(url, themeName, addAsSubmodule) {
+  async import(themeUrl, themeName, addAsSubmodule) {
     if (!this.config) {
       throw new UserError('No jambo.json found. Did you `jambo init` yet?');
     }
-    if (!url && !themeName) {
+    if (!themeUrl && !themeName) {
       throw new UserError('A URL or a theme must be specifed for an import');
     }
     try {
-      const themeRepo = url || ThemeManager.getRepoForTheme(themeName);
-      const themeRepoName = url ? getRepoNameFromURL(url) : themeName;
+      const themeRepo = themeUrl || ThemeManager.getRepoForTheme(themeName);
+      const themeRepoName = themeUrl ? getRepoNameFromURL(themeUrl) : themeName;
       const themePath = path.join(this.config.dirs.themes, themeRepoName);
 
       if (addAsSubmodule) {

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -53,6 +53,7 @@ exports.RepositoryScaffolder = class {
       if (theme) {
         const themeImporter = new ThemeImporter(jamboConfig);
         await themeImporter.import(
+          null,
           theme, 
           repositorySettings.shouldAddThemeAsSubmodule());
       }

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const simpleGit = require('simple-git/promise');
 
-const { getRepoForTheme } = require('../../utils/gitutils');
+const { ThemeManager } = require('../../utils/thememanager');
 const { CustomCommand } = require('../../utils/customcommands/command');
 const { CustomCommandExecuter } = require('../../utils/customcommands/commandexecuter');
 const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argumentmetadata');
@@ -158,8 +158,13 @@ class ThemeUpgrader {
    * @param {string} branch
    */
   async _recloneTheme(themeName, themePath, branch) {
+    if (!ThemeManager.isThemeKnown(themeName)) {
+      throw new UserError(
+        `The theme ${themeName} cannot be upgraded because it is not a known theme.`
+      );
+    }
     await fs.remove(themePath);
-    const themeRepoURL = getRepoForTheme(themeName);
+    const themeRepoURL = ThemeManager.getRepoForTheme(themeName);
     const updateBranch = branch || 'master';
     await git.clone(themeRepoURL, themePath, ['--branch', updateBranch]);
   }

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -158,11 +158,6 @@ class ThemeUpgrader {
    * @param {string} branch
    */
   async _recloneTheme(themeName, themePath, branch) {
-    if (!ThemeManager.isThemeKnown(themeName)) {
-      throw new UserError(
-        `The theme ${themeName} cannot be upgraded because it is not a known theme.`
-      );
-    }
     await fs.remove(themePath);
     const themeRepoURL = ThemeManager.getRepoForTheme(themeName);
     const updateBranch = branch || 'master';

--- a/src/utils/gitutils.js
+++ b/src/utils/gitutils.js
@@ -1,13 +1,9 @@
-const UserError = require('../errors/usererror')
+const path = require('path');
+
 /**
- * Gets the git repo URL for the given theme name.
- * @param {string} themeName 
+ * Gets the repo name from a git repo URL
+ * @param {string} repoURL
  */
-exports.getRepoForTheme = function(themeName) {
-  switch (themeName) {
-    case 'answers-hitchhiker-theme':
-      return 'https://github.com/yext/answers-hitchhiker-theme.git';
-    default:
-      throw new UserError('Unrecognized theme');
-  }
+exports.getRepoNameFromURL = function(repoURL) {
+  return path.basename(repoURL, '.git');
 }

--- a/src/utils/thememanager.js
+++ b/src/utils/thememanager.js
@@ -1,6 +1,6 @@
 const UserError = require('../errors/usererror')
 
-const themeRepos = {
+const ThemeRepos = {
   'answers-hitchhiker-theme': 'https://github.com/yext/answers-hitchhiker-theme.git'
 }
 
@@ -15,7 +15,7 @@ class ThemeManager {
    * @returns {boolean}
    */
   static isThemeKnown(themeName) {
-    return (themeName in themeRepos);
+    return (themeName in ThemeRepos);
   }
 
   /**
@@ -23,7 +23,7 @@ class ThemeManager {
    * @returns {string[]}
    */
   static getKnownThemes() {
-    return Object.keys(themeRepos);
+    return Object.keys(ThemeRepos);
   }
 
   /**
@@ -36,7 +36,7 @@ class ThemeManager {
     if (!this.isThemeKnown(themeName)) {
       throw new UserError(`The theme ${themeName} is not known by Jambo.`);
     }
-    return themeRepos[themeName];
+    return ThemeRepos[themeName];
   }
 }
 

--- a/src/utils/thememanager.js
+++ b/src/utils/thememanager.js
@@ -1,0 +1,43 @@
+const UserError = require('../errors/usererror')
+
+const themeRepos = {
+  'answers-hitchhiker-theme': 'https://github.com/yext/answers-hitchhiker-theme.git'
+}
+
+/**
+ * Responsible for providing information about themes known by Jambo
+ */
+class ThemeManager {
+  /**
+   * Returns true if a theme name is known by Jambo
+   *
+   * @param {string} themeName 
+   * @returns {boolean}
+   */
+  static isThemeKnown(themeName) {
+    return (themeName in themeRepos);
+  }
+
+  /**
+   * Returns an array of known themes
+   * @returns {string[]}
+   */
+  static getKnownThemes() {
+    return Object.keys(themeRepos);
+  }
+
+  /**
+   * Gets the repo for a given theme name
+   * 
+   * @param {string} themeName The URL to a theme, or the name of a known theme.
+   * @returns 
+   */
+  static getRepoForTheme(themeName) {
+    if (!this.isThemeKnown(themeName)) {
+      throw new UserError(`The theme ${themeName} is not known by Jambo.`);
+    }
+    return themeRepos[themeName];
+  }
+}
+
+module.exports = ThemeManager;


### PR DESCRIPTION
Add a --themUrl option to the import command

The theme URL is now the preferred way to import a theme. This PR deprecates specifying a theme name directly.

J=SLAP-1136
TEST=manual

Test importing by HTTPS URL, SSH URL, and by theme name. Confirm that an error is thrown if neither a URL or a theme name are supplied. Confirm that an error is thrown if a URL is not supplied and the theme isn't known by jambo. Test that if both URL and theme are supplied, the URL is used. Test an upgrade. Observe the output of `jambo import --help` and `jambo describe`