### PR TITLE
use es6 dynamic import for hbs helpers

### DIFF
--- a/src/commands/build/sitesgenerator.ts
+++ b/src/commands/build/sitesgenerator.ts
@@ -148,7 +148,7 @@ class SitesGenerator {
     if (fs.existsSync(customHbsHelpersDir)) {
       try {
         info('Registering custom Handlebars helpers from the default theme');
-        registerCustomHbsHelpers(hbs, customHbsHelpersDir);
+        await registerCustomHbsHelpers(hbs, customHbsHelpersDir);
       } catch (err) {
         throw new UserError('Failed to register custom handlebars helpers', err.stack);
       }

--- a/tests/acceptance/test-themes/customcommand/commands/addVertical.js
+++ b/tests/acceptance/test-themes/customcommand/commands/addVertical.js
@@ -8,7 +8,7 @@ const fs = require('fs');
  * VerticalAdder represents the `vertical` custom jambo command. The command adds
  * a new page for the given Vertical and associates a card type with it.
  */
-class VerticalAdder {
+module.exports = class VerticalAdder {
   constructor(jamboConfig) {
     this.config = jamboConfig;
   }
@@ -102,4 +102,3 @@ class VerticalAdder {
     fs.writeFileSync('index.html', content);
   }
 }
-module.exports = VerticalAdder;

--- a/tests/fixtures/hooks/templatedataformatter.js
+++ b/tests/fixtures/hooks/templatedataformatter.js
@@ -11,7 +11,7 @@
  * 
  * @param {Object} pageNameToConfig object of pageName to pageConfig
  */
-export default function (pageMetadata, siteLevelAttributes, pageNameToConfig) {
+module.exports = function (pageMetadata, siteLevelAttributes, pageNameToConfig) {
   return {
     aPageMetadata: pageMetadata,
     someSiteLevelAttributes: siteLevelAttributes,

--- a/tests/fixtures/hooks/templatedatavalidator.js
+++ b/tests/fixtures/hooks/templatedatavalidator.js
@@ -6,7 +6,7 @@ import { warn } from '../../../src/utils/logger';
  * @param {Object} pageData configuration(s) of a page template
  * @returns {boolean} false if validator should throw an error
  */
-export default function (pageData) {
+module.exports = function (pageData) {
    if(!pageData["params"]["example"]) {
        warn('Missing Info: param example in config file(s)');
        return true; //gracefully ignore missing param on page

--- a/tests/handlebars/registercustomhbshelpers.js
+++ b/tests/handlebars/registercustomhbshelpers.js
@@ -1,12 +1,15 @@
 import registerCustomHbsHelpers from '../../src/handlebars/registercustomhbshelpers';
 import path from 'path';
 import hbs from 'handlebars';
-const pathToHelpers = path.resolve(__dirname, '../fixtures/handlebars/customhelpers');
-registerCustomHbsHelpers(hbs, pathToHelpers)
+
+beforeAll(async () => {
+  const pathToHelpers = path.resolve(__dirname, '../fixtures/handlebars/customhelpers');
+  await registerCustomHbsHelpers(hbs, pathToHelpers);
+});
 
 describe('can register a custom hbs helper', () => {
   it('recognizes https://yext.com as absolute', () => {
-    const template = hbs.compile('{{#if (isNonRelativeUrl url)}}is absolute!{{/if}}');
+    const template = hbs.compile('{{#if (isNonRelativeUrl url) }}is absolute!{{/if}}');
     const data = {
       url: 'https://yext.com'
     };

--- a/tests/utils/i18nutils.js
+++ b/tests/utils/i18nutils.js
@@ -1,4 +1,4 @@
-import { canonicalizeLocale } from '../../src/utils/i18nutils';
+import { canonicalizeLocale, parseLocale } from '../../src/utils/i18nutils';
 
 describe('canonicalizeLocale correctly normalizes locales', () => {
   it('converts language to lower case and region to upper case', () => {


### PR DESCRIPTION
jambo build is already an async command, so its easy to refactor
this dynamic require into a dynamic import statement.
The other dynamic requires in jambo are harder to refactor because
they live inside fully synchronous commands/methods, like our custom
commands importer.

TEST=manual

smoke test jambo (on a different branch that has all TS changes)