### PR TITLE
add Coveralls github workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,30 @@
+# This workflow will run our tests, generate an lcov code coverage file,
+# and send that coverage to Coveralls 
+
+name: Code Coverage
+
+on:
+  push:
+    branches-ignore: dev/*
+  pull_request:
+
+jobs:
+  Coveralls:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npx jest --coverage
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,6 +26,7 @@ jobs:
     - run: git config --global user.email "slapshot@yext.com"
     - run: git config --global user.name "Jambo run-tests.yml"
     - run: npx jest --config=jest-coverage.json
+    - run: ls
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
+    - run: git config --global user.email "slapshot@yext.com"
+    - run: git config --global user.name "Jambo run-tests.yml"
     - run: npx jest --coverage
     - name: Coveralls
       uses: coverallsapp/github-action@master

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,6 @@ jobs:
     - run: git config --global user.email "slapshot@yext.com"
     - run: git config --global user.name "Jambo run-tests.yml"
     - run: npx jest --config=jest-coverage.json
-    - run: ls
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
     - run: npm ci
     - run: git config --global user.email "slapshot@yext.com"
     - run: git config --global user.name "Jambo run-tests.yml"
-    - run: npx jest --config=../../jest-coverage.json
+    - run: npx jest --config=jest-coverage.json
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
     - run: npm ci
     - run: git config --global user.email "slapshot@yext.com"
     - run: git config --global user.name "Jambo run-tests.yml"
-    - run: npx jest --coverage
+    - run: npx jest --config=../../jest-coverage.json
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Jambo
 
+<div>
+  <a href='https://coveralls.io/github/yext/jambo?branch=master'>
+    <img src='https://coveralls.io/repos/github/yext/jambo/badge.svg?branch=master' alt='Coverage Status' />
+  </a>
+</div>
+
 Jambo is a JAMStack implementation using Handlebars.
 
 ## Installation

--- a/jest-coverage.json
+++ b/jest-coverage.json
@@ -1,0 +1,15 @@
+{
+  "collectCoverage": true,
+  "collectCoverageFrom": ["src/**"],
+  "setupFilesAfterEnv": [
+    "./tests/setup/setup.js"
+  ],
+  "testMatch": [
+    "**/tests/**/*.js"
+  ],
+  "testPathIgnorePatterns": [
+    "<rootDir>/tests/fixtures/",
+    "<rootDir>/tests/setup/",
+    "<rootDir>/tests/acceptance/"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "shell-quote": "^1.7.2"
   },
   "jest": {
+    "collectCoverageFrom": ["src/**"],
     "verbose": true,
     "setupFilesAfterEnv": [
       "./tests/setup/setup.js"


### PR DESCRIPTION
Adds a code coverage workflow using Coveralls.
Because the acceptance tests are ran using jest, and are run
in the main thread (i.e. no spawnSyncs), the acceptance tests
count towards our coverage. Acceptance test coverage is probably
of a lower overall "quality" than our unit test coverage, since it's
not as rigid about checking output values.

Also adds a code coverage badge to the readme.

J=SLAP-873
TEST=auto