### PR TITLE
factor out buildJamboCLI() from cli.js

### DIFF
--- a/src/buildJamboCLI.js
+++ b/src/buildJamboCLI.js
@@ -1,0 +1,69 @@
+const fs = require('file-system');
+const path = require('path');
+const { parseJamboConfig } = require('./utils/jamboconfigutils');
+const CommandRegistry = require('./commands/commandregistry');
+const YargsFactory = require('./yargsfactory');
+const CommandImporter = require('./commands/commandimporter');
+
+/**
+ * @param {string[]} argv the argv for the current process
+ * @returns {import('yargs').Argv} A fully built Jambo CLI instance.
+ */
+module.exports = function buildJamboCLI(argv) {
+  const jamboConfig = fs.existsSync('jambo.json') && parseJamboConfig();
+  const commandRegistry = new CommandRegistry();
+
+  if (argv.length < 3) {
+    console.error('You must provide Jambo with a command.');
+    return;
+  }
+
+  const shouldParseCustomCommands =
+    shouldImportCustomCommands(argv[2], commandRegistry);
+  const canParseCustomCommands =
+    jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output;
+
+  if (shouldParseCustomCommands && canParseCustomCommands) {
+    importCustomCommands(jamboConfig, commandRegistry);
+  }
+
+  const yargsFactory = new YargsFactory(commandRegistry, jamboConfig);
+  return yargsFactory.createCLI();
+}
+
+/**
+ * Determines if custom {@link Command}s should be imported and added to the CLI instance.
+ * 
+ * @param {string} invokedCommand The Jambo command that was invoked from the 
+ *                                command line.
+ * @param {CommandRegistry} commandRegistry The registry containing all built-in commands.
+ * @returns {boolean} If custom {@link Command}s need to be added to the CLI instance.    
+ */
+function shouldImportCustomCommands(invokedCommand, commandRegistry) {
+  const isCustomCommand =
+    !commandRegistry.getAliases().includes(invokedCommand) &&
+    !invokedCommand.startsWith('--');
+
+  return invokedCommand === '--help' ||
+    invokedCommand === 'describe' ||
+    isCustomCommand;
+}
+
+/**
+ * Imports custom commands from the Theme and the top-level of the site repository.
+ * The imported commands are added to the provided {@link CommandRegistry}.
+ * 
+ * @param {Object} jamboConfig The site's parsed Jambo configuration.
+ * @param {CommandRegistry} commandRegistry The existing registry of built-in commands.
+ */
+function importCustomCommands(jamboConfig, commandRegistry) {
+  const commandImporter = jamboConfig.defaultTheme ?
+    new CommandImporter(
+      jamboConfig.dirs.output,
+      path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
+    new CommandImporter(jamboConfig.dirs.output);
+
+  commandImporter.import().forEach(customCommand => {
+    commandRegistry.addCommand(customCommand)
+  });
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,13 +1,6 @@
 #!/usr/bin/env node
-
-const fs = require('file-system');
-const path = require('path');
-
-const { parseJamboConfig } = require('./utils/jamboconfigutils');
 const { exitWithError } = require('./utils/errorutils');
-const CommandRegistry = require('./commands/commandregistry');
-const YargsFactory = require('./yargsfactory');
-const CommandImporter = require('./commands/commandimporter');
+const buildJamboCLI = require('./buildJamboCLI');
 
 // Exit with a non-zero exit code for unhandled rejections and uncaught exceptions
 process.on('unhandledRejection', err => {
@@ -17,67 +10,5 @@ process.on('uncaughtException', err => {
   exitWithError(err);
 });
 
-buildJamboCLI();
-
-/**
- * @returns {Object} A fully built Jambo CLI instance.
- */
-function buildJamboCLI() {
-  const jamboConfig = fs.existsSync('jambo.json') && parseJamboConfig();
-  const commandRegistry = new CommandRegistry();
-
-  if (process.argv.length < 3) {
-    console.error('You must provide Jambo with a command.');
-    return;
-  }
-
-  const shouldParseCustomCommands = 
-    shouldImportCustomCommands(process.argv[2], commandRegistry);
-  const canParseCustomCommands = 
-    jamboConfig && jamboConfig.dirs && jamboConfig.dirs.output;
-  
-  if (shouldParseCustomCommands && canParseCustomCommands) {
-    importCustomCommands(jamboConfig, commandRegistry);
-  }
-  
-  const yargsFactory = new YargsFactory(commandRegistry, jamboConfig);
-  const options = yargsFactory.createCLI();
-  return options.argv;
-}
-
-/**
- * Determines if custom {@link Command}s should be imported and added to the CLI instance.
- * 
- * @param {string} invokedCommand The Jambo command that was invoked from the 
- *                                command line.
- * @param {CommandRegistry} commandRegistry The registry containing all built-in commands.
- * @returns {boolean} If custom {@link Command}s need to be added to the CLI instance.    
- */
-function shouldImportCustomCommands(invokedCommand, commandRegistry) {
-  const isCustomCommand = 
-    !commandRegistry.getAliases().includes(invokedCommand) &&
-    !invokedCommand.startsWith('--');
-
-  return invokedCommand === '--help' ||
-    invokedCommand === 'describe' ||
-    isCustomCommand;
-}
-
-/**
- * Imports custom commands from the Theme and the top-level of the site repository.
- * The imported commands are added to the provided {@link CommandRegistry}.
- * 
- * @param {Object} jamboConfig The site's parsed Jambo configuration.
- * @param {CommandRegistry} commandRegistry The existing registry of built-in commands.
- */
-function importCustomCommands(jamboConfig, commandRegistry) {
-  const commandImporter = jamboConfig.defaultTheme ?
-    new CommandImporter(
-      jamboConfig.dirs.output,
-      path.join(jamboConfig.dirs.themes, jamboConfig.defaultTheme)) :
-    new CommandImporter(jamboConfig.dirs.output);
-
-  commandImporter.import().forEach(customCommand => {
-    commandRegistry.addCommand(customCommand)
-  });
-}
+const jambo = buildJamboCLI(process.argv)
+jambo && jambo.argv;

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,4 +11,4 @@ process.on('uncaughtException', err => {
 });
 
 const jambo = buildJamboCLI(process.argv)
-jambo && jambo.argv;
+jambo && jambo.parse();


### PR DESCRIPTION
This commit factors out the buildJamboCLI() method
from cli.js. No functional changes have been made.
This method will be used by the upcoming acceptance test
infrastructure, to create test jambo instances.

J=SLAP-992
TEST=manual

test that I can still build pages with jambo
test that jambo still logs 'You must provide Jambo with a command.'
if you don't enter a command
test that custom commands still work