### PR TITLE
add --globs param to extract-translations cmd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3461,6 +3461,19 @@
         }
       }
     },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
+    "@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -8285,11 +8298,23 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "simple-git": {
-      "version": "1.132.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
-      "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.40.0.tgz",
+      "integrity": "sha512-7IO/eQwrN5kvS38TTu9ljhG9tx2nn0BTqZOmqpPpp51TvE44YIvLA6fETqEVA8w/SeEfPaVv6mk7Tsk9Jns+ag==",
       "requires": {
-        "debug": "^4.0.1"
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "sisteransi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3461,19 +3461,6 @@
         }
       }
     },
-    "@kwsites/file-exists": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
-      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-      "requires": {
-        "debug": "^4.1.1"
-      }
-    },
-    "@kwsites/promise-deferred": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -8298,23 +8285,11 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "simple-git": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.40.0.tgz",
-      "integrity": "sha512-7IO/eQwrN5kvS38TTu9ljhG9tx2nn0BTqZOmqpPpp51TvE44YIvLA6fETqEVA8w/SeEfPaVv6mk7Tsk9Jns+ag==",
+      "version": "1.132.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
+      "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
       "requires": {
-        "@kwsites/file-exists": "^1.1.1",
-        "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
+        "debug": "^4.0.1"
       }
     },
     "sisteransi": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "merge-options": "^2.0.0",
     "npmlog": "^4.1.2",
     "prompts": "^2.3.1",
-    "simple-git": "^2.40.0",
+    "simple-git": "^1.131.0",
     "yargs": "^17.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "merge-options": "^2.0.0",
     "npmlog": "^4.1.2",
     "prompts": "^2.3.1",
-    "simple-git": "^1.131.0",
+    "simple-git": "^2.40.0",
     "yargs": "^17.0.0"
   },
   "devDependencies": {

--- a/src/commands/extract-translations/defaulttranslationglobber.js
+++ b/src/commands/extract-translations/defaulttranslationglobber.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+
+module.exports = class DefaultTranslationGlobber {
+  constructor(dirs = {}, ignoredPaths = []) {
+    this.pages = dirs.pages || '';
+    this.partials = dirs.partials || [];
+    this.ignoredPaths = ignoredPaths;
+    this.extensions = ['.js', '.hbs']; // only extract from files with these extensions
+  }
+
+  getGlobs() {
+    const { files, directories } = this._getFilesAndDirsFromJamboConfig();
+    return this._globInputFilePaths(directories, files, this.ignoredPaths);
+  }
+
+  /**
+   * Globs together an array of files to extract from.
+   *
+   * @param {Array<string>} directories directories to recursively extract from
+   * @param {Array<string>} specificFiles specific files to extract from
+   * @param {Array<string>} ignoredPaths paths to recursively ignore
+   * @returns {Array<string>}
+   */
+   _globInputFilePaths(directories, specificFiles, ignoredPaths) {
+    const extensions = this.extensions.join(',');
+    const directoryGlobs = directories.map(dirpath => `${dirpath}/**/*{${extensions}}`);
+    const ignoreGlobs = ignoredPaths.map(dirpath => `!${dirpath}`);
+    return [...directoryGlobs, ...specificFiles, ...ignoreGlobs];
+  }
+
+  /**
+   * Returns an array of files and array of directories contained in the jamboConfig.
+   *
+   * @returns {{files: Array.<string>, directories: Array.<string>}}
+   */
+   _getFilesAndDirsFromJamboConfig() {
+    const files = [];
+    const directories = [];
+    const pathsThatExist = [this.pages, ...this.partials].filter(p => fs.existsSync(p));
+    for (const pathname of pathsThatExist) {
+      const isFile = fs.lstatSync(pathname).isFile();
+      if (isFile) {
+        files.push(pathname);
+      } else {
+        directories.push(pathname);
+      }
+    }
+    return { files: files, directories: directories };
+  }
+}

--- a/src/commands/extract-translations/defaulttranslationglobber.js
+++ b/src/commands/extract-translations/defaulttranslationglobber.js
@@ -1,5 +1,9 @@
 const fs = require('fs');
 
+/**
+ * DefaultTranslationGlobber contains the default logic for determining
+ * which files are scanned by the extract-translations command.
+ */
 module.exports = class DefaultTranslationGlobber {
   constructor(dirs = {}, ignoredPaths = []) {
     this.pages = dirs.pages || '';
@@ -8,28 +12,35 @@ module.exports = class DefaultTranslationGlobber {
     this.extensions = ['.js', '.hbs']; // only extract from files with these extensions
   }
 
+  /**
+   * Returns the default globs to be scanned, using the given
+   * site specific templates and partials, as well as any ignored paths.
+   *
+   * @returns {Array<string>}
+   */
   getGlobs() {
     const { files, directories } = this._getFilesAndDirsFromJamboConfig();
     return this._globInputFilePaths(directories, files, this.ignoredPaths);
   }
 
   /**
-   * Globs together an array of files to extract from.
+   * Globs together the given directories, files, and ignored paths.
    *
    * @param {Array<string>} directories directories to recursively extract from
-   * @param {Array<string>} specificFiles specific files to extract from
+   * @param {Array<string>} files any individual files to extract from
    * @param {Array<string>} ignoredPaths paths to recursively ignore
    * @returns {Array<string>}
    */
-   _globInputFilePaths(directories, specificFiles, ignoredPaths) {
+   _globInputFilePaths(directories, files, ignoredPaths) {
     const extensions = this.extensions.join(',');
     const directoryGlobs = directories.map(dirpath => `${dirpath}/**/*{${extensions}}`);
     const ignoreGlobs = ignoredPaths.map(dirpath => `!${dirpath}`);
-    return [...directoryGlobs, ...specificFiles, ...ignoreGlobs];
+    return [...directoryGlobs, ...files, ...ignoreGlobs];
   }
 
   /**
-   * Returns an array of files and array of directories contained in the jamboConfig.
+   * Returns the site-specific partials/templates in a jambo config,
+   * separating them based on whether they are files or directories.
    *
    * @returns {{files: Array.<string>, directories: Array.<string>}}
    */

--- a/src/commands/extract-translations/jambotranslationextractor.js
+++ b/src/commands/extract-translations/jambotranslationextractor.js
@@ -1,15 +1,15 @@
 const TranslationExtractor = require('../../i18n/extractor/translationextractor');
 const { ArgumentMetadata, ArgumentType } = require('../../models/commands/argumentmetadata');
-const fsExtra = require('fs-extra');
-const fs = require('fs');
 const { info } = require('../../utils/logger');
+const DefaultTranslationGlobber = require('./defaulttranslationglobber');
+const { readGitignorePaths } = require('../../utils/gitutils');
 
 /**
  * JamboTranslationExtractor extracts translations from a jambo repo.
  */
 class JamboTranslationExtractor {
   constructor(jamboConfig) {
-    this.config = jamboConfig;
+    this.jamboConfig = jamboConfig;
     this.extractor = new TranslationExtractor();
   }
 
@@ -23,6 +23,13 @@ class JamboTranslationExtractor {
 
   static args() {
     return {
+      globs: new ArgumentMetadata({
+        displayName: 'Globs to Scan',
+        type: ArgumentType.ARRAY,
+        description:
+          'specify globs to scan for translations, instead of using the defaults',
+        isRequired: false
+      }),
       output: new ArgumentMetadata({
         displayName: 'Output Path',
         type: ArgumentType.STRING,
@@ -44,51 +51,28 @@ class JamboTranslationExtractor {
     };
   }
 
-  execute(args) {
-    this._extract(args.output);
+  execute({ output, globs }) {
+    if (globs && globs.length > 0) {
+      this._extract(output, globs);
+    } else {
+      const gitignorePaths = readGitignorePaths();
+      const defaultGlobber = new DefaultTranslationGlobber(
+        this.jamboConfig.dirs, gitignorePaths);
+      const defaultGlobs = defaultGlobber.getGlobs();
+      this._extract(output, defaultGlobs);
+    }
   }
 
   /**
    * Extracts i18n strings from a jambo repo to a designed output file.
+   *
    * @param {string} outputPath
+   * @param {Array<string>} globs
    */
-  async _extract(outputPath) {
-    const { files, directories } = this._getFilesAndDirsFromJamboConfig();
-    const gitignorePaths = this._parseGitignorePaths();
+  _extract(outputPath, globs) {
     info(`Extracting translations to ${outputPath}`);
-    this.extractor.extract({
-      specificFiles: files,
-      directories: directories,
-      ignoredPaths: gitignorePaths
-    });
+    this.extractor.extract(globs);
     this.extractor.savePotFile(outputPath);
-  }
-
-  /**
-   * Gets the list of gitignored paths, if a .gitignore file exists.
-   * @returns {Promise.<Array.<string>>}
-   */
-  _parseGitignorePaths() {
-    if (fsExtra.pathExistsSync('.gitignore')) {
-      const ignoredPaths = fs.readFileSync('.gitignore', 'utf-8');
-      return ignoredPaths.split('\n').filter(pathname => pathname);
-    }
-    return [];
-  }
-
-  /**
-   * Returns an array of files and array of directories contained in the jamboConfig.
-   * @returns {{files: Array.<string>, directories: Array.<string>}}
-   */
-  _getFilesAndDirsFromJamboConfig() {
-    const { pages, partials } = this.config.dirs;
-    const files = [];
-    const directories = [];
-    for (const pathname of [pages, ...partials]) {
-      const isFile = fs.existsSync(pathname) && fs.lstatSync(pathname).isFile();
-      isFile ? files.push(pathname) : directories.push(pathname);
-    }
-    return { files: files, directories: directories };
   }
 }
 

--- a/src/utils/gitutils.js
+++ b/src/utils/gitutils.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const fs = require('fs');
+const fsExtra = require('fs-extra');
 
 /**
  * Gets the repo name from a git repo URL
@@ -6,4 +8,17 @@ const path = require('path');
  */
 exports.getRepoNameFromURL = function(repoURL) {
   return path.basename(repoURL, '.git');
+}
+
+/**
+ * Reads a gitignore.
+ * 
+ * @return {Array<string>}
+ */
+exports.readGitignorePaths = function() {
+  if (fsExtra.pathExistsSync('.gitignore')) {
+    const ignoredPaths = fs.readFileSync('.gitignore', 'utf-8');
+    return ignoredPaths.split('\n').filter(pathname => pathname);
+  }
+  return [];
 }

--- a/tests/acceptance/fixtures/describe/describe-test.json
+++ b/tests/acceptance/fixtures/describe/describe-test.json
@@ -83,6 +83,11 @@
   "extract-translations": {
     "displayName": "Extract Translations",
     "params": {
+      "globs": {
+        "displayName": "Globs to Scan",
+        "required": false,
+        "type": "array"
+      },
       "output": {
         "displayName": "Output Path",
         "type": "string",

--- a/tests/acceptance/fixtures/extract-translations/custom-globs.pot
+++ b/tests/acceptance/fixtures/extract-translations/custom-globs.pot
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+#: themes/basic-flow/translations/translation-folder/ignored.hbs:1
+#: translations/translation-folder/ignored.hbs:1
+msgid "ignore me by default!"
+msgstr ""
+
+#: user-created.js:1
+msgctxt "RSVP is a verb"
+msgid "RSVP"
+msgstr ""

--- a/tests/acceptance/fixtures/extract-translations/default.pot
+++ b/tests/acceptance/fixtures/extract-translations/default.pot
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+#: translations/lonewolf.hbs:1
+msgid "don't forget me by default though!"
+msgstr ""
+
+#: translations/translation-folder/template.hbs:1
+msgctxt "Example: 1-10 of 50"
+msgid ""
+"<span class=\"yxt-VerticalResultsCount-start\">[[start]]</span>\n"
+"<span class=\"yxt-VerticalResultsCount-dash\">-</span>\n"
+"<span class=\"yxt-VerticalResultsCount-end\">[[end]]</span>\n"
+"<span class=\"yxt-VerticalResultsCount-of\">of</span>\n"
+"<span class=\"yxt-VerticalResultsCount-total\">[[resultsCount]]</span>"
+msgstr ""

--- a/tests/acceptance/suites/extract-translations.js
+++ b/tests/acceptance/suites/extract-translations.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+
+const { runInPlayground } = require('../setup/playground');
+
+it('extract translations w/ default settings', () => runInPlayground(async t => {
+  await t.jambo('init');
+  await t.jambo('import --themeUrl ../test-themes/basic-flow');
+  await t.jambo('override --path translations/translation-folder');
+  await t.jambo('override --path translations/lonewolf.hbs');
+  fs.writeFileSync('.gitignore', '**/ignored.hbs')
+  await t.jambo('extract-translations');
+  const expectedPot = fs.readFileSync('messages.pot', 'utf-8');
+  const actualPot = fs.readFileSync(
+    '../fixtures/extract-translations/default.pot', 'utf-8');
+  expect(actualPot).toEqual(expectedPot);
+}));
+
+it('extract translations w/ custom globs', () => runInPlayground(async t => {
+  await t.jambo('init');
+  await t.jambo('import --themeUrl ../test-themes/basic-flow');
+  await t.jambo('override --path translations/translation-folder');
+  await t.jambo('override --path translations/lonewolf.hbs');
+  fs.writeFileSync('.gitignore', '**/ignored.hbs')
+  await fs.writeFileSync(
+    'user-created.js',
+    '{{ translateJS phrase=\'RSVP\' context=\'RSVP is a verb\' }}'
+  );
+  await t.jambo('extract-translations --globs \'**/ignored.hbs\' user-created.js');
+  const expectedPot = fs.readFileSync('messages.pot', 'utf-8');
+  const actualPot = fs.readFileSync(
+    '../fixtures/extract-translations/custom-globs.pot', 'utf-8');
+  expect(actualPot).toEqual(expectedPot);
+}));

--- a/tests/acceptance/test-themes/basic-flow/translations/lonewolf.hbs
+++ b/tests/acceptance/test-themes/basic-flow/translations/lonewolf.hbs
@@ -1,0 +1,1 @@
+{{translate phrase='don\'t forget me by default though!'}}

--- a/tests/acceptance/test-themes/basic-flow/translations/translation-folder/ignored.hbs
+++ b/tests/acceptance/test-themes/basic-flow/translations/translation-folder/ignored.hbs
@@ -1,0 +1,1 @@
+{{translate phrase='ignore me by default!'}}

--- a/tests/acceptance/test-themes/basic-flow/translations/translation-folder/template.hbs
+++ b/tests/acceptance/test-themes/basic-flow/translations/translation-folder/template.hbs
@@ -1,0 +1,13 @@
+{{translate
+        phrase=
+'<span class="yxt-VerticalResultsCount-start">[[start]]</span>
+<span class="yxt-VerticalResultsCount-dash">-</span>
+<span class="yxt-VerticalResultsCount-end">[[end]]</span>
+<span class="yxt-VerticalResultsCount-of">of</span>
+<span class="yxt-VerticalResultsCount-total">[[resultsCount]]</span>'
+        context='Example: 1-10 of 50'
+        start=pageStart
+        end=pageEnd
+        resultsCount=total
+        escapeHTML='false'
+}}

--- a/tests/i18n/extract/defaulttranslationglobber.js
+++ b/tests/i18n/extract/defaulttranslationglobber.js
@@ -1,0 +1,71 @@
+const path = require('path');
+const process = require('process');
+
+const DefaultTranslationGlobber = require('../../../src/commands/extract-translations/defaulttranslationglobber');
+
+const fixturesAbsPath = path.resolve(__dirname, '../../fixtures/extractions');
+const fixturesDir = path.relative(process.cwd(), fixturesAbsPath);
+
+it('can glob a single file', () => {
+  const filePath = path.join(fixturesDir, 'rawcomponent.js');
+  const globber = new DefaultTranslationGlobber({
+    partials: [ filePath ]
+  });
+  expect(globber.getGlobs()).toEqual([ filePath ]);
+});
+
+it('will ignore paths that do not exist', () => {
+  const globber = new DefaultTranslationGlobber({
+    partials: [ 'DNE.txt' ]
+  });
+  expect(globber.getGlobs()).toEqual([]);
+});
+
+it('will glob partial folder paths', () => {
+  const globber = new DefaultTranslationGlobber({
+    partials: [ fixturesDir ]
+  });
+  expect(globber.getGlobs()).toEqual([`${fixturesDir}/**/*{.js,.hbs}`]);
+});
+
+it('will glob the pages folder', () => {
+  const globber = new DefaultTranslationGlobber({
+    pages: fixturesDir
+  });
+  expect(globber.getGlobs()).toEqual([`${fixturesDir}/**/*{.js,.hbs}`]);
+});
+
+it('will ignore a pages folder that does not exist', () => {
+  const globber = new DefaultTranslationGlobber({
+    pages: 'DNE/DNE/DNE'
+  });
+  expect(globber.getGlobs()).toEqual([]);
+});
+
+it('ignores paths properly', () => {
+  const ignoredPaths = ['node_modules', 'static/node_modules'];
+  const globber = new DefaultTranslationGlobber({}, ignoredPaths);
+  expect(globber.getGlobs()).toEqual([
+    '!node_modules',
+    '!static/node_modules',
+  ]);
+});
+
+it('can handle input w/pages + partials + gitignore', () => {
+  const ignoredPaths = ['node_modules', 'static/node_modules'];
+  const componentPath = path.join(fixturesDir, 'rawcomponent.js');
+  const templatePath = path.join(fixturesDir, 'rawtemplate.hbs');
+  const fakePath = 'DNE/DNE';
+  const globber = new DefaultTranslationGlobber({
+    pages: fixturesDir,
+    partials: [ fixturesDir, componentPath, templatePath, fakePath ]
+  }, ignoredPaths);
+  expect(globber.getGlobs()).toEqual([
+    'tests/fixtures/extractions/**/*{.js,.hbs}',
+    'tests/fixtures/extractions/**/*{.js,.hbs}',
+    'tests/fixtures/extractions/rawcomponent.js',
+    'tests/fixtures/extractions/rawtemplate.hbs',
+    '!node_modules',
+    '!static/node_modules',
+  ]);
+});

--- a/tests/i18n/extract/translationextractor.js
+++ b/tests/i18n/extract/translationextractor.js
@@ -2,9 +2,11 @@ const TranslationExtractor = require('../../../src/i18n/extractor/translationext
 const path = require('path');
 const fs = require('fs');
 
-
 describe('TranslationExtractor', () => {
-  const fixturesDir = path.resolve(__dirname, '../../fixtures/extractions');
+  const rootDir = path.resolve(__dirname, '../../..');
+  const fixturesAbsPath = path.resolve(__dirname, '../../fixtures/extractions');
+  const fixturesDir = path.relative(rootDir, fixturesAbsPath);
+
   const rawcomponentPot = readExpectedPot('rawcomponent.pot');
   const combinedPot = readExpectedPot('combined.pot');
   const rawtemplatePot = readExpectedPot('rawtemplate.pot');
@@ -24,9 +26,7 @@ describe('TranslationExtractor', () => {
   it('can extract from just an hbs file', () => {
     const rawtemplate =
       path.relative(process.cwd(), path.join(fixturesDir, 'rawtemplate.hbs'));
-    extractor.extract({
-      specificFiles: [ rawtemplate ]
-    });
+    extractor.extract([ rawtemplate ]);
     const potString = extractor.getPotString();
     expect(potString).toEqual(rawtemplatePot);
   });
@@ -34,36 +34,26 @@ describe('TranslationExtractor', () => {
   it('can extract from just a js file', () => {
     const rawcomponent =
       path.relative(process.cwd(), path.join(fixturesDir, 'rawcomponent.js'));
-    extractor.extract({
-      specificFiles: [ rawcomponent ]
-    });
+    extractor.extract([ rawcomponent ]);
     const potString = extractor.getPotString();
     expect(potString).toEqual(rawcomponentPot);
   });
 
   it('can extract all translations from a folder', () => {
-    extractor.extract({
-      directories: [ fixturesDir ]
-    });
+    extractor.extract([ fixturesDir ]);
     const potString = extractor.getPotString();
     expect(potString).toEqual(combinedPot);
   });
 
   it('can ignore an entire folder', async () => {
-    extractor.extract({
-      directories: [ fixturesDir ],
-      ignoredPaths: [ fixturesDir ]
-    });
+    extractor.extract([ fixturesDir, `!${fixturesDir}` ]);
     const potString = extractor.getPotString();
     expect(potString).toEqual(emptyPot);
   });
 
   it('can ignore a specific file when specifying a directory', () => {
     const rawcomponent = path.join(fixturesDir, 'rawcomponent.js');
-    extractor.extract({
-      directories: [ fixturesDir ],
-      ignoredPaths: [ rawcomponent ]
-    });
+    extractor.extract([ fixturesDir, `!${rawcomponent}` ]);
     const potString = extractor.getPotString();
     expect(potString).toEqual(rawtemplatePot);
   });
@@ -71,10 +61,7 @@ describe('TranslationExtractor', () => {
   it('ignoring a specific file takes priority over specifying that file', async () => {
     const rawcomponent =
       path.relative(process.cwd(), path.join(fixturesDir, 'rawcomponent.js'));
-    extractor.extract({
-      specificFiles: [ rawcomponent ],
-      ignoredPaths: [ rawcomponent ]
-    });
+    extractor.extract([ rawcomponent, `!${rawcomponent}` ]);
     const potString = extractor.getPotString();
     expect(potString).toEqual(emptyPot);
   });


### PR DESCRIPTION
This commit updates the extract-translations command
to take in a --globs argument.
The TranslationExtractor was refactored to only take in
a glob, instead of taking in arrays of files, directories,
and ignored files. The logic of creating an array of globs
by reading from the jambo.json and gitignore files has
been moved into the DefaultTranslationGlobber.

simple-git was updated from 1.131 to 2.40 to remove git
ENOENT errors during acceptance tests. There were improvements
to how simple-git performs git operations in parallel after v2.
We only use simple-git for very basic operations like cloning,
init-ing, and checking out submodules, staging files, and committing,
so there shouldn't be any issues with upgrading. The only breaking
changes in v2.0.0 are git.log using strict ISO by default, and changes
to methods that being with underscores (aka private methods).

J=SLAP-1378
TEST=manual,auto

run jambo extract-translations in the theme, and also in campbells-ca
see messages.pot generated as expected

add acceptance + unit tests