### PR TITLE
v1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.10.4",
+  "version": "1.11.0",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {
@@ -49,7 +49,9 @@
     "shell-quote": "^1.7.2"
   },
   "jest": {
-    "collectCoverageFrom": ["src/**"],
+    "collectCoverageFrom": [
+      "src/**"
+    ],
     "verbose": true,
     "setupFilesAfterEnv": [
       "./tests/setup/setup.js"


### PR DESCRIPTION
### Changes
- The "addAsSubmodule" param for the init and import commands was renamed to "useSubmodules". It now defaults to false instead of true (#207)
- When upgrading a theme checked in as regular files, Jambo now automatically removes the .git folder (#208)
- The init and import commands now support a "themeUrl" param, which lets you specify a git URL to use for the theme (#206, #205)
- Jambo now supports multiline {{ translate }} helpers (#201, #200)