### PR TITLE
locale fallback acceptance test

### DIFF
--- a/tests/acceptance/suites/locale-fallback.js
+++ b/tests/acceptance/suites/locale-fallback.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+
+const { runInPlayground } = require('../setup/playground');
+
+it('check locale fallback functionality for page and config files', 
+  () => runInPlayground(async t => {
+  await t.jambo('init');
+  await t.jambo('import --themeUrl ../test-themes/locale-fallback');
+  await t.jambo('page --name index --template universal-standard --locales es');
+  await t.jambo('page --name index.fr --template universal-fallback');
+  await t.jambo('build');
+
+  const localePage = fs.readFileSync('public/es/index.html', 'utf-8');
+  const localeFallbackPage = fs.readFileSync(
+    'public/fr/index.html', 'utf-8');
+  expect(localePage).toEqualHtml(localeFallbackPage);
+}));

--- a/tests/acceptance/suites/locale-fallback.js
+++ b/tests/acceptance/suites/locale-fallback.js
@@ -6,7 +6,15 @@ it('check locale fallback functionality for page and config files',
   () => runInPlayground(async t => {
   await t.jambo('init');
   await t.jambo('import --themeUrl ../test-themes/locale-fallback');
+  /**
+   * Creates index.html.hbs and index.json following universal-standard template.
+   * Also generates an empty ({}) index.es.json file, which will fallback on index.fr.json
+   */
   await t.jambo('page --name index --template universal-standard --locales es');
+  /**
+   * Creates index.fr.html.hbs and index.fr.json following universal-fallback template.
+   * Since es doesn't have an index page template, it will fallback on index.fr.html.hbs
+   */
   await t.jambo('page --name index.fr --template universal-fallback');
   await t.jambo('build');
 

--- a/tests/acceptance/test-themes/basic-flow/postimport.js
+++ b/tests/acceptance/test-themes/basic-flow/postimport.js
@@ -11,7 +11,7 @@ const { assign, stringify } = require('comment-json');
 function updateDefaultTheme(themeName) {
   const jamboConfig = JSON.parse(fs.readFileSync('jambo.json', 'utf-8'));
   if (jamboConfig.defaultTheme !== themeName) {
-    const updatedConfig = assign({ defaultTheme: themeName }, jamboConfig);
+    const updatedConfig = assign(jamboConfig, { defaultTheme: themeName });
     fs.writeFileSync('jambo.json', stringify(updatedConfig, null, 2));
   }
 }

--- a/tests/acceptance/test-themes/customcommand/postimport.js
+++ b/tests/acceptance/test-themes/customcommand/postimport.js
@@ -10,7 +10,7 @@ const { assign, stringify } = require('comment-json');
 function updateDefaultTheme(themeName) {
   const jamboConfig = JSON.parse(fs.readFileSync('jambo.json', 'utf-8'));
   if (jamboConfig.defaultTheme !== themeName) {
-    const updatedConfig = assign({ defaultTheme: themeName }, jamboConfig);
+    const updatedConfig = assign(jamboConfig, { defaultTheme: themeName });
     fs.writeFileSync('jambo.json', stringify(updatedConfig, null, 2));
   }
 }

--- a/tests/acceptance/test-themes/locale-fallback/config/locale_config.json
+++ b/tests/acceptance/test-themes/locale-fallback/config/locale_config.json
@@ -1,0 +1,27 @@
+{
+  "default": "en",
+  "localeConfig": {
+    "en": {
+      // "fallback": [""], // allows you to specify locale fallbacks for this locale
+      // "translationFile": "<filepath>.po", // the filepath for the translation file
+      // "urlOverride": "", // provide an override for the url path for this locale if you want it to be different than specified in the urlFormat object
+      "experienceKey": "testkey" //  the unique key of your search configuration for this locale
+    },
+    "fr": {
+      // "fallback": [""], // allows you to specify locale fallbacks for this locale
+      // "translationFile": "../../translation/es.po", // the filepath for the translation file
+      // "urlOverride": "", // provide an override for the url path for this locale if you want it to be different than specified in the urlFormat object
+      "experienceKey": "testkey-fr" //  the unique key of your search configuration for this locale
+    },
+    "es": {
+      "fallback": ["fr"], // allows you to specify locale fallbacks for this locale
+      // "translationFile": "../../translation/es.po", // the filepath for the translation file
+      // "urlOverride": "", // provide an override for the url path for this locale if you want it to be different than specified in the urlFormat object
+      "experienceKey": "testkey-es" //  the unique key of your search configuration for this locale
+    }
+  },
+  "urlFormat": {
+    "baseLocale": "{locale}/{pageName}.{pageExt}",
+    "default": "{pageName}.{pageExt}"
+  }
+}

--- a/tests/acceptance/test-themes/locale-fallback/postimport.js
+++ b/tests/acceptance/test-themes/locale-fallback/postimport.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const fsExtra = require('fs-extra');
+const { assign, stringify } = require('comment-json');
+
+/**
+ * Updates the defaultTheme field in the jambo.json.
+ * 
+ * @param {string} themeName 
+ */
+function updateDefaultTheme(themeName) {
+  const jamboConfig = JSON.parse(fs.readFileSync('jambo.json', 'utf-8'));
+  if (jamboConfig.defaultTheme !== themeName) {
+    const updatedConfig = assign({ defaultTheme: themeName }, jamboConfig);
+    fs.writeFileSync('jambo.json', stringify(updatedConfig, null, 2));
+  }
+}
+
+updateDefaultTheme('locale-fallback');
+fs.writeFileSync('config/global_config.json', '{}');
+fsExtra.copySync('themes/locale-fallback/config/locale_config.json', 
+  'config/locale_config.json');
+fsExtra.copySync('themes/locale-fallback/static', 'static');

--- a/tests/acceptance/test-themes/locale-fallback/postimport.js
+++ b/tests/acceptance/test-themes/locale-fallback/postimport.js
@@ -11,7 +11,7 @@ const { assign, stringify } = require('comment-json');
 function updateDefaultTheme(themeName) {
   const jamboConfig = JSON.parse(fs.readFileSync('jambo.json', 'utf-8'));
   if (jamboConfig.defaultTheme !== themeName) {
-    const updatedConfig = assign({ defaultTheme: themeName }, jamboConfig);
+    const updatedConfig = assign(jamboConfig, { defaultTheme: themeName });
     fs.writeFileSync('jambo.json', stringify(updatedConfig, null, 2));
   }
 }

--- a/tests/acceptance/test-themes/locale-fallback/script/core.hbs
+++ b/tests/acceptance/test-themes/locale-fallback/script/core.hbs
@@ -1,0 +1,3 @@
+<script>
+{{> @partial-block }}
+</script>

--- a/tests/acceptance/test-themes/locale-fallback/templates/universal-fallback/markup/directanswer.hbs
+++ b/tests/acceptance/test-themes/locale-fallback/templates/universal-fallback/markup/directanswer.hbs
@@ -1,0 +1,1 @@
+<div class="Answers-directAnswer js-answersDirectAnswer" id="js-answersDirectAnswer"></div>

--- a/tests/acceptance/test-themes/locale-fallback/templates/universal-fallback/page-config.json
+++ b/tests/acceptance/test-themes/locale-fallback/templates/universal-fallback/page-config.json
@@ -1,0 +1,14 @@
+{
+  "pageTitle": "universal page",
+  "componentSettings": {
+    /**
+    "QASubmission": {
+      "entityId": "", // Set the ID of the entity to use for Q&A submissions, must be of entity type "Organization"
+      "privacyPolicyUrl": "" // The fully qualified URL to the privacy policy
+    },
+    **/
+    "DirectAnswer": {
+      "anotherDummyConfig": "another dummy config"
+    }
+  }
+}

--- a/tests/acceptance/test-themes/locale-fallback/templates/universal-fallback/page.html.hbs
+++ b/tests/acceptance/test-themes/locale-fallback/templates/universal-fallback/page.html.hbs
@@ -1,0 +1,5 @@
+{{#> script/core }}
+  {{> templates/universal-standard/script/directanswer }}
+{{/script/core }}
+{{> templates/universal-standard/markup/directanswer }}
+<div>Hello World!</div>

--- a/tests/acceptance/test-themes/locale-fallback/templates/universal-fallback/script/directanswer.hbs
+++ b/tests/acceptance/test-themes/locale-fallback/templates/universal-fallback/script/directanswer.hbs
@@ -1,0 +1,3 @@
+ANSWERS.addComponent("DirectAnswer", Object.assign({}, {
+  container: "#js-answersDirectAnswer"
+}, {{{ json componentSettings.DirectAnswer }}}));

--- a/tests/acceptance/test-themes/locale-fallback/templates/universal-standard/markup/directanswer.hbs
+++ b/tests/acceptance/test-themes/locale-fallback/templates/universal-standard/markup/directanswer.hbs
@@ -1,0 +1,1 @@
+<div class="Answers-directAnswer js-answersDirectAnswer" id="js-answersDirectAnswer"></div>

--- a/tests/acceptance/test-themes/locale-fallback/templates/universal-standard/page-config.json
+++ b/tests/acceptance/test-themes/locale-fallback/templates/universal-standard/page-config.json
@@ -1,0 +1,14 @@
+{
+  "pageTitle": "universal page",
+  "componentSettings": {
+    /**
+    "QASubmission": {
+      "entityId": "", // Set the ID of the entity to use for Q&A submissions, must be of entity type "Organization"
+      "privacyPolicyUrl": "" // The fully qualified URL to the privacy policy
+    },
+    **/
+    "DirectAnswer": {
+      "dummyConfig": "dummy config"
+    }
+  }
+}

--- a/tests/acceptance/test-themes/locale-fallback/templates/universal-standard/page.html.hbs
+++ b/tests/acceptance/test-themes/locale-fallback/templates/universal-standard/page.html.hbs
@@ -1,0 +1,5 @@
+{{#> script/core }}
+  {{> templates/universal-standard/script/directanswer }}
+{{/script/core }}
+{{> templates/universal-standard/markup/directanswer }}
+

--- a/tests/acceptance/test-themes/locale-fallback/templates/universal-standard/script/directanswer.hbs
+++ b/tests/acceptance/test-themes/locale-fallback/templates/universal-standard/script/directanswer.hbs
@@ -1,0 +1,3 @@
+ANSWERS.addComponent("DirectAnswer", Object.assign({}, {
+  container: "#js-answersDirectAnswer"
+}, {{{ json componentSettings.DirectAnswer }}}));


### PR DESCRIPTION
Created locale fallback acceptance test

- created a new test-theme folder `locale-fallback` with locale_config.json that contains 3 locales: en (default locale), fr (locale fallback for es), and es.
- 'locale-fallback' acceptance test: use `locale-fallback` theme and create an index page for en and es, `index.html.hbs` and `index.fr.html.hbs,` using two different templates. When executing jambo page command for en index page, also create a pageConfig for es with the flag `--locales es`. See that es index page fall back on the pageTemplate and config file for fr.

J=SLAP-1303
TEST=auto

Set `procrastinateCleanup` to true when running the test. See that in the playground folder, the expected config files, pageTemplates, and public html files are build as expected for en, es, and fr. See that acceptance test passed