### PR TITLE
add return value types to base command class

### DIFF
--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -1,3 +1,8 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import { JamboConfig } from '../JamboConfig';
+import { ArgumentMetadata } from './argumentmetadata';
+
 /**
  * An interface that represents a command in the Jambo CLI. 
  */
@@ -6,32 +11,40 @@ class Command {
   /**
    * @returns {string} The alias for the command.
    */
-  static getAlias() { }
+  static getAlias(): string { return ''; }
 
   /**
    * @returns {string} A short, one sentence description of the command. This
    *                   description appears as part of the help text in the CLI. 
    */
-  static getShortDescription() { }
+  static getShortDescription(): string {
+    return '';
+  }
 
   /**
    * Executes the command with the provided arguments.
    * 
-   * @param {Object<string, ?>} args The arguments, keyed by name.
+   * @param {Object<string, unknown>} args The arguments, keyed by name.
    */
-  execute(args) { }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  execute(args: Record<string, unknown>): Record<string, unknown> {
+    return {};
+  }
 
   /**
    * @returns {Object<string, ArgumentMetadata>} Descriptions of each argument,
    *                                             keyed by name.
    */
-  static args() { }
+  static args(): Record<string, ArgumentMetadata>{
+    return {};
+  }
 
   /**
    * @param {Object} jamboConfig the config of the jambo repository
    * @returns {Object} description of the card command, including paths to 
    *                   all available cards
    */
-  static describe(jamboConfig) { }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  static describe(jamboConfig: JamboConfig): Promise<any> | any {}
 }
 export default Command;

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-
 import { JamboConfig } from '../JamboConfig';
 import { ArgumentMetadata } from './argumentmetadata';
 

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -47,16 +47,16 @@ class YargsFactory {
    * @param {Class} commandClass A Jambo {@link Command}'s class.
    * @returns {Object<string, ?>} The {@link yargs} CommandModule for the {@link Command}.
    */
-  _createCommandModule(commandClass) {
+  _createCommandModule(commandClass: typeof Command): CommandModule {
     return {
       command: commandClass.getAlias(),
-      desc: commandClass.getShortDescription(),
+      describe: commandClass.getShortDescription(),
       builder: yargs => {
         Object.entries(commandClass.args()).forEach(([name, metadata]) => {
           if (metadata.getType() === ArgumentType.ARRAY) {
             this._addListOption(name, metadata, yargs);
           } else {
-            yargs.option(
+            yargs.option<any, any>(
               name,
               {
                 type: metadata.getType(),
@@ -66,6 +66,7 @@ class YargsFactory {
               });
           }
         });
+        return yargs;
       },
       handler: async argv => {
         const commandInstance = this._createCommandInstance(commandClass);

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -56,7 +56,7 @@ class YargsFactory {
           if (metadata.getType() === ArgumentType.ARRAY) {
             this._addListOption(name, metadata, yargs);
           } else {
-            yargs.option<any, any>(
+            yargs.option<string, any>(
               name,
               {
                 type: metadata.getType(),


### PR DESCRIPTION
Adds return types to the base command class so typescript is happy.
The types could have been any, but it felt a little more correct to just
use the correct types.

Also update _createCommandModule desc -> describe, because desc doesn't
exist on the exported yargs types (though it appears to work so probably
just deprecated).