### PR TITLE
fix typo templateDataFormattter -> templateDataFormatterHook

### DIFF
--- a/src/commands/build/templateargsbuilder.ts
+++ b/src/commands/build/templateargsbuilder.ts
@@ -62,14 +62,14 @@ export default class TemplateArgsBuilder {
    * @param {Object<string, Object>} pageNameToConfig
    * @returns {Object}
    */
-  _getTemplateDataFromFormatter(pageMetadata, siteLevelAttributes, pageNameToConfig) {
+  _getTemplateDataFromFormatter(pageMetadata: any, siteLevelAttributes: any, pageNameToConfig: Record<string, any>) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const formatterFunction = require(this.templateDataFormatterHook);
       return formatterFunction(pageMetadata, siteLevelAttributes, pageNameToConfig);
     } catch (err) {
       const msg =
-        `Could not load template data hook from ${this._templateDataFormatter}: `;
+        `Could not load template data hook from ${this.templateDataFormatterHook}: `;
       throw new UserError(msg, err.stack);
     }
   }


### PR DESCRIPTION
Fixes a typo found by typescript

I was using sublime merge's "stage hunk" feature and the parameter types
were registered in the same hunk as the typo fix, and it didn't seem worth it to manually separate out
the commits.