### PR TITLE
Do not run the `babel` helper in Development Mode.

### DIFF
--- a/src/handlebars/registerhbshelpers.js
+++ b/src/handlebars/registerhbshelpers.js
@@ -83,7 +83,7 @@ module.exports = function registerHbsHelpers(hbs) {
     if (process.env.IS_DEVELOPMENT_PREVIEW === 'true' ) {
       return srcCode;
     } else {
-      return transformSync(srcCode, {
+      return babel.transformSync(srcCode, {
         compact: true,
         minified: true,
         comments: false,

--- a/src/handlebars/registerhbshelpers.js
+++ b/src/handlebars/registerhbshelpers.js
@@ -79,19 +79,25 @@ module.exports = function registerHbsHelpers(hbs) {
 
   hbs.registerHelper('babel', function(options) {
     const srcCode = options.fn(this);
-    return babel.transformSync(srcCode, {
-      compact: true,
-      minified: true,
-      sourceType: 'script',
-      presets: ['@babel/preset-env'],
-      plugins: [
-        '@babel/syntax-dynamic-import',
-        '@babel/plugin-transform-arrow-functions',
-        '@babel/plugin-proposal-object-rest-spread',
-        '@babel/plugin-transform-object-assign',
-      ]
+    
+    if (process.env.IS_DEVELOPMENT_PREVIEW === 'true' ) {
+      return srcCode;
+    } else {
+      return transformSync(srcCode, {
+        compact: true,
+        minified: true,
+        comments: false,
+        sourceType: 'script',
+        presets: ['@babel/preset-env'],
+        plugins: [
+          '@babel/syntax-dynamic-import',
+          '@babel/plugin-transform-arrow-functions',
+          '@babel/plugin-proposal-object-rest-spread',
+          '@babel/plugin-transform-object-assign',
+        ]
       }).code;
-  })
+    }
+  });
 
   hbs.registerHelper('partialPattern', function(cardPath, opt) {
     let result = '';


### PR DESCRIPTION
This PR adds a check to the `babel` helper to see if we are currently in the Development Mode. If
so, the enclosed source code is not run through Babel, it is returned verbatim. This is a preview
optimization, since the Babel-ification is a relatively slow operation. It's not necessary for
preview either, assuming devs are not previewing their changes in IE11.

J=SLAP-1312
TEST=manual

Ensured that when in Development mode, the helper was a simple pass-through. In Production mode,
the enclosed code was Babel-ified.