### PR TITLE
update canonicalizeLocale to handle 中文(chinese)

### DIFF
--- a/src/utils/i18nutils.js
+++ b/src/utils/i18nutils.js
@@ -12,19 +12,16 @@ canonicalizeLocale = function(localeCode) {
   }
   const localeCodeSections = localeCode.replace(/-/g, '_').split('_');
   const numSections = localeCodeSections.length;
+  const language = localeCodeSections[0].toLowerCase();
   if (numSections === 1) {
-    return localeCodeSections[0].toLowerCase();
+    return language;
   } else if (numSections === 2) {
-    const language = localeCodeSections[0].toLowerCase();
-    const region = localeCodeSections[1].toUpperCase();
-    return `${language}_${region}`; 
+    if (language === 'zh') {
+      return formatLocale(language, localeCodeSections[1]);
+    }
+    return formatLocale(language, null, localeCodeSections[1]);
   } else if (numSections === 3) {
-    const language = localeCodeSections[0].toLowerCase();
-    const rawModifier = localeCodeSections[1];
-    const languageModifier =
-      rawModifier.charAt(0).toUpperCase() + rawModifier.slice(1).toLowerCase();
-    const region = localeCodeSections[2].toUpperCase();
-    return `${language}-${languageModifier}_${region}`;
+    return formatLocale(language, localeCodeSections[1], localeCodeSections[2]);
   } else if (numSections > 3) {
     warn(
       `Encountered strangely formatted locale "${localeCode}", ` +
@@ -33,3 +30,22 @@ canonicalizeLocale = function(localeCode) {
   }
 }
 exports.canonicalizeLocale = canonicalizeLocale;
+
+/**
+ * Formats a locale code given its constituent parts.
+ *
+ * @param {string} language zh in zh-Hans_CH
+ * @param {string?} modifier Hans in zh-Hans_CH
+ * @param {string?} region CH in zh-Hans_CH
+ * @returns 
+ */
+function formatLocale(language, modifier, region) {
+  let result = language.toLowerCase();
+  if (modifier) {
+    result += '-' + modifier.charAt(0).toUpperCase() + modifier.slice(1).toLowerCase();
+  }
+  if (region) {
+    result += '_' + region.toUpperCase();
+  }
+  return result;
+}

--- a/src/utils/i18nutils.js
+++ b/src/utils/i18nutils.js
@@ -29,7 +29,12 @@ function parseLocale(localeCode) {
     if (numSections === 1) {
       return {};
     } else if (numSections === 2 && language === 'zh') {
-      return { modifier: localeCodeSections[1] };
+      const ambiguous = localeCodeSections[1].toLowerCase();
+      if (['hans', 'hant'].includes(ambiguous)) {
+        return { modifier: ambiguous };
+      } else {
+        return { region: ambiguous };
+      }
     } else if (numSections === 2) {
       return { region: localeCodeSections[1] };
     } else if (numSections === 3) {

--- a/src/utils/i18nutils.js
+++ b/src/utils/i18nutils.js
@@ -1,4 +1,4 @@
-const { warn } = require('npmlog');
+const { warn } = require('./logger');
 
 /**
  * Normalizes a locale code

--- a/src/utils/i18nutils.js
+++ b/src/utils/i18nutils.js
@@ -29,18 +29,14 @@ function parseLocale(localeCode) {
     if (numSections === 1) {
       return {};
     } else if (numSections === 2 && language === 'zh') {
-      return { 
-        modifier: localeCodeSections[1]
-      };
+      return { modifier: localeCodeSections[1] };
     } else if (numSections === 2) {
-      return {
-        region: localeCodeSections[1]
-      }
+      return { region: localeCodeSections[1] };
     } else if (numSections === 3) {
       return {
         modifier: localeCodeSections[1],
         region: localeCodeSections[2]
-      }
+      };
     } else if (numSections > 3) {
       throw new UserError(
         `Encountered strangely formatted locale "${localeCode}", ` +

--- a/src/utils/i18nutils.js
+++ b/src/utils/i18nutils.js
@@ -1,3 +1,5 @@
+const { warn } = require('npmlog');
+
 /**
  * Normalizes a locale code
  *
@@ -8,18 +10,26 @@ canonicalizeLocale = function(localeCode) {
   if (!localeCode) {
     return;
   }
-  const localeCodeSections = localeCode.replace('-', '_')
-    .split('_');
-
-  const languageIndex = 0;
-  const regionIndex = 1;
-
-  localeCodeSections[languageIndex] = localeCodeSections[languageIndex].toLowerCase();
-
-  if (localeCodeSections.length > regionIndex) {
-    localeCodeSections[regionIndex] = localeCodeSections[regionIndex].toUpperCase();
+  const localeCodeSections = localeCode.replace(/-/g, '_').split('_');
+  const numSections = localeCodeSections.length;
+  if (numSections === 1) {
+    return localeCodeSections[0].toLowerCase();
+  } else if (numSections === 2) {
+    const language = localeCodeSections[0].toLowerCase();
+    const region = localeCodeSections[1].toUpperCase();
+    return `${language}_${region}`; 
+  } else if (numSections === 3) {
+    const language = localeCodeSections[0].toLowerCase();
+    const rawModifier = localeCodeSections[1];
+    const languageModifier =
+      rawModifier.charAt(0).toUpperCase() + rawModifier.slice(1).toLowerCase();
+    const region = localeCodeSections[2].toUpperCase();
+    return `${language}-${languageModifier}_${region}`;
+  } else if (numSections > 3) {
+    warn(
+      `Encountered strangely formatted locale "${localeCode}", ` +
+      `with ${numSections} sections.`);
+    return localeCode;
   }
-
-  return localeCodeSections.join('_');
 }
 exports.canonicalizeLocale = canonicalizeLocale;

--- a/tests/acceptance/suites/themeupgrader.js
+++ b/tests/acceptance/suites/themeupgrader.js
@@ -5,7 +5,7 @@ const ThemeManager = require('../../../src/utils/thememanager');
 const path = require('path');
 
 ThemeManager.getRepoForTheme = () => {
-    return path.resolve(__dirname, '../test-themes/basic-flow');
+  return path.resolve(__dirname, '../test-themes/basic-flow');
 };
 
 //Silence error logs
@@ -14,15 +14,15 @@ console.error = jest.fn();
 afterAll(() => console.error = error);
 
 it('tests upgrade fail', () => runInPlayground(async t => {
-    await git.cwd(process.cwd());
-    await t.jambo('init');
-    await t.jambo(
-        'import --themeUrl ../test-themes/basic-flow');
-    await git.add('.');
-    await git.commit('theme');
-    await expect(t.jambo('upgrade --branch fail')).rejects.toThrow(
-        /Remote branch fail not found in upstream origin/);
-    const diff = await git.diff();
-    expect(diff).toBe('');
-  }));
+  await git.cwd(process.cwd());
+  await t.jambo('init');
+  await t.jambo(
+    'import --themeUrl ../test-themes/basic-flow');
+  await git.add('.');
+  await git.commit('theme');
+  await expect(t.jambo('upgrade --branch fail')).rejects.toThrow(
+    /Remote branch fail not found in upstream origin/);
+  const diff = await git.diff();
+  expect(diff).toBe('');
+}));
 

--- a/tests/utils/i18nutils.js
+++ b/tests/utils/i18nutils.js
@@ -1,15 +1,33 @@
 const { canonicalizeLocale } = require('../../src/utils/i18nutils');
 
-describe('canonicalizeLocale correctly normalizes locales', () => {
-  it('converts language to lower case and region to upper case', () => {
-    const locale = 'FR_ch';
-    const canonicalizedLocale = canonicalizeLocale(locale);
-    expect(canonicalizedLocale).toEqual('fr_CH');
-  });
-
-  it('converts dashes to underscores', () => {
-    const locale = 'fr-CH';
-    const canonicalizedLocale = canonicalizeLocale(locale);
-    expect(canonicalizedLocale).toEqual('fr_CH');
-  });
+it('converts language to lower case and region to upper case', () => {
+  const locale = 'FR_ch';
+  const canonicalizedLocale = canonicalizeLocale(locale);
+  expect(canonicalizedLocale).toEqual('fr_CH');
 });
+
+it('converts dashes to underscores', () => {
+  const locale = 'fr-CH';
+  const canonicalizedLocale = canonicalizeLocale(locale);
+  expect(canonicalizedLocale).toEqual('fr_CH');
+});
+
+describe('works for chinese', () => {
+  const testCases = [
+    ['using dashes', 'zh-Hans-CH'],
+    ['using underscores', 'zh_Hans_CH'],
+    ['underscore then dash', 'zh_Hans-CH'],
+    ['dash then underscore', 'zh-Hans_CH'],
+    ['updates casing', 'zh-hans_ch'],
+  ];
+  const expected = 'zh-Hans_CH';
+  for (const [testName, inputLocale] of testCases) {
+    runTest(testName, inputLocale, expected);
+  }
+});
+
+function runTest(testName, inputLocale, expectedLocale) {
+  it(testName, () => {
+    expect(canonicalizeLocale(inputLocale)).toEqual(expectedLocale);
+  });
+}

--- a/tests/utils/i18nutils.js
+++ b/tests/utils/i18nutils.js
@@ -1,34 +1,65 @@
-const { canonicalizeLocale } = require('../../src/utils/i18nutils');
+const { canonicalizeLocale, parseLocale } = require('../../src/utils/i18nutils');
 
-it('converts language to lower case and region to upper case', () => {
-  const locale = 'FR_ch';
-  const canonicalizedLocale = canonicalizeLocale(locale);
-  expect(canonicalizedLocale).toEqual('fr_CH');
-});
-
-it('converts dashes to underscores', () => {
-  const locale = 'fr-CH';
-  const canonicalizedLocale = canonicalizeLocale(locale);
-  expect(canonicalizedLocale).toEqual('fr_CH');
-});
-
-describe('works for chinese', () => {
-  const testCases = [
-    ['using dashes', 'zh-Hans-CH'],
-    ['using underscores', 'zh_Hans_CH'],
-    ['underscore then dash', 'zh_Hans-CH'],
-    ['dash then underscore', 'zh-Hans_CH'],
-    ['updates casing', 'ZH-hans_Ch'],
-    ['does not have region code', 'zh-hans', 'zh-Hans'],
-  ];
-  const expected = 'zh-Hans_CH';
-  for (const [testName, inputLocale, specificExpected] of testCases) {
-    runTest(testName, inputLocale, specificExpected || expected);
-  }
-});
-
-function runTest(testName, inputLocale, expectedLocale) {
-  it(testName, () => {
-    expect(canonicalizeLocale(inputLocale)).toEqual(expectedLocale);
+describe('canonicalizeLocale correctly normalizes locales', () => {
+  it('converts language to lower case and region to upper case', () => {
+    const locale = 'FR_ch';
+    const canonicalizedLocale = canonicalizeLocale(locale);
+    expect(canonicalizedLocale).toEqual('fr_CH');
   });
-}
+
+  it('converts dashes to underscores', () => {
+    const locale = 'fr-CH';
+    const canonicalizedLocale = canonicalizeLocale(locale);
+    expect(canonicalizedLocale).toEqual('fr_CH');
+  });
+
+  describe('works for chinese', () => {
+    function runTest(testName, inputLocale, expectedLocale) {
+      it(testName, () => {
+        expect(canonicalizeLocale(inputLocale)).toEqual(expectedLocale);
+      });
+    }
+    const testCases = [
+      ['using dashes', 'zh-Hans-CH'],
+      ['using underscores', 'zh_Hans_CH'],
+      ['underscore then dash', 'zh_Hans-CH'],
+      ['dash then underscore', 'zh-Hans_CH'],
+      ['updates casing', 'ZH-hans_Ch'],
+      ['does not have region code', 'zh-hans', 'zh-Hans'],
+    ];
+    const expected = 'zh-Hans_CH';
+    for (const [testName, inputLocale, specificExpected] of testCases) {
+      runTest(testName, inputLocale, specificExpected || expected);
+    }
+  });
+});
+
+describe('parseLocale', () => {
+  it('performs case formatting', () => {
+    expect(parseLocale('Zh-hans-Ch')).toEqual({
+      language: 'zh',
+      modifier: 'Hans',
+      region: 'CH'
+    })
+  });
+
+  it('ZH_HANS', () => {
+    expect(parseLocale('ZH_HANS')).toEqual({
+      language: 'zh',
+      modifier: 'Hans'
+    })
+  });
+
+  it('2 section non-chinese locale', () => {
+    expect(parseLocale('FR-freE')).toEqual({
+      language: 'fr',
+      region: 'FREE'
+    });
+  });
+
+  it('simple language', () => {
+    expect(parseLocale('FR')).toEqual({
+      language: 'fr'
+    });
+  });
+});

--- a/tests/utils/i18nutils.js
+++ b/tests/utils/i18nutils.js
@@ -26,6 +26,7 @@ describe('canonicalizeLocale correctly normalizes locales', () => {
       ['dash then underscore', 'zh-Hans_CH'],
       ['updates casing', 'ZH-hans_Ch'],
       ['does not have region code', 'zh-hans', 'zh-Hans'],
+      ['has region but no modifier', 'zh-cH', 'zh_CH']
     ];
     const expected = 'zh-Hans_CH';
     for (const [testName, inputLocale, specificExpected] of testCases) {
@@ -43,10 +44,17 @@ describe('parseLocale', () => {
     })
   });
 
-  it('ZH_HANS', () => {
+  it('chinese with modifier only', () => {
     expect(parseLocale('ZH_HANS')).toEqual({
       language: 'zh',
       modifier: 'Hans'
+    })
+  });
+
+  it('chinese with region only', () => {
+    expect(parseLocale('ZH-cH')).toEqual({
+      language: 'zh',
+      region: 'CH'
     })
   });
 

--- a/tests/utils/i18nutils.js
+++ b/tests/utils/i18nutils.js
@@ -18,11 +18,12 @@ describe('works for chinese', () => {
     ['using underscores', 'zh_Hans_CH'],
     ['underscore then dash', 'zh_Hans-CH'],
     ['dash then underscore', 'zh-Hans_CH'],
-    ['updates casing', 'zh-hans_ch'],
+    ['updates casing', 'ZH-hans_Ch'],
+    ['does not have region code', 'zh-hans', 'zh-Hans'],
   ];
   const expected = 'zh-Hans_CH';
-  for (const [testName, inputLocale] of testCases) {
-    runTest(testName, inputLocale, expected);
+  for (const [testName, inputLocale, specificExpected] of testCases) {
+    runTest(testName, inputLocale, specificExpected || expected);
   }
 });
 


### PR DESCRIPTION
J=SLAP-1526
TEST=auto,manual

unit tests
ran build with zh-hans-ch in locale config, saw that the generated source code used the correct locale in the page
tried building a page with a locale with >3 sections, got a jambo warning but build continued without changing the locale