### PR TITLE
Codify the minimum required Node version for Jambo.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "bin": {
     "jambo": "src/cli.js"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "author": "nbramblett@yext.com",
   "license": "BSD-3-Clause",
   "bugs": {


### PR DESCRIPTION
This PR adds `engines.node` to the `package.json`. This property
allows us to specify the Node version(s) that work with a given
Jambo version. If a user tries to npm install Jambo with an
incompatible Node version, they will receive an error and the
install will fail (assuming they have `engine-strict` enabled).

A change will be made to the Template repos to ensure that it
includes a .npmrc file with `engine-strict`.

TEST=manual

Tried installing Jambo in a local repo with Node 10. I saw an error
indicating my Node version did not meet Jambo's requirements. When
I switched to Node 12, I was able to install it without issue.