### PR TITLE
Add themeUrl param to the init command

### DIFF
--- a/src/commands/init/initcommand.js
+++ b/src/commands/init/initcommand.js
@@ -1,5 +1,6 @@
 const { RepositorySettings, RepositoryScaffolder } = require('./repositoryscaffolder');
 const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argumentmetadata');
+const ThemeManager = require('../../utils/thememanager');
 
 /**
  * InitCommand initializes the current directory as a Jambo repository.
@@ -15,9 +16,14 @@ class InitCommand {
 
   static args() {
     return {
+      themeUrl: new ArgumentMetadata({
+        type: ArgumentType.STRING,
+        description: 'url of a theme\'s git repo to import during the init',
+      }),
       theme: new ArgumentMetadata({
         type: ArgumentType.STRING,
-        description: 'a starter theme',
+        description: '(deprecated: specify the themeUrl instead)'
+          + ' the name of a theme to import during the init',
         isRequired: false
       }),
       addThemeAsSubmodule: new ArgumentMetadata({
@@ -29,10 +35,14 @@ class InitCommand {
   }
 
   static describe() {
-    const importableThemes = this._getImportableThemes();
+    const importableThemes = ThemeManager.getKnownThemes();
     return {
       displayName: 'Initialize Jambo',
       params: {
+        themeUrl: {
+          displayName: 'URL',
+          type: 'string',
+        },
         theme: {
           displayName: 'Theme',
           type: 'singleoption',
@@ -45,13 +55,6 @@ class InitCommand {
         }
       }
     }
-  }
-
-  /**
-   * @returns {Array<string>} the names of the available themes to be imported
-   */
-  static _getImportableThemes() {
-    return ['answers-hitchhiker-theme'];
   }
 
   execute(args) {

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -7,14 +7,19 @@ const git = simpleGit();
 
 /**
  * RepositorySettings contains the information needed by Jambo to scaffold a new site
- * repository. Currently, these settings include an optional theme and whether or not
- * the theme should be imported as a submodule.
+ * repository. Currently, these settings include an optional themeUrl, theme name, and
+ * whether or not the theme should be imported as a submodule.
  */
 exports.RepositorySettings = class {
-  constructor({ theme, addThemeAsSubmodule, includeTranslations }) {
+  constructor({ themeUrl, theme, addThemeAsSubmodule, includeTranslations }) {
+    this._themeUrl = themeUrl;
     this._theme = theme;
     this._addThemeAsSubmodule = addThemeAsSubmodule;
     this._includeTranslations = includeTranslations;
+  }
+
+  getThemeUrl() {
+    return this._themeUrl;
   }
 
   getTheme() {
@@ -49,11 +54,12 @@ exports.RepositoryScaffolder = class {
       this._createDirectorySkeleton(includeTranslations);
       const jamboConfig = this._createJamboConfig(includeTranslations);
 
+      const themeUrl = repositorySettings.getThemeUrl();
       const theme = repositorySettings.getTheme();
-      if (theme) {
+      if (themeUrl || theme) {
         const themeImporter = new ThemeImporter(jamboConfig);
         await themeImporter.import(
-          null,
+          themeUrl,
           theme, 
           repositorySettings.shouldAddThemeAsSubmodule());
       }


### PR DESCRIPTION
Allow a themeUrl to be passed to the init command

This is adds the same functionality that #205 does for the import command, except this is for the init command

J=SLAP-1136
TEST=manual

Test importing by theme URL, and by theme name. Confirm that init works if neither a URL or a theme name is supplied. Confirm that an error is thrown if a URL is not supplied and the theme isn't known by jambo. Test that if both URL and theme are supplied, the URL is used. Observe the output of jambo init --help and jambo describe