### PR TITLE
Add Jambo build validation hook

### DIFF
--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -43,6 +43,7 @@ module.exports = class PageWriter {
    * Writes a file to the output directory per page in the given PageSet.
    *
    * @param {PageSet} pageSet the collection of pages to generate
+   * @throws {UserError} on missing config(s)
    */
   writePages(pageSet) {
     if (!pageSet || pageSet.getPages().length < 1) {
@@ -68,10 +69,12 @@ module.exports = class PageWriter {
         env: this._env
       });
       
-      this._templateDataValidator.validate({
+      if(!this._templateDataValidator.validate({
         pageName: page.getName(),
         pageData: templateArguments
-      });
+      })) {
+        throw new UserError('Invalid page template configuration(s).');
+      }
 
       info(`Writing output file for the '${page.getName()}' page`);
       const template = hbs.compile(page.getTemplateContents());

--- a/src/commands/build/pagewriter.js
+++ b/src/commands/build/pagewriter.js
@@ -35,7 +35,7 @@ module.exports = class PageWriter {
     /**
      * @type {TemplateDataValidator}
      */
-     this._templateDataValidator =
+    this._templateDataValidator =
       new TemplateDataValidator(config.templateDataValidationHook);
   }
 
@@ -43,7 +43,8 @@ module.exports = class PageWriter {
    * Writes a file to the output directory per page in the given PageSet.
    *
    * @param {PageSet} pageSet the collection of pages to generate
-   * @throws {UserError} on missing config(s)
+   * @throws {UserError} on missing page config(s), validation hook execution 
+   * failure, and invalid template data using Theme's validation hook
    */
   writePages(pageSet) {
     if (!pageSet || pageSet.getPages().length < 1) {

--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -177,10 +177,13 @@ class SitesGenerator {
 
       const templateDataFormatterHook = path.resolve(
         config.dirs.themes, config.defaultTheme, 'hooks', 'templatedataformatter.js');
+      const templateDataValidationHook = path.resolve(
+        config.dirs.themes, config.defaultTheme, 'hooks', 'templatedatavalidator.js');
       // Write pages
       new PageWriter({
         outputDirectory: config.dirs.output,
         templateDataFormatterHook: templateDataFormatterHook,
+        templateDataValidationHook: templateDataValidationHook,
         env: env,
       }).writePages(pageSet);
     }

--- a/src/commands/build/templatedatavalidator.js
+++ b/src/commands/build/templatedatavalidator.js
@@ -1,6 +1,7 @@
 const fs = require('file-system');
 const UserError = require('../../errors/usererror');
 const { isCustomError } = require('../../utils/errorutils');
+const { info } = require('../../utils/logger');
 
 /**
  * TemplateDataValidator is reponsible for checking data supplied to a page
@@ -25,7 +26,7 @@ module.exports = class TemplateDataValidator {
         return;
     }
     try {
-        console.log(`Validating configuration for page "${pageName}".`);
+        info(`Validating configuration for page "${pageName}".`);
         const validatorFunction = require(this._templateDataValidationHook);
         validatorFunction(pageData);
     } catch (err) {

--- a/src/commands/build/templatedatavalidator.js
+++ b/src/commands/build/templatedatavalidator.js
@@ -24,6 +24,7 @@ module.exports = class TemplateDataValidator {
   
   /**
    * Execute validation hook's function if file exists
+   * 
    * @param {Object} page
    * @param {string} page.pageName name of the current page
    * @param {Object} page.pageData template arguments for the current page

--- a/src/commands/build/templatedatavalidator.js
+++ b/src/commands/build/templatedatavalidator.js
@@ -18,8 +18,9 @@ module.exports = class TemplateDataValidator {
   
   /**
    * Execute validation hook's function if file exists
-   * @param {string} pageName name of the current page
-   * @param {Object} pageData template arguments for the current page
+   * @param {Object} page
+   * @param {string} page.pageName name of the current page
+   * @param {Object} page.pageData template arguments for the current page
    */
   validate({ pageName, pageData }) {
     if (!fs.existsSync(this._templateDataValidationHook)) {

--- a/src/commands/build/templatedatavalidator.js
+++ b/src/commands/build/templatedatavalidator.js
@@ -1,0 +1,40 @@
+const fs = require('file-system');
+const UserError = require('../../errors/usererror');
+const { isCustomError } = require('../../utils/errorutils');
+
+/**
+ * TemplateDataValidator is reponsible for checking data supplied to a page
+ * using Theme's custom validation steps (if any).
+ */
+module.exports = class TemplateDataValidator {
+  constructor(templateDataValidationHook) {
+    /**
+     *  The path to template data validation hook.
+     * @type {string}
+     */
+    this._templateDataValidationHook = templateDataValidationHook;
+  }
+  
+  /**
+   *  Execute validation hook's function if file exists
+   * @param {string} pageName name of the current page
+   * @param {Object} pageData template arguments for the current page
+   */
+  validate({ pageName, pageData }) {
+    if (!fs.existsSync(this._templateDataValidationHook)) {
+        return;
+    }
+    try {
+        console.log(`Validating configuration for page "${pageName}".`);
+        const validatorFunction = require(this._templateDataValidationHook);
+        validatorFunction(pageData);
+    } catch (err) {
+        if(isCustomError(err)) {
+            throw err;
+        }
+        const msg = 
+            `Error executing validation hook from ${this._templateDataValidationHook}: `;
+        throw new UserError(msg, err.stack);
+    }
+  }
+}

--- a/src/commands/build/templatedatavalidator.js
+++ b/src/commands/build/templatedatavalidator.js
@@ -10,14 +10,14 @@ const { info } = require('../../utils/logger');
 module.exports = class TemplateDataValidator {
   constructor(templateDataValidationHook) {
     /**
-     *  The path to template data validation hook.
+     * The path to template data validation hook.
      * @type {string}
      */
     this._templateDataValidationHook = templateDataValidationHook;
   }
   
   /**
-   *  Execute validation hook's function if file exists
+   * Execute validation hook's function if file exists
    * @param {string} pageName name of the current page
    * @param {Object} pageData template arguments for the current page
    */

--- a/tests/commands/build/templatedatavalidator.js
+++ b/tests/commands/build/templatedatavalidator.js
@@ -58,7 +58,7 @@ describe('TemplateDataValidator validates config data using hook properly', () =
     expect(() => new TemplateDataValidator(templateDataValidationHook).validate({
         pageName: 'examplePage',
         pageData: templateData
-    })).not.toThrow(UserError);
+    })).not.toThrow();
   });
 
   it('throws an error when a field in config is missing', () => {

--- a/tests/commands/build/templatedatavalidator.js
+++ b/tests/commands/build/templatedatavalidator.js
@@ -1,0 +1,83 @@
+const TemplateDataValidator = require('../../../src/commands/build/templatedatavalidator');
+const path = require('path');
+const UserError = require('../../../src/errors/usererror');
+
+describe('TemplateDataValidator validates config data using hook properly', () => {
+  const currentPageConfig = {
+    url: 'examplePage.html',
+    verticalKey: 'examplePage',
+    pageTitle: 'Example Page',
+    pageSettings: { search: { verticalKey: 'examplePage', defaultInitialSearch: '' } },
+    componentSettings: {
+      prop: 'example1',
+    }, 
+    verticalsToConfig: {
+      examplePage: {
+        prop: 'example2'
+      }
+    }
+  };
+  const verticalConfigs = {
+    page1: {
+      config: {
+        prop: 'example'
+      }
+    },
+    page2: {
+      config: {
+        prop: 'example2'
+      }
+    }
+  };
+  const global_config = {
+    sdkVersion: 'X.X',
+    apiKey: 'exampleKey',
+    experienceKey: 'slanswers',
+    locale: 'en'
+  };
+  const params = {
+    example: 'param'
+  };
+  const relativePath = '..';
+  const env = {
+    envVar: 'envVar',
+  };
+
+  it('does not throw an error with a correct config', () => {
+    const templateDataValidationHook = path.resolve(
+        __dirname, '../../fixtures/hooks/templatedatavalidator.js');
+    const templateData = {
+        currentPageConfig,
+        verticalConfigs,
+        global_config,
+        params,
+        relativePath,
+        env
+    };
+
+    expect(() => new TemplateDataValidator(templateDataValidationHook).validate({
+        pageName: 'examplePage',
+        pageData: templateData
+    })).not.toThrow(UserError);
+  });
+
+  it('throws an error when a field in config is missing', () => {
+    const templateDataValidationHook = path.resolve(
+        __dirname, '../../fixtures/hooks/templatedatavalidator.js');
+    const global_config_missing_key = {};
+    const templateData = {
+        currentPageConfig,
+        verticalConfigs,
+        global_config_missing_key,
+        params,
+        relativePath,
+        env
+    };  
+
+    expect(() => new TemplateDataValidator(templateDataValidationHook).validate({
+        pageName: 'examplePage',
+        pageData: templateData
+    })).toThrow(UserError);
+
+  });
+});

--- a/tests/commands/build/templatedatavalidator.js
+++ b/tests/commands/build/templatedatavalidator.js
@@ -48,17 +48,18 @@ describe('TemplateDataValidator validates config data using hook properly', () =
         __dirname, '../../fixtures/hooks/templatedatavalidator.js');
     const templateData = {
         currentPageConfig,
-        verticalConfigs,
-        global_config,
-        params,
-        relativePath,
-        env
+        verticalConfigs : verticalConfigs,
+        global_config : global_config,
+        params : params,
+        relativePath: relativePath,
+        env: env
     };
 
-    expect(() => new TemplateDataValidator(templateDataValidationHook).validate({
+    const isValid = new TemplateDataValidator(templateDataValidationHook).validate({
         pageName: 'examplePage',
         pageData: templateData
-    })).not.toThrow();
+    });
+    expect(isValid).toEqual(true);
   });
 
   it('throws an error when a field in config is missing', () => {
@@ -67,17 +68,40 @@ describe('TemplateDataValidator validates config data using hook properly', () =
     const global_config_missing_key = {};
     const templateData = {
         currentPageConfig,
-        verticalConfigs,
-        global_config_missing_key,
-        params,
-        relativePath,
-        env
-    };  
+        verticalConfigs : verticalConfigs,
+        global_config : global_config_missing_key,
+        params : params,
+        relativePath: relativePath,
+        env: env
+    }; 
 
-    expect(() => new TemplateDataValidator(templateDataValidationHook).validate({
+    const isValid = new TemplateDataValidator(templateDataValidationHook).validate({
         pageName: 'examplePage',
         pageData: templateData
-    })).toThrow(UserError);
+    });
+    expect(isValid).toEqual(false);
 
   });
+
+
+  it('does not throw error, gracefully ignore missing config field in bad pages', () => {
+    const templateDataValidationHook = path.resolve(
+        __dirname, '../../fixtures/hooks/templatedatavalidator.js');
+    const params_missing_field = {};
+    const templateData = {
+        currentPageConfig,
+        verticalConfigs : verticalConfigs,
+        global_config : global_config,
+        params : params_missing_field,
+        relativePath: relativePath,
+        env: env
+    };
+
+    const isValid = new TemplateDataValidator(templateDataValidationHook).validate({
+        pageName: 'examplePage',
+        pageData: templateData
+    });
+    expect(isValid).toEqual(true);
+  });
+
 });

--- a/tests/fixtures/hooks/templatedatavalidator.js
+++ b/tests/fixtures/hooks/templatedatavalidator.js
@@ -1,4 +1,4 @@
-
+const { warn } = require('../../../src/utils/logger');
 /**
  * A test data validator hook.
  *
@@ -7,11 +7,11 @@
  */
  module.exports = function (pageData) {
     if(!pageData["params"]["example"]) {
-        console.log('Missing Info: param example in config file(s)');
+        warn('Missing Info: param example in config file(s)');
         return true; //gracefully ignore missing param on page
     }
     if(!pageData["global_config"]["experienceKey"]) {
-        console.log('Missing Info: experienceKey in config file(s)');
+        warn('Missing Info: experienceKey in config file(s)');
         return false;
     }
     return true;

--- a/tests/fixtures/hooks/templatedatavalidator.js
+++ b/tests/fixtures/hooks/templatedatavalidator.js
@@ -1,12 +1,18 @@
-const UserError = require('../../../src/errors/usererror');
 
 /**
  * A test data validator hook.
  *
  * @param {Object} pageData configuration(s) of a page template
+ * @returns {boolean} false if validator should throw an error
  */
  module.exports = function (pageData) {
-    if(!pageData["global_config"]["experienceKey"]) {
-        throw new UserError('Missing Info: experienceKey in config file(s)');
+    if(!pageData["params"]["example"]) {
+        console.log('Missing Info: param example in config file(s)');
+        return true; //gracefully ignore missing param on page
     }
+    if(!pageData["global_config"]["experienceKey"]) {
+        console.log('Missing Info: experienceKey in config file(s)');
+        return false;
+    }
+    return true;
 }

--- a/tests/fixtures/hooks/templatedatavalidator.js
+++ b/tests/fixtures/hooks/templatedatavalidator.js
@@ -1,0 +1,12 @@
+const UserError = require('../../../src/errors/usererror');
+
+/**
+ * A test data validator hook.
+ *
+ * @param {Object} pageData configuration(s) of a page template
+ */
+ module.exports = function (pageData) {
+    if(!pageData["global_config"]["experienceKey"]) {
+        throw new UserError('Missing Info: experienceKey in config file(s)');
+    }
+}


### PR DESCRIPTION
- Added another operation inside PageWriter to ensure template data is correct
using TemplateDataValidator, which pass in the formatted config data to the theme's validation
hook function

J=SLAP-1369
TEST=auto

Created Jest tests using default config format with/without missing field when
pass to validation hook and check if errors are handle properly