### PR TITLE
add configFile: false for babel helper

### DIFF
--- a/src/handlebars/registerhbshelpers.ts
+++ b/src/handlebars/registerhbshelpers.ts
@@ -83,9 +83,10 @@ export default function registerHbsHelpers(hbs: typeof Handlebars) {
     if (process.env.IS_DEVELOPMENT_PREVIEW === 'true' ) {
       return srcCode;
     } else {
-      return babel.transformSync(srcCode, {
+      return transformSync(srcCode, {
         compact: true,
         minified: true,
+        configFile: false,
         comments: false,
         sourceType: 'script',
         presets: ['@babel/preset-env'],


### PR DESCRIPTION
This prevents babel from automatically trying to use the babel.config.js
we added to jambo as part of the TS migration.
Our babel.config.js is only intended to be used by jest, not our built in
babel helper.

The import was already changed from `babel` to `{ transformSync }`.
We could keep the original babel import by turning on `allowSyntheticDefaultImports` in 
our tsconfig, but there doesn't seem to be too much point for that.