### PR TITLE
update isCustomError to be a type guard

### DIFF
--- a/src/utils/errorutils.ts
+++ b/src/utils/errorutils.ts
@@ -8,10 +8,12 @@ import { error } from './logger';
  * async operations will be lost.
  * @param {Error} error
  */
-export const exitWithError = (err = {}) => {
+export const exitWithError = (err: Error | UserError | SystemError) => {
   err.stack && error(err.stack);
-  const exitCode = err.exitCode || 1;
-  process.exit(exitCode);
+  if (isCustomError(err)) {
+    process.exit(err.exitCode || 1);
+  }
+  process.exit(1);
 };
 
 /**
@@ -19,6 +21,6 @@ export const exitWithError = (err = {}) => {
  * (Either UserError or SystemError)
  * @param {Error} err The error to evaluate
  */
-export const isCustomError = (err) => {
+export const isCustomError = (err: Error): err is UserError | SystemError => {
   return (err instanceof UserError || err instanceof SystemError);
 };


### PR DESCRIPTION
The issue was that err.exitCode does not exist on the vanilla
Error class, only our augmented UserError and SystemError classes