### PR TITLE
handle undefined err in exitWithError

### DIFF
--- a/src/utils/errorutils.ts
+++ b/src/utils/errorutils.ts
@@ -8,10 +8,12 @@ import { error } from './logger';
  * async operations will be lost.
  * @param {Error} error
  */
-export const exitWithError = (err: Error | UserError | SystemError) => {
-  err.stack && error(err.stack);
-  if (isCustomError(err)) {
-    process.exit(err.exitCode || 1);
+export const exitWithError = (err: Error | UserError | SystemError | undefined) => {
+  if (err) {
+    err.stack && error(err.stack);
+    if (isCustomError(err)) {
+      process.exit(err.exitCode || 1);
+    }
   }
   process.exit(1);
 };


### PR DESCRIPTION
Previously, we defaulted err to the empty object, which would nicely
handle err being undefined. Typescript is happy with us defaulting it
to empty object, though, since it's not of type Error | SystemError | UserError.

TEST=manual

test that I can run jambo card, without all of the required params, and the
error will still printed nicely