### PR TITLE
allow async command handlers, use cwd for git ops

### DIFF
--- a/src/commands/build/buildcommand.js
+++ b/src/commands/build/buildcommand.js
@@ -36,9 +36,9 @@ class BuildCommand {
     }
   }
 
-  execute(args) {
+  async execute(args) {
     try {
-      this.sitesGenerator.generate(args.jsonEnvVars);
+      await this.sitesGenerator.generate(args.jsonEnvVars);
     } catch (err) {
       if (isCustomError(err)) {
         throw err;

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -12,6 +12,7 @@ const { CustomCommand } = require('../../utils/customcommands/command');
 const { CustomCommandExecuter } = require('../../utils/customcommands/commandexecuter');
 const { searchDirectoryIgnoringExtensions } = require('../../utils/fileutils');
 const fsExtra = require('fs-extra');
+const process = require('process');
 
 /**
  * ThemeImporter imports a specified theme into the themes directory.
@@ -71,8 +72,8 @@ class ThemeImporter {
     }
   }
 
-  execute(args) {
-    this.import(args.themeUrl, args.theme, args.useSubmodules)
+  async execute(args) {
+    await this.import(args.themeUrl, args.theme, args.useSubmodules)
       .then(console.log);
   }
 
@@ -99,7 +100,7 @@ class ThemeImporter {
       const themeRepo = themeUrl || ThemeManager.getRepoForTheme(themeName);
       const themeRepoName = themeUrl ? getRepoNameFromURL(themeUrl) : themeName;
       const themePath = path.join(this.config.dirs.themes, themeRepoName);
-
+      await git.cwd(process.cwd());
       if (useSubmodules) {
         await git.submoduleAdd(themeRepo, themePath);
       } else {

--- a/src/commands/init/initcommand.js
+++ b/src/commands/init/initcommand.js
@@ -55,10 +55,10 @@ class InitCommand {
     }
   }
 
-  execute(args) {
+  async execute(args) {
     const repositorySettings = new RepositorySettings(args);
     const repositoryScaffolder = new RepositoryScaffolder();
-    repositoryScaffolder.create(repositorySettings);
+    await repositoryScaffolder.create(repositorySettings);
   }
 }
 

--- a/src/commands/init/repositoryscaffolder.js
+++ b/src/commands/init/repositoryscaffolder.js
@@ -1,6 +1,7 @@
 const ThemeImporter = require('../import/themeimporter');
 
 const fs = require('file-system');
+const process = require('process');
 const simpleGit = require('simple-git/promise');
 const SystemError = require('../../errors/systemerror');
 const git = simpleGit();
@@ -46,6 +47,8 @@ exports.RepositoryScaffolder = class {
    */
   async create(repositorySettings) {
     try {
+      const cwd = process.cwd();
+      await git.cwd(cwd);
       await git.init();
       fs.writeFileSync('.gitignore', 'public/\nnode_modules/\n');
 

--- a/src/yargsfactory.js
+++ b/src/yargsfactory.js
@@ -16,6 +16,8 @@ class YargsFactory {
   /**
    * Generates a {@link yargs} instance with all of the built-in and custom
    * commands known to Jambo. 
+   * 
+   * @returns {import('yargs').Argv}
    */
   createCLI() {
     const cli = yargs.usage('Usage: $0 <cmd> <operation> [options]');
@@ -23,7 +25,7 @@ class YargsFactory {
     this._commandRegistry.getCommands().forEach(commandClass => {
       cli.command(this._createCommandModule(commandClass));
     });
-    cli.strict()
+    cli.strict();
 
     return cli;
   }
@@ -52,9 +54,9 @@ class YargsFactory {
           }
         });
       },
-      handler: argv => {
+      handler: async argv => {
         const commandInstance = this._createCommandInstance(commandClass);
-        commandInstance.execute(argv);
+        await commandInstance.execute(argv);
       }
     }
   }

--- a/src/yargsfactory.js
+++ b/src/yargsfactory.js
@@ -67,7 +67,7 @@ class YargsFactory {
    * 
    * @param {string} name The name of the option.
    * @param {ArgumentMetadata} metadata The option's {@link ArgumentMetadata}.
-   * @param {Object} yargs The Yargs instance to modify.
+   * @param {import('yargs').Argv} yargs The Yargs instance to modify.
    */
   _addListOption(name, metadata, yargs) {
     yargs.array(name);


### PR DESCRIPTION
This commit allows command handlers to be async, so that
upcoming acceptance test infrastructure can run multiple
commands one after another in the same process.

It also updates the init and import commands to perform
git operations within the current working directory, instead
of the initial directory jambo was called in. This is needed so that
acceptance tests can use jambo in a directory different than 
the one the acceptance tests live in. It also will be useful if we
ever release a Jambo API, so that Jambo can be called programmatically
in JS.

This does not change Jambo's behavior when only one
command is run per process, which is what normally happens.

J=SLAP-992
TEST=manual

test that custom commands work, init works, import works, and build works