### PR TITLE
rename addAsSubmodules to useSubmodules, false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Install jambo from npm, and save it to your package.json as a dev-dependency.
 ```bash
 npm install -D jambo
 ```
+
 ___
 
 ## Usage
@@ -28,9 +29,13 @@ Currently, only answers-hitchhiker-theme is supported.
 
 ###### Optional Arguments
 
---theme _theme_name_
+--themeUrl _theme_url_
 
-Import a theme after initializing the repo.
+The git URL of the theme to import, if a theme should be imported on init.
+
+--useSubmodules _true/false_
+
+If importing a theme on init, whether to import it as a git submodule as opposed to regular files. Defaults to false.
 
 #### Import
 
@@ -42,13 +47,13 @@ The import command imports the designated theme into the 'themes' folder.
 
 **--themeUrl** _theme_url_
 
-The URL of the theme to import.
+The git URL of the theme to import.
 
 ###### Optional Arguments
 
 --useSubmodules _true/false_
 
-Whether to import the theme as a submodule, as opposed to regular files. Defaults to false.
+Whether to import the theme as a git submodule, as opposed to regular files. Defaults to false.
 
 #### Override
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ The URL of the theme to import.
 
 ###### Optional Arguments
 
---addAsSubmodule _true/false_
+--useSubmodules _true/false_
 
-Whether to import the theme as a submodule, defaults to true.
+Whether to import the theme as a submodule, as opposed to regular files. Defaults to false.
 
 #### Override
 

--- a/src/commands/init/initcommand.js
+++ b/src/commands/init/initcommand.js
@@ -28,8 +28,7 @@ class InitCommand {
       }),
       useSubmodules: new ArgumentMetadata({
         type: ArgumentType.BOOLEAN, 
-        description: 'if starter theme should be imported as submodule',
-        defaultValue: true
+        description: 'if starter theme should be imported as submodule'
       }),
     }
   }
@@ -50,8 +49,7 @@ class InitCommand {
         },
         useSubmodules: {
           displayName: 'Use Submodules',
-          type: 'boolean',
-          default: true
+          type: 'boolean'
         }
       }
     }

--- a/src/commands/init/initcommand.js
+++ b/src/commands/init/initcommand.js
@@ -26,7 +26,7 @@ class InitCommand {
           + ' the name of a theme to import during the init',
         isRequired: false
       }),
-      addThemeAsSubmodule: new ArgumentMetadata({
+      useSubmodules: new ArgumentMetadata({
         type: ArgumentType.BOOLEAN, 
         description: 'if starter theme should be imported as submodule',
         defaultValue: true
@@ -48,8 +48,8 @@ class InitCommand {
           type: 'singleoption',
           options: importableThemes
         },
-        addThemeAsSubmodule: {
-          displayName: 'Add Theme as Submodule',
+        useSubmodules: {
+          displayName: 'Use Submodules',
           type: 'boolean',
           default: true
         }

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -11,10 +11,10 @@ const git = simpleGit();
  * whether or not the theme should be imported as a submodule.
  */
 exports.RepositorySettings = class {
-  constructor({ themeUrl, theme, addThemeAsSubmodule, includeTranslations }) {
+  constructor({ themeUrl, theme, useSubmodules, includeTranslations }) {
     this._themeUrl = themeUrl;
     this._theme = theme;
-    this._addThemeAsSubmodule = addThemeAsSubmodule;
+    this._useSubmodules = useSubmodules;
     this._includeTranslations = includeTranslations;
   }
 
@@ -26,8 +26,8 @@ exports.RepositorySettings = class {
     return this._theme;
   }
 
-  shouldAddThemeAsSubmodule() {
-    return this._addThemeAsSubmodule;
+  shouldUseSubmodules() {
+    return this._useSubmodules;
   }
 
   shouldIncludeTranslations() {
@@ -61,7 +61,7 @@ exports.RepositoryScaffolder = class {
         await themeImporter.import(
           themeUrl,
           theme, 
-          repositorySettings.shouldAddThemeAsSubmodule());
+          repositorySettings.shouldUseSubmodules());
       }
     } catch (err) {
       throw new SystemError(err.message, err.stack);

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -15,10 +15,9 @@ const mockInitCommand = {
           type: 'singleoption',
           options: ['answers-hitchhiker-theme']
         },
-        addThemeAsSubmodule: {
-          displayName: 'Add Theme as Submodule',
-          type: 'boolean',
-          default: true
+        useSubmodules: {
+          displayName: 'Use Submodules',
+          type: 'boolean'
         }
       }
     }
@@ -54,10 +53,9 @@ describe('DescribeCommand works correctly', () => {
           type: 'singleoption',
           options: ['answers-hitchhiker-theme']
         },
-        addThemeAsSubmodule: {
-          displayName: 'Add Theme as Submodule',
-          type: 'boolean',
-          default: true
+        useSubmodules: {
+          displayName: 'Use Submodules',
+          type: 'boolean'
         }
       }
     });


### PR DESCRIPTION
This commit renames the --addAsSubmodules param of jambo import and init to
--useSubmodules, and changse the default to false.

J=SLAP-1135
TEST=manual

test that I can import a theme with useSubmodules, and it will be a submodule
test jambo import --theme answers-hitchihker-theme and see it will be imported
as regular checked in files, with the a .git folder removed. check that I can commit
the theme changes without any errors/warning messages, which you would see if
you tried the .git folder wasn't removed

test importing a theme on init, but as submodule and as regular files