### PR TITLE
use npmlog for logging with colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3189,6 +3189,18 @@
         "jest-message-util": "^25.5.0",
         "jest-util": "^25.5.0",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "@jest/core": {
@@ -3227,6 +3239,16 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -3303,6 +3325,16 @@
         "v8-to-istanbul": "^4.1.3"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -3387,6 +3419,16 @@
         "write-file-atomic": "^3.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -3405,6 +3447,18 @@
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^15.0.0",
         "chalk": "^3.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -3740,6 +3794,44 @@
         "picomatch": "^2.0.4"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3856,6 +3948,16 @@
         "slash": "^3.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -4109,16 +4211,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      }
-    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -4163,6 +4255,11 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -4228,6 +4325,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-type": {
       "version": "1.0.4",
@@ -4422,6 +4524,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -5179,6 +5286,54 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
@@ -5371,6 +5526,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -5759,8 +5919,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -5880,6 +6039,16 @@
             "yargs": "^15.3.1"
           },
           "dependencies": {
+            "chalk": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
             "yargs": {
               "version": "15.4.1",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -6050,6 +6219,16 @@
         "realpath-native": "^2.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -6068,6 +6247,18 @@
         "diff-sequences": "^25.2.6",
         "jest-get-type": "^25.2.6",
         "pretty-format": "^25.5.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "jest-docblock": {
@@ -6090,6 +6281,18 @@
         "jest-get-type": "^25.2.6",
         "jest-util": "^25.5.0",
         "pretty-format": "^25.5.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "jest-environment-jsdom": {
@@ -6343,6 +6546,18 @@
         "jest-util": "^25.5.0",
         "pretty-format": "^25.5.0",
         "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "jest-leak-detector": {
@@ -6365,6 +6580,18 @@
         "jest-diff": "^25.5.0",
         "jest-get-type": "^25.2.6",
         "pretty-format": "^25.5.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "jest-message-util": {
@@ -6383,6 +6610,16 @@
         "stack-utils": "^1.0.1"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -6429,6 +6666,16 @@
         "slash": "^3.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -6475,6 +6722,16 @@
         "throat": "^5.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -6517,6 +6774,16 @@
         "yargs": "^15.3.1"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -6622,6 +6889,16 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -6643,6 +6920,16 @@
         "make-dir": "^3.0.0"
       },
       "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "graceful-fs": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -6663,6 +6950,18 @@
         "jest-get-type": "^25.2.6",
         "leven": "^3.1.0",
         "pretty-format": "^25.5.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "jest-watcher": {
@@ -6677,6 +6976,18 @@
         "chalk": "^3.0.0",
         "jest-util": "^25.5.0",
         "string-length": "^3.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "jest-worker": {
@@ -7103,6 +7414,22 @@
         "path-key": "^2.0.0"
       }
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -7114,6 +7441,11 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -7388,6 +7720,11 @@
           "dev": true
         }
       }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -7889,8 +8226,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -7946,8 +8282,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "simple-git": {
       "version": "1.132.0",
@@ -8833,6 +9168,43 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "i18next-conv": "^10.0.2",
     "lodash": "^4.17.15",
     "merge-options": "^2.0.0",
+    "npmlog": "^4.1.2",
     "prompts": "^2.3.1",
     "simple-git": "^1.131.0",
     "yargs": "^17.0.0"

--- a/src/buildJamboCLI.js
+++ b/src/buildJamboCLI.js
@@ -4,6 +4,7 @@ const { parseJamboConfig } = require('./utils/jamboconfigutils');
 const CommandRegistry = require('./commands/commandregistry');
 const YargsFactory = require('./yargsfactory');
 const CommandImporter = require('./commands/commandimporter');
+const { error } = require('./utils/logger');
 
 /**
  * @param {string[]} argv the argv for the current process
@@ -14,7 +15,7 @@ module.exports = function buildJamboCLI(argv) {
   const commandRegistry = new CommandRegistry();
 
   if (argv.length < 3) {
-    console.error('You must provide Jambo with a command.');
+    error('You must provide Jambo with a command.');
     return;
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,8 +2,9 @@
 const { exitWithError } = require('./utils/errorutils');
 const buildJamboCLI = require('./buildJamboCLI');
 
+// Exit with a non-zero exit code for unhandled rejections and uncaught exceptions
+process.on('unhandledRejection', exitWithError);
+process.on('uncaughtException', exitWithError);
+
 const jambo = buildJamboCLI(process.argv);
-jambo && jambo.parseAsync().catch(err => {
-  // Exit with a non-zero exit code for unhandled rejections and uncaught exceptions
-  exitWithError(err);
-});
+jambo && jambo.parseAsync().catch(exitWithError);

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,13 +2,8 @@
 const { exitWithError } = require('./utils/errorutils');
 const buildJamboCLI = require('./buildJamboCLI');
 
-// Exit with a non-zero exit code for unhandled rejections and uncaught exceptions
-process.on('unhandledRejection', err => {
-  exitWithError(err);
-});
-process.on('uncaughtException', err => {
-  exitWithError(err);
-});
-
 const jambo = buildJamboCLI(process.argv);
-jambo && jambo.parse();
+jambo && jambo.parseAsync().catch(err => {
+  // Exit with a non-zero exit code for unhandled rejections and uncaught exceptions
+  exitWithError(err);
+});

--- a/src/commands/build/pagesetsbuilder.js
+++ b/src/commands/build/pagesetsbuilder.js
@@ -6,6 +6,7 @@ const PageSet = require('../../models/pageset');
 const PageTemplate = require('../../models/pagetemplate');
 const PageTemplateDirector = require('./pagetemplatedirector');
 const { NO_LOCALE } = require('../../constants');
+const { warn } = require('../../utils/logger');
 
 /**
  * PageSetsBuilder is responsible for matching {@link PageConfigs} and
@@ -47,7 +48,7 @@ module.exports = class PageSetsBuilder {
         const localeMessage = locale !== NO_LOCALE
           ? ` for '${locale}' locale`
           : '';
-        console.log(
+        warn(
           `Warning: No page templates found${localeMessage}, not generating a ` +
           `page set${localeMessage}`);
         continue;
@@ -80,7 +81,7 @@ module.exports = class PageSetsBuilder {
         const localeMessage = config.getLocale() !== NO_LOCALE
           ? ` found for '${config.getLocale()}' locale`
           : '';
-        console.log(
+        warn(
           `Warning: No page template '${config.getPageName()}'${localeMessage}, ` +
           `not generating a '${config.getPageName()}' page${localeMessage}`);
         continue;

--- a/src/commands/build/pagesetsbuilder.js
+++ b/src/commands/build/pagesetsbuilder.js
@@ -49,7 +49,7 @@ module.exports = class PageSetsBuilder {
           ? ` for '${locale}' locale`
           : '';
         warn(
-          `Warning: No page templates found${localeMessage}, not generating a ` +
+          `No page templates found${localeMessage}, not generating a ` +
           `page set${localeMessage}`);
         continue;
       }
@@ -82,7 +82,7 @@ module.exports = class PageSetsBuilder {
           ? ` found for '${config.getLocale()}' locale`
           : '';
         warn(
-          `Warning: No page template '${config.getPageName()}'${localeMessage}, ` +
+          `No page template '${config.getPageName()}'${localeMessage}, ` +
           `not generating a '${config.getPageName()}' page${localeMessage}`);
         continue;
       }

--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -7,6 +7,7 @@ const UserError = require('../../errors/usererror');
 const { NO_LOCALE } = require('../../constants');
 const LocalizationConfig = require('../../models/localizationconfig');
 const TemplateArgsBuilder = require('./templateargsbuilder');
+const { info } = require('../../utils/logger');
 
 /**
  * PageWriter is responsible for writing output files for the given {@link PageSet} to
@@ -43,14 +44,14 @@ module.exports = class PageWriter {
     const localeMessage = pageSet.getLocale() !== NO_LOCALE
       ? ` for '${pageSet.getLocale()}' locale`
       : '';
-    console.log(`Writing files${localeMessage}`);
+    info(`Writing files${localeMessage}`);
 
     for (const page of pageSet.getPages()) {
       if (!page.getConfig()) {
         throw new UserError(`Error: No config found for page: ${page.getName()}`);
       }
 
-      console.log(`Writing output file for the '${page.getName()}' page`);
+      info(`Writing output file for the '${page.getName()}' page`);
       const templateArguments = this._templateArgsBuilder.buildArgs({
         relativePath: this._calculateRelativePath(page.getOutputPath()),
         pageName: page.getName(),

--- a/src/commands/commandimporter.js
+++ b/src/commands/commandimporter.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs-extra');
+const { warn } = require('../utils/logger');
 
 /**
  * Imports all custom {@link Command}s within a Jambo repository.
@@ -40,8 +41,7 @@ class CommandImporter {
           if (this._validateCustomCommand(commandClass)) {
             customCommands.push(commandClass);
           } else {
-            console.warn(
-              `Command in ${path.basename(filePath)} was not formatted properly`);
+            warn(`Command in ${path.basename(filePath)} was not formatted properly`);
           }
         });
 

--- a/src/commands/extract-translations/jambotranslationextractor.js
+++ b/src/commands/extract-translations/jambotranslationextractor.js
@@ -2,6 +2,7 @@ const TranslationExtractor = require('../../i18n/extractor/translationextractor'
 const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argumentmetadata');
 const fsExtra = require('fs-extra');
 const fs = require('fs');
+const { info } = require('../../utils/logger');
 
 /**
  * JamboTranslationExtractor extracts translations from a jambo repo.
@@ -54,7 +55,7 @@ class JamboTranslationExtractor {
   async _extract(outputPath) {
     const { files, directories } = this._getFilesAndDirsFromJamboConfig();
     const gitignorePaths = this._parseGitignorePaths();
-    console.log(`Extracting translations to ${outputPath}`);
+    info(`Extracting translations to ${outputPath}`);
     this.extractor.extract({
       specificFiles: files,
       directories: directories,

--- a/src/commands/import/themeimporter.js
+++ b/src/commands/import/themeimporter.js
@@ -73,8 +73,7 @@ class ThemeImporter {
   }
 
   async execute(args) {
-    await this.import(args.themeUrl, args.theme, args.useSubmodules)
-      .then(console.log);
+    await this.import(args.themeUrl, args.theme, args.useSubmodules);
   }
 
   /**

--- a/src/commands/upgrade/themeupgrader.js
+++ b/src/commands/upgrade/themeupgrader.js
@@ -11,6 +11,7 @@ const UserError = require('../../errors/systemerror');
 const { isCustomError } = require('../../utils/errorutils');
 const { searchDirectoryIgnoringExtensions } = require('../../utils/fileutils');
 const fsExtra = require('fs-extra');
+const { info } = require('../../utils/logger');
 
 const git = simpleGit();
 
@@ -114,11 +115,11 @@ class ThemeUpgrader {
       this._executePostUpgradeScript(themePath, isLegacy);
     }
     if (isLegacy) {
-      console.log(
+      info(
         'Legacy theme upgrade complete. \n' +
         'You may need to manually reinstall dependencies (e.g. an npm install).');
     } else {
-      console.log(
+      info(
         'Theme upgrade complete. \n' +
         'You may need to manually reinstall dependencies (e.g. an npm install).');
     }

--- a/src/errors/systemerror.js
+++ b/src/errors/systemerror.js
@@ -10,8 +10,8 @@ class SystemError extends Error {
     this.exitCode = 14;
 
     if (stack) {
-      this.stack = stack;
       this.message = `${this.name}: ${message}`;
+      this.stack = `${this.message}\n${stack}`;
     } else {
       Error.captureStackTrace(this, this.constructor);
     }

--- a/src/errors/usererror.js
+++ b/src/errors/usererror.js
@@ -9,8 +9,8 @@ class UserError extends Error {
     this.exitCode = 13;
 
     if (stack) {
-      this.stack = stack;
       this.message = `${this.name}: ${message}`;
+      this.stack = `${this.message}\n${stack}`;
     } else {
       Error.captureStackTrace(this, this.constructor);
     }

--- a/src/models/configurationregistry.js
+++ b/src/models/configurationregistry.js
@@ -5,6 +5,7 @@ const LocalizationConfig = require('./localizationconfig');
 const PageConfig = require('./pageconfig');
 const { FileNames, ConfigKeys } = require('../constants');
 const RawConfigValidator = require('../validation/rawconfigvalidator');
+const { info } = require('../utils/logger');
 
 /**
  * ConfigurationRegistry is a registry of the configuration files provided to Jambo.
@@ -88,7 +89,7 @@ module.exports = class ConfigurationRegistry {
     const rawLocaleConfig = configNameToRawConfig[ConfigKeys.LOCALE_CONFIG];
 
     if (!rawLocaleConfig) {
-      console.log(
+      info(
         `Cannot find '${FileNames.LOCALE_CONFIG}', using locale information ` +
         `from ${FileNames.GLOBAL_CONFIG}.`);
     }

--- a/src/utils/errorutils.js
+++ b/src/utils/errorutils.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
 const UserError = require('../errors/usererror');
 const SystemError = require('../errors/systemerror');
+const { error } = require('./logger');
 
 /**
  * Print the error, and then forcefully end the 
@@ -8,11 +8,8 @@ const SystemError = require('../errors/systemerror');
  * async operations will be lost.
  * @param {Error} error
  */
-exports.exitWithError = (err) => {
-  fs.writeSync(process.stderr.fd,
-    `${err.message}\n` +
-    `${err.stack}`
-  );
+exports.exitWithError = (err = {}) => {
+  err.stack && error(err.stack);
   const exitCode = err.exitCode || 1;
   process.exit(exitCode);
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,34 @@
+const log = require('npmlog');
+
+log.heading = 'jambo';
+log.headingStyle = { fg: 'magenta' };
+
+// Don't display a log prefix.
+const PREFIX = '';
+
+/**
+ * Logs an error.
+ *
+ * @param  {...any} args 
+ */
+exports.error = function(...args) {
+  log.error(PREFIX, ...args)
+}
+
+/**
+ * Logs a warning.
+ *
+ * @param  {...any} args 
+ */
+exports.warn = function(...args) {
+  log.warn(PREFIX, ...args)
+}
+
+/**
+ * Logs info.
+ *
+ * @param  {...any} args 
+ */
+exports.info = function(...args) {
+  log.info(PREFIX, ...args)
+}

--- a/src/yargsfactory.js
+++ b/src/yargsfactory.js
@@ -27,7 +27,8 @@ class YargsFactory {
         info(yargs.help());
         if (msg) error(msg);
         exitWithError(err);
-      });
+      })
+      .showHelp(help => info(help));
 
     this._commandRegistry.getCommands().forEach(commandClass => {
       cli.command(this._createCommandModule(commandClass));

--- a/src/yargsfactory.js
+++ b/src/yargsfactory.js
@@ -27,8 +27,7 @@ class YargsFactory {
         info(yargs.help());
         if (msg) error(msg);
         exitWithError(err);
-      })
-      .showHelp(help => info(help));
+      });
 
     this._commandRegistry.getCommands().forEach(commandClass => {
       cli.command(this._createCommandModule(commandClass));

--- a/src/yargsfactory.js
+++ b/src/yargsfactory.js
@@ -2,6 +2,8 @@ const yargs = require('yargs');
 const PageScaffolder = require('./commands/page/add/pagescaffolder');
 const SitesGenerator = require('./commands/build/sitesgenerator');
 const { ArgumentMetadata, ArgumentType } = require('./models/commands/argumentmetadata');
+const { info, error } = require('./utils/logger');
+const { exitWithError } = require('./utils/errorutils');
 
 /**
  * Creates the {@link yargs} instance that powers the Jambo CLI.
@@ -19,7 +21,13 @@ class YargsFactory {
    * @returns {import('yargs').Argv}
    */
   createCLI() {
-    const cli = yargs.usage('Usage: $0 <cmd> <operation> [options]');
+    const cli = yargs
+      .usage('Usage: $0 <cmd> <operation> [options]')
+      .fail((msg, err, yargs) => {
+        info(yargs.help());
+        if (msg) error(msg);
+        exitWithError(err);
+      });
 
     this._commandRegistry.getCommands().forEach(commandClass => {
       cli.command(this._createCommandModule(commandClass));

--- a/tests/acceptance/setup/TestInstance.js
+++ b/tests/acceptance/setup/TestInstance.js
@@ -1,5 +1,6 @@
 const buildJamboCLI = require('../../../src/buildJamboCLI');
 const { parse } = require('shell-quote');
+const { error } = require('../../../src/utils/logger');
 
 /**
  * TestInstance gives Jambo acceptance tests different ways
@@ -13,7 +14,7 @@ module.exports = class TestInstance {
     return buildJamboCLI(argv)
       .scriptName('jambo')
       .fail(function(msg, err) {
-        console.error('Error running command:', command);
+        error('Error running command:', command);
         if (err) throw err
       })
       .exitProcess(false)

--- a/tests/acceptance/suites/basic-flow.js
+++ b/tests/acceptance/suites/basic-flow.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const path = require('path');
 
 const { runInPlayground } = require('../setup/playground');
 


### PR DESCRIPTION
This commit refactors jambo's logging to use npmlog,
which is the logger used by npm (surprise!).
It adds a magenta 'jambo' log heading to differentiate it from
npm, which uses a white on black 'npm' heading.

J=SLAP-226
TEST=manual

test a regular jambo build
test jambo build when it throws an error because there's no jambo.json
test jambo page that is missing required arguments
test the custom card command in the theme
see that the tested logs look as expected, and contain the same information as before
jambo help prints normally
jambo version prints normally
warning is given if custom command is malformatted

test that you can set the npmlog log level anywhere, and that log level will be reflected globally
in the future we can let jambo set different log levels or even silence logging