### PR TITLE
Update to new Command interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,6 @@ The name this page will be registered as.
 
 The template to generate the page with.
 
---layout _layout_name_
-
-The layout to use around the page.
-
 #### Build
 
 ```bash
@@ -119,8 +115,7 @@ The build command uses the 'defaultTheme' attribute in the jambo.json in Jambo's
     "config":"config",
     "overrides":"overrides",
     "output":"public",
-    "pages":"pages",
-    "layouts":"layouts"
+    "pages":"pages"
   },
   "defaultTheme": "answers-hitchhiker-theme"
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ The git URL of the theme to import, if a theme should be imported on init.
 
 If importing a theme on init, whether to import it as a git submodule as opposed to regular files. Defaults to false.
 
+--includeTranslations _true/false_
+
+If importing a theme on init, whether to initializes a translations directory as well. Defaults to false.
+
 #### Import
 
 ```bash

--- a/src/commands/build/buildcommand.ts
+++ b/src/commands/build/buildcommand.ts
@@ -2,35 +2,26 @@ import { ArgumentMetadata, ArgumentType } from '../../models/commands/argumentme
 import UserError from '../../errors/usererror';
 import { isCustomError } from '../../utils/errorutils';
 import SitesGenerator from './sitesgenerator';
+import Command from '../../models/commands/command';
 
 /**
  * BuildCommand builds all pages in the Jambo repo and places them in the
  * public directory.
  */
-class BuildCommand {
-  sitesGenerator: SitesGenerator
+const BuildCommand : Command = class {
+  static alias = 'build';
+  static shortDescription = 'build the static pages for the site';
+  static args: Record<string, ArgumentMetadata> = {
+    jsonEnvVars: {
+      type: ArgumentType.ARRAY,
+      description: 'environment variables containing JSON',
+      isRequired: false
+    }
+  };
+  sitesGenerator: SitesGenerator;
 
   constructor(sitesGenerator) {
     this.sitesGenerator = sitesGenerator;
-  }
-
-  static getAlias() {
-    return 'build';
-  }
-
-  static getShortDescription() {
-    return 'build the static pages for the site';
-  }
-
-  static args() {
-    return {
-      jsonEnvVars: new ArgumentMetadata({
-        type: ArgumentType.ARRAY,
-        itemType: ArgumentType.STRING, 
-        description: 'environment variables containing JSON',
-        isRequired: false
-      })
-    }
   }
 
   static describe() {
@@ -39,7 +30,7 @@ class BuildCommand {
     }
   }
 
-  async execute(args) {
+  async execute(args: Record<string, any>): Promise<any> {
     try {
       await this.sitesGenerator.generate(args.jsonEnvVars);
     } catch (err) {

--- a/src/commands/build/buildcommand.ts
+++ b/src/commands/build/buildcommand.ts
@@ -14,7 +14,7 @@ const BuildCommand : Command = class {
   constructor(sitesGenerator) {
     this.sitesGenerator = sitesGenerator;
   }
- 
+
   static getAlias() {
     return 'build';
   }

--- a/src/commands/build/buildcommand.ts
+++ b/src/commands/build/buildcommand.ts
@@ -1,14 +1,23 @@
-import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import UserError from '../../errors/usererror';
 import { isCustomError } from '../../utils/errorutils';
 import SitesGenerator from './sitesgenerator';
-import Command from '../../models/commands/command';
+import Command, { ArgsForExecute } from '../../models/commands/command';
 
+const args = {
+  jsonEnvVars: {
+    type: 'array',
+    itemType:'string', 
+    description: 'environment variables containing JSON',
+    isRequired: false
+  }
+} as const;
+type Args = typeof args;
+  
 /**
  * BuildCommand builds all pages in the Jambo repo and places them in the
  * public directory.
  */
-const BuildCommand : Command = class {
+const BuildCommand : Command<Args> = class {
   sitesGenerator: SitesGenerator;
 
   constructor(sitesGenerator) {
@@ -24,14 +33,7 @@ const BuildCommand : Command = class {
   }
 
   static args() {
-    return {
-      jsonEnvVars: new ArgumentMetadataImpl({
-        type: 'array',
-        itemType:'string', 
-        description: 'environment variables containing JSON',
-        isRequired: false
-      })
-    }
+    return args;
   }
 
   static describe() {
@@ -40,7 +42,7 @@ const BuildCommand : Command = class {
     }
   }
 
-  async execute(args: Record<string, any>): Promise<any> {
+  async execute(args: ArgsForExecute<Args>): Promise<any> {
     try {
       await this.sitesGenerator.generate(args.jsonEnvVars);
     } catch (err) {

--- a/src/commands/build/buildcommand.ts
+++ b/src/commands/build/buildcommand.ts
@@ -12,12 +12,13 @@ const args = {
   }
 } as const;
 type Args = typeof args;
+type ExecArgs = ArgsForExecute<Args>;
   
 /**
  * BuildCommand builds all pages in the Jambo repo and places them in the
  * public directory.
  */
-const BuildCommand : Command<Args> = class {
+const BuildCommand : Command<Args, ExecArgs> = class {
   sitesGenerator: SitesGenerator;
 
   constructor(sitesGenerator) {
@@ -42,7 +43,7 @@ const BuildCommand : Command<Args> = class {
     }
   }
 
-  async execute(args: ArgsForExecute<Args>): Promise<any> {
+  async execute(args: ExecArgs): Promise<any> {
     try {
       await this.sitesGenerator.generate(args.jsonEnvVars);
     } catch (err) {

--- a/src/commands/build/buildcommand.ts
+++ b/src/commands/build/buildcommand.ts
@@ -1,4 +1,4 @@
-import { ArgumentMetadata, ArgumentType } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
 import UserError from '../../errors/usererror';
 import { isCustomError } from '../../utils/errorutils';
 import SitesGenerator from './sitesgenerator';
@@ -9,19 +9,29 @@ import Command from '../../models/commands/command';
  * public directory.
  */
 const BuildCommand : Command = class {
-  static alias = 'build';
-  static shortDescription = 'build the static pages for the site';
-  static args: Record<string, ArgumentMetadata> = {
-    jsonEnvVars: {
-      type: ArgumentType.ARRAY,
-      description: 'environment variables containing JSON',
-      isRequired: false
-    }
-  };
   sitesGenerator: SitesGenerator;
 
   constructor(sitesGenerator) {
     this.sitesGenerator = sitesGenerator;
+  }
+ 
+  static getAlias() {
+    return 'build';
+  }
+
+  static getShortDescription() {
+    return 'build the static pages for the site';
+  }
+
+  static args() {
+    return {
+      jsonEnvVars: new ArgumentMetadata({
+        type: 'array',
+        itemType:'string', 
+        description: 'environment variables containing JSON',
+        isRequired: false
+      })
+    }
   }
 
   static describe() {

--- a/src/commands/build/buildcommand.ts
+++ b/src/commands/build/buildcommand.ts
@@ -6,7 +6,7 @@ import Command, { ArgsForExecute } from '../../models/commands/command';
 const args = {
   jsonEnvVars: {
     type: 'array',
-    itemType:'string', 
+    itemType: 'string', 
     description: 'environment variables containing JSON',
     isRequired: false
   }

--- a/src/commands/build/buildcommand.ts
+++ b/src/commands/build/buildcommand.ts
@@ -1,4 +1,4 @@
-import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import UserError from '../../errors/usererror';
 import { isCustomError } from '../../utils/errorutils';
 import SitesGenerator from './sitesgenerator';
@@ -25,7 +25,7 @@ const BuildCommand : Command = class {
 
   static args() {
     return {
-      jsonEnvVars: new ArgumentMetadata({
+      jsonEnvVars: new ArgumentMetadataImpl({
         type: 'array',
         itemType:'string', 
         description: 'environment variables containing JSON',

--- a/src/commands/build/pageconfigdecorator.ts
+++ b/src/commands/build/pageconfigdecorator.ts
@@ -7,7 +7,7 @@ import LocalizationConfig from '../../models/localizationconfig';
  * information provided.
  */
 export default class PageConfigDecorator {
-  _localizationConfig: LocalizationConfig
+  private _localizationConfig: LocalizationConfig
 
   constructor(localizationConfig) {
     /**

--- a/src/commands/build/pagesetsbuilder.ts
+++ b/src/commands/build/pagesetsbuilder.ts
@@ -15,8 +15,8 @@ import GlobalConfig from '../../models/globalconfig';
  * of {@link PageSet}s.
  */
 export default class PageSetsBuilder {
-  _globalConfig: GlobalConfig
-  _localizationConfig: LocalizationConfig
+  private _globalConfig: GlobalConfig
+  private _localizationConfig: LocalizationConfig
 
   constructor({ globalConfig, localizationConfig }) {
     /**

--- a/src/commands/build/pagetemplatedirector.ts
+++ b/src/commands/build/pagetemplatedirector.ts
@@ -6,7 +6,7 @@ import LocalizationConfig from '../../models/localizationconfig';
  * per (pageTemplate, locale) combination.
  */
 export default class PageTemplateDirector {
-  _localizationConfig: LocalizationConfig
+  private _localizationConfig: LocalizationConfig
 
   constructor(localizationConfig) {
     /**

--- a/src/commands/build/pagewriter.ts
+++ b/src/commands/build/pagewriter.ts
@@ -13,10 +13,10 @@ import { info } from '../../utils/logger';
  * the given output directory.
  */
 export default class PageWriter {
-  _env: any
-  _outputDirectory: string
-  _templateArgsBuilder: TemplateArgsBuilder
-  _templateDataValidator: TemplateDataValidator
+  private _env: any
+  private _outputDirectory: string
+  private _templateArgsBuilder: TemplateArgsBuilder
+  private _templateDataValidator: TemplateDataValidator
 
   constructor(config) {
     /**

--- a/src/commands/build/templatedatavalidator.ts
+++ b/src/commands/build/templatedatavalidator.ts
@@ -7,8 +7,8 @@ import { info } from '../../utils/logger';
  * using Theme's custom validation steps (if any).
  */
 export default class TemplateDataValidator {
-  _templateDataValidationHook: string
-  _hasHook: string
+  private _templateDataValidationHook: string
+  private _hasHook: string
 
   constructor(templateDataValidationHook) {
     /**

--- a/src/commands/commandimporter.ts
+++ b/src/commands/commandimporter.ts
@@ -125,24 +125,16 @@ export default class CommandImporter {
    * @returns {class} An implemenation of the current {@link Command} interface.
    */
   _handleLegacyImport(commandCreator: (jamboConfig: JamboConfig) => any) {
-    return class {
+    const Cmd : Command = class {
       _wrappedInstance: any
 
       constructor(jamboConfig) {
         this._wrappedInstance = commandCreator(jamboConfig);
       }
-
-      static getAlias() {
-        return commandCreator({}).getAlias();
-      }
-
-      static getShortDescription() {
-        return commandCreator({}).getShortDescription();
-      }
-
-      static args() {
-        return commandCreator({}).args();
-      }
+      
+      static alias = commandCreator({}).getAlias();
+      static shortDescription = commandCreator({}).getShortDescription();
+      static args = commandCreator({}).args();
 
       static describe(jamboConfig) {
         return commandCreator(jamboConfig).describe();
@@ -152,5 +144,6 @@ export default class CommandImporter {
         return this._wrappedInstance.execute(args);
       }
     }
+    return Cmd;
   }
 }

--- a/src/commands/commandimporter.ts
+++ b/src/commands/commandimporter.ts
@@ -130,7 +130,7 @@ export default class CommandImporter {
       constructor(jamboConfig) {
         this._wrappedInstance = commandCreator(jamboConfig);
       }
-      
+
       static getAlias() {
         return commandCreator({}).getAlias();
       }

--- a/src/commands/commandimporter.ts
+++ b/src/commands/commandimporter.ts
@@ -124,7 +124,7 @@ export default class CommandImporter {
    * @returns {class} An implemenation of the current {@link Command} interface.
    */
   _handleLegacyImport(commandCreator: (jamboConfig: JamboConfig) => any) {
-    const cmd : Command<any> = class {
+    const cmd : Command<any, any> = class {
       _wrappedInstance: any
 
       constructor(jamboConfig) {

--- a/src/commands/commandimporter.ts
+++ b/src/commands/commandimporter.ts
@@ -84,7 +84,7 @@ export default class CommandImporter {
    * @param {Command} commandClass The custom {@link Command}'s class
    * @returns {boolean} A boolean indicating if the custom {@Command} is valid.
    */
-  _validateCustomCommand(commandClass: typeof Command) {
+  _validateCustomCommand(commandClass: Command) {
     let isValidCommand;
     try {
       const getMethods = (classObject) => Object.getOwnPropertyNames(classObject)

--- a/src/commands/commandimporter.ts
+++ b/src/commands/commandimporter.ts
@@ -84,7 +84,7 @@ export default class CommandImporter {
    * @param {Command} commandClass The custom {@link Command}'s class
    * @returns {boolean} A boolean indicating if the custom {@Command} is valid.
    */
-  _validateCustomCommand(commandClass: Command) {
+  _validateCustomCommand(commandClass) {
     let isValidCommand;
     try {
       const getMethods = (classObject) => Object.getOwnPropertyNames(classObject)
@@ -103,7 +103,6 @@ export default class CommandImporter {
     } catch {
       isValidCommand = false;
     }
-
     return isValidCommand;
   }
   
@@ -132,9 +131,17 @@ export default class CommandImporter {
         this._wrappedInstance = commandCreator(jamboConfig);
       }
       
-      static alias = commandCreator({}).getAlias();
-      static shortDescription = commandCreator({}).getShortDescription();
-      static args = commandCreator({}).args();
+      static getAlias() {
+        return commandCreator({}).getAlias();
+      }
+
+      static getShortDescription() {
+        return commandCreator({}).getShortDescription();
+      }
+
+      static args() {
+        return commandCreator({}).args();
+      }
 
       static describe(jamboConfig) {
         return commandCreator(jamboConfig).describe();

--- a/src/commands/commandimporter.ts
+++ b/src/commands/commandimporter.ts
@@ -8,8 +8,8 @@ import { JamboConfig } from '../models/JamboConfig';
  * Imports all custom {@link Command}s within a Jambo repository.
  */
 export default class CommandImporter {
-  _outputDir: string
-  _themeDir: string
+  private _outputDir: string
+  private _themeDir: string
 
   constructor(outputDir, themeDir?) {
     this._outputDir = outputDir;

--- a/src/commands/commandimporter.ts
+++ b/src/commands/commandimporter.ts
@@ -124,7 +124,7 @@ export default class CommandImporter {
    * @returns {class} An implemenation of the current {@link Command} interface.
    */
   _handleLegacyImport(commandCreator: (jamboConfig: JamboConfig) => any) {
-    const cmd : Command = class {
+    const cmd : Command<any> = class {
       _wrappedInstance: any
 
       constructor(jamboConfig) {

--- a/src/commands/commandimporter.ts
+++ b/src/commands/commandimporter.ts
@@ -124,7 +124,7 @@ export default class CommandImporter {
    * @returns {class} An implemenation of the current {@link Command} interface.
    */
   _handleLegacyImport(commandCreator: (jamboConfig: JamboConfig) => any) {
-    const Cmd : Command = class {
+    const cmd : Command = class {
       _wrappedInstance: any
 
       constructor(jamboConfig) {
@@ -151,6 +151,6 @@ export default class CommandImporter {
         return this._wrappedInstance.execute(args);
       }
     }
-    return Cmd;
+    return cmd;
   }
 }

--- a/src/commands/commandregistry.ts
+++ b/src/commands/commandregistry.ts
@@ -12,7 +12,7 @@ import Command from '../models/commands/command';
  * A registry that maintains the built-in and custom commands for the Jambo CLI.
  */
 class CommandRegistry {
-  _commandsByName: Record<string, Command>
+  private _commandsByName: Record<string, Command>
 
   constructor() {
     this._commandsByName = this._initialize();

--- a/src/commands/commandregistry.ts
+++ b/src/commands/commandregistry.ts
@@ -12,7 +12,7 @@ import Command from '../models/commands/command';
  * A registry that maintains the built-in and custom commands for the Jambo CLI.
  */
 class CommandRegistry {
-  _commandsByName: Record<string, typeof Command>
+  _commandsByName: Record<string, Command>
 
   constructor() {
     this._commandsByName = this._initialize();
@@ -23,8 +23,8 @@ class CommandRegistry {
    *
    * @param {Class} commandClass 
    */
-  addCommand(commandClass: typeof Command) {
-    this._commandsByName[commandClass.getAlias()] = commandClass;
+  addCommand(commandClass: Command) {
+    this._commandsByName[commandClass.alias] = commandClass;
   }
 
   /**
@@ -57,14 +57,14 @@ class CommandRegistry {
    */
   _initialize(): Record<string, any> {
     return {
-      [ InitCommand.getAlias() ]: InitCommand,
-      [ ThemeImporter.getAlias() ]: ThemeImporter,
-      [ PageCommand.getAlias() ]: PageCommand,
-      [ OverrideCommand.getAlias() ]: OverrideCommand,
-      [ BuildCommand.getAlias() ]: BuildCommand,
-      [ ThemeUpgrader.getAlias() ]: ThemeUpgrader,
-      [ DescribeCommand.getAlias() ]: DescribeCommand,
-      [ JamboTranslationExtractor.getAlias() ]: JamboTranslationExtractor
+      [ InitCommand.alias ]: InitCommand,
+      [ ThemeImporter.alias ]: ThemeImporter,
+      [ PageCommand.alias ]: PageCommand,
+      [ OverrideCommand.alias ]: OverrideCommand,
+      [ BuildCommand.alias ]: BuildCommand,
+      [ ThemeUpgrader.alias ]: ThemeUpgrader,
+      [ DescribeCommand.alias ]: DescribeCommand,
+      [ JamboTranslationExtractor.alias ]: JamboTranslationExtractor
     };
   }
 }

--- a/src/commands/commandregistry.ts
+++ b/src/commands/commandregistry.ts
@@ -12,7 +12,7 @@ import Command from '../models/commands/command';
  * A registry that maintains the built-in and custom commands for the Jambo CLI.
  */
 class CommandRegistry {
-  private _commandsByName: Record<string, Command<any>>
+  private _commandsByName: Record<string, Command<any, any>>
 
   constructor() {
     this._commandsByName = this._initialize();
@@ -23,7 +23,7 @@ class CommandRegistry {
    *
    * @param {Class} commandClass 
    */
-  addCommand(commandClass: Command<any>) {
+  addCommand(commandClass: Command<any, any>) {
     this._commandsByName[commandClass.getAlias()] = commandClass;
   }
 

--- a/src/commands/commandregistry.ts
+++ b/src/commands/commandregistry.ts
@@ -24,7 +24,7 @@ class CommandRegistry {
    * @param {Class} commandClass 
    */
   addCommand(commandClass: Command) {
-    this._commandsByName[commandClass.alias] = commandClass;
+    this._commandsByName[commandClass.getAlias()] = commandClass;
   }
 
   /**
@@ -57,14 +57,14 @@ class CommandRegistry {
    */
   _initialize(): Record<string, any> {
     return {
-      [ InitCommand.alias ]: InitCommand,
-      [ ThemeImporter.alias ]: ThemeImporter,
-      [ PageCommand.alias ]: PageCommand,
-      [ OverrideCommand.alias ]: OverrideCommand,
-      [ BuildCommand.alias ]: BuildCommand,
-      [ ThemeUpgrader.alias ]: ThemeUpgrader,
-      [ DescribeCommand.alias ]: DescribeCommand,
-      [ JamboTranslationExtractor.alias ]: JamboTranslationExtractor
+      [ InitCommand.getAlias() ]: InitCommand,
+      [ ThemeImporter.getAlias() ]: ThemeImporter,
+      [ PageCommand.getAlias() ]: PageCommand,
+      [ OverrideCommand.getAlias() ]: OverrideCommand,
+      [ BuildCommand.getAlias() ]: BuildCommand,
+      [ ThemeUpgrader.getAlias() ]: ThemeUpgrader,
+      [ DescribeCommand.getAlias() ]: DescribeCommand,
+      [ JamboTranslationExtractor.getAlias() ]: JamboTranslationExtractor
     };
   }
 }

--- a/src/commands/commandregistry.ts
+++ b/src/commands/commandregistry.ts
@@ -12,7 +12,7 @@ import Command from '../models/commands/command';
  * A registry that maintains the built-in and custom commands for the Jambo CLI.
  */
 class CommandRegistry {
-  private _commandsByName: Record<string, Command>
+  private _commandsByName: Record<string, Command<any>>
 
   constructor() {
     this._commandsByName = this._initialize();
@@ -23,7 +23,7 @@ class CommandRegistry {
    *
    * @param {Class} commandClass 
    */
-  addCommand(commandClass: Command) {
+  addCommand(commandClass: Command<any>) {
     this._commandsByName[commandClass.getAlias()] = commandClass;
   }
 

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -5,9 +5,9 @@ import { JamboConfig } from '../../models/JamboConfig';
  * DescribeCommand outputs JSON that describes all registered Jambo commands
  * and their possible arguments.
  */
-const DescribeCommand : Command<any> = class {
+const DescribeCommand : Command<any, any> = class {
   private _jamboConfig: JamboConfig
-  getCommands: () => Command<any>[]
+  getCommands: () => Command<any, any>[]
 
   constructor(jamboConfig, getCommands) {
     /**

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -1,3 +1,4 @@
+import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
 import Command from '../../models/commands/command';
 import { JamboConfig } from '../../models/JamboConfig';
 
@@ -5,9 +6,12 @@ import { JamboConfig } from '../../models/JamboConfig';
  * DescribeCommand outputs JSON that describes all registered Jambo commands
  * and their possible arguments.
  */
-class DescribeCommand {
+const DescribeCommand : Command  = class {
   _jamboConfig: JamboConfig
-  getCommands: () => (typeof Command)[]
+  getCommands: () => Command[]
+  static alias = 'describe';
+  static shortDescription = 'describe all the registered jambo commands and their possible arguments';
+  static args: Record<string, ArgumentMetadata> = {};
 
   constructor(jamboConfig, getCommands) {
     /**
@@ -15,18 +19,6 @@ class DescribeCommand {
      */
     this._jamboConfig = jamboConfig;
     this.getCommands = getCommands;
-  }
-
-  static getAlias() {
-    return 'describe';
-  }
-
-  static getShortDescription() {
-    return 'describe all the registered jambo commands and their possible arguments';
-  }
-
-  static args() {
-    return {};
   }
 
   /**
@@ -51,11 +43,11 @@ class DescribeCommand {
         const describeValue = command.describe(this._jamboConfig);
         if (describeValue.then && typeof describeValue.then === 'function') {
           return describeValue.then(
-            (value) => { descriptions[command.getAlias()] = value; }
+            (value) => { descriptions[command.alias] = value; }
           );
         } else {
-          if (command.getAlias() !== 'describe') {
-            descriptions[command.getAlias()] = describeValue;
+          if (command.alias !== 'describe') {
+            descriptions[command.alias] = describeValue;
           }
         }
       }

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -1,14 +1,11 @@
 import Command from '../../models/commands/command';
 import { JamboConfig } from '../../models/JamboConfig';
 
-const args = {};
-type Args = typeof args;
-
 /**
  * DescribeCommand outputs JSON that describes all registered Jambo commands
  * and their possible arguments.
  */
-const DescribeCommand : Command<Args> = class {
+const DescribeCommand : Command<any> = class {
   private _jamboConfig: JamboConfig
   getCommands: () => Command<any>[]
 
@@ -29,7 +26,7 @@ const DescribeCommand : Command<Args> = class {
   }
 
   static args() {
-    return args;
+    return {};
   }
 
   /**

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -6,7 +6,7 @@ import { JamboConfig } from '../../models/JamboConfig';
  * and their possible arguments.
  */
 const DescribeCommand : Command  = class {
-  _jamboConfig: JamboConfig
+  private _jamboConfig: JamboConfig
   getCommands: () => Command[]
 
   constructor(jamboConfig, getCommands) {

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -1,13 +1,16 @@
 import Command from '../../models/commands/command';
 import { JamboConfig } from '../../models/JamboConfig';
 
+const args = {};
+type Args = typeof args;
+
 /**
  * DescribeCommand outputs JSON that describes all registered Jambo commands
  * and their possible arguments.
  */
-const DescribeCommand : Command  = class {
+const DescribeCommand : Command<Args> = class {
   private _jamboConfig: JamboConfig
-  getCommands: () => Command[]
+  getCommands: () => Command<any>[]
 
   constructor(jamboConfig, getCommands) {
     /**
@@ -26,7 +29,7 @@ const DescribeCommand : Command  = class {
   }
 
   static args() {
-    return {};
+    return args;
   }
 
   /**

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -1,4 +1,3 @@
-import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
 import Command from '../../models/commands/command';
 import { JamboConfig } from '../../models/JamboConfig';
 
@@ -9,9 +8,6 @@ import { JamboConfig } from '../../models/JamboConfig';
 const DescribeCommand : Command  = class {
   _jamboConfig: JamboConfig
   getCommands: () => Command[]
-  static alias = 'describe';
-  static shortDescription = 'describe all the registered jambo commands and their possible arguments';
-  static args: Record<string, ArgumentMetadata> = {};
 
   constructor(jamboConfig, getCommands) {
     /**
@@ -19,6 +15,18 @@ const DescribeCommand : Command  = class {
      */
     this._jamboConfig = jamboConfig;
     this.getCommands = getCommands;
+  }
+
+  static getAlias() {
+    return 'describe';
+  }
+
+  static getShortDescription() {
+    return 'describe all the registered jambo commands and their possible arguments';
+  }
+
+  static args() {
+    return {}
   }
 
   /**
@@ -43,11 +51,11 @@ const DescribeCommand : Command  = class {
         const describeValue = command.describe(this._jamboConfig);
         if (describeValue.then && typeof describeValue.then === 'function') {
           return describeValue.then(
-            (value) => { descriptions[command.alias] = value; }
+            (value) => { descriptions[command.getAlias()] = value; }
           );
         } else {
-          if (command.alias !== 'describe') {
-            descriptions[command.alias] = describeValue;
+          if (command.getAlias() !== 'describe') {
+            descriptions[command.getAlias()] = describeValue;
           }
         }
       }

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -26,7 +26,7 @@ const DescribeCommand : Command  = class {
   }
 
   static args() {
-    return {}
+    return {};
   }
 
   /**

--- a/src/commands/extract-translations/jambotranslationextractor.ts
+++ b/src/commands/extract-translations/jambotranslationextractor.ts
@@ -10,6 +10,14 @@ import Command from '../../models/commands/command';
  * JamboTranslationExtractor extracts translations from a jambo repo.
  */
 const JamboTranslationExtractor : Command = class {
+  jamboConfig: JamboConfig
+  extractor: TranslationExtractor
+  
+  constructor(jamboConfig) {
+    this.jamboConfig = jamboConfig;
+    this.extractor = new TranslationExtractor();
+  }
+
   static getAlias() {
     return 'extract-translations';
   }
@@ -35,13 +43,6 @@ const JamboTranslationExtractor : Command = class {
         defaultValue: 'messages.pot'
       })
     };
-  }
-  jamboConfig: JamboConfig
-  extractor: TranslationExtractor
-  
-  constructor(jamboConfig) {
-    this.jamboConfig = jamboConfig;
-    this.extractor = new TranslationExtractor();
   }
 
   static describe() {

--- a/src/commands/extract-translations/jambotranslationextractor.ts
+++ b/src/commands/extract-translations/jambotranslationextractor.ts
@@ -1,5 +1,5 @@
 import TranslationExtractor from '../../i18n/extractor/translationextractor';
-import { ArgumentMetadata, ArgumentType } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
 import { info } from '../../utils/logger';
 import DefaultTranslationGlobber from './defaulttranslationglobber';
 import { readGitignorePaths } from '../../utils/gitutils';
@@ -10,24 +10,32 @@ import Command from '../../models/commands/command';
  * JamboTranslationExtractor extracts translations from a jambo repo.
  */
 const JamboTranslationExtractor : Command = class {
-  static alias = 'extract-translations';
-  static shortDescription = 'extract translated strings from .hbs and .js files';
-  static args: Record<string, ArgumentMetadata> = {
-    globs: {
-      describeName: 'Globs to Scan',
-      type: ArgumentType.ARRAY,
-      description:
-        'specify globs to scan for translations, instead of using the defaults',
-      isRequired: false
-    },
-    output: {
-      describeName: 'Output Path',
-      type: ArgumentType.STRING,
-      description: 'the output path to extract the .pot file to',
-      isRequired: false,
-      defaultValue: 'messages.pot'
-    }
-  };
+  static getAlias() {
+    return 'extract-translations';
+  }
+
+  static getShortDescription() {
+    return 'extract translated strings from .hbs and .js files';
+  }
+
+  static args() {
+    return {
+      globs: new ArgumentMetadata({
+        displayName: 'Globs to Scan',
+        type: 'array',
+        description:
+          'specify globs to scan for translations, instead of using the defaults',
+        isRequired: false
+      }),
+      output: new ArgumentMetadata({
+        displayName: 'Output Path',
+        type: 'string',
+        description: 'the output path to extract the .pot file to',
+        isRequired: false,
+        defaultValue: 'messages.pot'
+      })
+    };
+  }
   jamboConfig: JamboConfig
   extractor: TranslationExtractor
   
@@ -37,15 +45,15 @@ const JamboTranslationExtractor : Command = class {
   }
 
   static describe() {
+    const args = this.args();
     return {
       displayName: 'Extract Translations',
-      params: Object.keys(this.args).reduce((params, alias) => {
+      params: Object.keys(args).reduce((params, alias) => {
         params[alias] = {
-          displayName: this.args[alias].describeName,
-          type: this.args[alias].type,
-          required: this.args[alias].isRequired,
-          default: this.args[alias].defaultValue,
-
+          displayName: args[alias].getDisplayName(),
+          type: args[alias].getType(),
+          required: args[alias].isRequired(),
+          default: args[alias].defaultValue(),
         }
         return params;
       }, {})

--- a/src/commands/extract-translations/jambotranslationextractor.ts
+++ b/src/commands/extract-translations/jambotranslationextractor.ts
@@ -23,11 +23,12 @@ const args = {
   }
 } as const;
 type Args = typeof args;
+type ExecArgs = ArgsForExecute<Args>;
 
 /**
  * JamboTranslationExtractor extracts translations from a jambo repo.
  */
-const JamboTranslationExtractor : Command<Args> = class {
+const JamboTranslationExtractor : Command<Args, ExecArgs> = class {
   jamboConfig: JamboConfig
   extractor: TranslationExtractor
   
@@ -64,7 +65,7 @@ const JamboTranslationExtractor : Command<Args> = class {
     };
   }
 
-  execute({ output, globs }: ArgsForExecute<Args>) {
+  execute({ output, globs }: ExecArgs) {
     if (globs && globs.length > 0) {
       this._extract(output, globs);
     } else {

--- a/src/commands/extract-translations/jambotranslationextractor.ts
+++ b/src/commands/extract-translations/jambotranslationextractor.ts
@@ -1,15 +1,33 @@
 import TranslationExtractor from '../../i18n/extractor/translationextractor';
-import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import { info } from '../../utils/logger';
 import DefaultTranslationGlobber from './defaulttranslationglobber';
 import { readGitignorePaths } from '../../utils/gitutils';
 import { JamboConfig } from '../../models/JamboConfig';
-import Command from '../../models/commands/command';
+import Command, { ArgsForExecute } from '../../models/commands/command';
+
+const args = {
+  globs: {
+    displayName: 'Globs to Scan',
+    type: 'array',
+    itemType: 'string',
+    description:
+      'specify globs to scan for translations, instead of using the defaults',
+    isRequired: false
+  },
+  output: {
+    displayName: 'Output Path',
+    type: 'string',
+    description: 'the output path to extract the .pot file to',
+    isRequired: false,
+    defaultValue: 'messages.pot'
+  }
+} as const ;
+type Args = typeof args;
 
 /**
  * JamboTranslationExtractor extracts translations from a jambo repo.
  */
-const JamboTranslationExtractor : Command = class {
+const JamboTranslationExtractor : Command<Args> = class {
   jamboConfig: JamboConfig
   extractor: TranslationExtractor
   
@@ -27,36 +45,26 @@ const JamboTranslationExtractor : Command = class {
   }
 
   static args() {
-    return {
-      globs: new ArgumentMetadataImpl({
-        displayName: 'Globs to Scan',
-        type: 'array',
-        description:
-          'specify globs to scan for translations, instead of using the defaults',
-        isRequired: false
-      }),
-      output: new ArgumentMetadataImpl({
-        displayName: 'Output Path',
-        type: 'string',
-        description: 'the output path to extract the .pot file to',
-        isRequired: false,
-        defaultValue: 'messages.pot'
-      })
-    };
+    return args;
   }
 
   static describe() {
-    const args = this.args();
     return {
       displayName: 'Extract Translations',
       params: Object.keys(args).reduce((params, alias) => {
-        params[alias] = args[alias].toDescribeFormat();
+        params[alias] = {
+          displayName: args[alias].displayName,
+          type: args[alias].type,
+          required: args[alias].isRequired,
+          default: args[alias].defaultValue,
+
+        }
         return params;
       }, {})
     };
   }
 
-  execute({ output, globs }) {
+  execute({ output, globs }: ArgsForExecute<Args>) {
     if (globs && globs.length > 0) {
       this._extract(output, globs);
     } else {

--- a/src/commands/extract-translations/jambotranslationextractor.ts
+++ b/src/commands/extract-translations/jambotranslationextractor.ts
@@ -1,5 +1,5 @@
 import TranslationExtractor from '../../i18n/extractor/translationextractor';
-import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import { info } from '../../utils/logger';
 import DefaultTranslationGlobber from './defaulttranslationglobber';
 import { readGitignorePaths } from '../../utils/gitutils';
@@ -28,14 +28,14 @@ const JamboTranslationExtractor : Command = class {
 
   static args() {
     return {
-      globs: new ArgumentMetadata({
+      globs: new ArgumentMetadataImpl({
         displayName: 'Globs to Scan',
         type: 'array',
         description:
           'specify globs to scan for translations, instead of using the defaults',
         isRequired: false
       }),
-      output: new ArgumentMetadata({
+      output: new ArgumentMetadataImpl({
         displayName: 'Output Path',
         type: 'string',
         description: 'the output path to extract the .pot file to',
@@ -50,12 +50,7 @@ const JamboTranslationExtractor : Command = class {
     return {
       displayName: 'Extract Translations',
       params: Object.keys(args).reduce((params, alias) => {
-        params[alias] = {
-          displayName: args[alias].getDisplayName(),
-          type: args[alias].getType(),
-          required: args[alias].isRequired(),
-          default: args[alias].defaultValue(),
-        }
+        params[alias] = args[alias].toDescribeFormat();
         return params;
       }, {})
     };

--- a/src/commands/extract-translations/jambotranslationextractor.ts
+++ b/src/commands/extract-translations/jambotranslationextractor.ts
@@ -21,7 +21,7 @@ const args = {
     isRequired: false,
     defaultValue: 'messages.pot'
   }
-} as const ;
+} as const;
 type Args = typeof args;
 
 /**

--- a/src/commands/extract-translations/jambotranslationextractor.ts
+++ b/src/commands/extract-translations/jambotranslationextractor.ts
@@ -4,52 +4,49 @@ import { info } from '../../utils/logger';
 import DefaultTranslationGlobber from './defaulttranslationglobber';
 import { readGitignorePaths } from '../../utils/gitutils';
 import { JamboConfig } from '../../models/JamboConfig';
+import Command from '../../models/commands/command';
 
 /**
  * JamboTranslationExtractor extracts translations from a jambo repo.
  */
-class JamboTranslationExtractor {
+const JamboTranslationExtractor : Command = class {
+  static alias = 'extract-translations';
+  static shortDescription = 'extract translated strings from .hbs and .js files';
+  static args: Record<string, ArgumentMetadata> = {
+    globs: {
+      describeName: 'Globs to Scan',
+      type: ArgumentType.ARRAY,
+      description:
+        'specify globs to scan for translations, instead of using the defaults',
+      isRequired: false
+    },
+    output: {
+      describeName: 'Output Path',
+      type: ArgumentType.STRING,
+      description: 'the output path to extract the .pot file to',
+      isRequired: false,
+      defaultValue: 'messages.pot'
+    }
+  };
   jamboConfig: JamboConfig
   extractor: TranslationExtractor
-
+  
   constructor(jamboConfig) {
     this.jamboConfig = jamboConfig;
     this.extractor = new TranslationExtractor();
   }
 
-  static getAlias() {
-    return 'extract-translations';
-  }
-
-  static getShortDescription() {
-    return 'extract translated strings from .hbs and .js files';
-  }
-
-  static args() {
-    return {
-      globs: new ArgumentMetadata({
-        displayName: 'Globs to Scan',
-        type: ArgumentType.ARRAY,
-        description:
-          'specify globs to scan for translations, instead of using the defaults',
-        isRequired: false
-      }),
-      output: new ArgumentMetadata({
-        displayName: 'Output Path',
-        type: ArgumentType.STRING,
-        description: 'the output path to extract the .pot file to',
-        isRequired: false,
-        defaultValue: 'messages.pot'
-      })
-    };
-  }
-
   static describe() {
-    const args = this.args();
     return {
       displayName: 'Extract Translations',
-      params: Object.keys(args).reduce((params, alias) => {
-        params[alias] = args[alias].toDescribeFormat();
+      params: Object.keys(this.args).reduce((params, alias) => {
+        params[alias] = {
+          displayName: this.args[alias].describeName,
+          type: this.args[alias].type,
+          required: this.args[alias].isRequired,
+          default: this.args[alias].defaultValue,
+
+        }
         return params;
       }, {})
     };

--- a/src/commands/import/themeimporter.ts
+++ b/src/commands/import/themeimporter.ts
@@ -31,11 +31,12 @@ const args = {
   },
 } as const;
 type Args = typeof args;
+type ExecArgs = ArgsForExecute<Args>;
 
 /**
  * ThemeImporter imports a specified theme into the themes directory.
  */
-const ThemeImporter : Command<Args> = class {
+const ThemeImporter : Command<Args, ExecArgs> = class {
   config: JamboConfig;
   private _themeShadower: ThemeShadower;
   private _postImportHook: 'postimport';
@@ -80,7 +81,7 @@ const ThemeImporter : Command<Args> = class {
     }
   }
 
-  async execute(args: ArgsForExecute<Args>) {
+  async execute(args: ExecArgs) {
     await this.import(args.themeUrl, args.theme, args.useSubmodules);
   }
 

--- a/src/commands/import/themeimporter.ts
+++ b/src/commands/import/themeimporter.ts
@@ -7,7 +7,7 @@ import { getRepoNameFromURL } from '../../utils/gitutils';
 import SystemError from '../../errors/systemerror';
 import UserError from '../../errors/usererror';
 import { isCustomError } from '../../utils/errorutils';
-import { ArgumentMetadata, ArgumentType } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
 import { CustomCommand } from '../../utils/customcommands/command';
 import { CustomCommandExecuter } from '../../utils/customcommands/commandexecuter';
 import { searchDirectoryIgnoringExtensions } from '../../utils/fileutils';
@@ -23,28 +23,37 @@ const ThemeImporter : Command = class {
   config: JamboConfig;
   _themeShadower: ThemeShadower;
   _postImportHook: 'postimport';
-  static alias = 'import';
-  static shortDescription = 'import a theme';
-  static args: Record<string, ArgumentMetadata> = {
-    themeUrl: {
-      type: ArgumentType.STRING,
-      description: 'url of the theme\'s git repo',
-    },
-    theme: {
-      type: ArgumentType.STRING,
-      description: '(deprecated: specify the themeUrl instead)'
-        + ' the name of the theme to import',
-    },
-    useSubmodules: {
-      type: ArgumentType.BOOLEAN,
-      description: 'import the theme as a submodule'
-    }
-  };
 
   constructor(jamboConfig) {
     this.config = jamboConfig;
     this._themeShadower = new ThemeShadower(jamboConfig);
     this._postImportHook = 'postimport';
+  }
+
+  static getAlias() {
+    return 'import';
+  }
+
+  static getShortDescription() {
+    return 'import a theme';
+  }
+
+  static args() {
+    return {
+      themeUrl: new ArgumentMetadata({
+        type: 'string',
+        description: 'url of the theme\'s git repo',
+      }),
+      theme: new ArgumentMetadata({
+        type:'string',
+        description: '(deprecated: specify the themeUrl instead)'
+          + ' the name of the theme to import',
+      }),
+      useSubmodules: new ArgumentMetadata({
+        type: 'boolean',
+        description: 'import the theme as a submodule'
+      }),
+    }
   }
 
   static describe() {

--- a/src/commands/import/themeimporter.ts
+++ b/src/commands/import/themeimporter.ts
@@ -13,7 +13,7 @@ import { searchDirectoryIgnoringExtensions } from '../../utils/fileutils';
 import fsExtra from 'fs-extra';
 import process from 'process';
 import { JamboConfig } from '../../models/JamboConfig';
-import Command from '../../models/commands/command';
+import Command, { ArgsForExecute } from '../../models/commands/command';
 
 const args = {
   themeUrl: {
@@ -29,7 +29,7 @@ const args = {
     type: 'boolean',
     description: 'import the theme as a submodule'
   },
-} as const ;
+} as const;
 type Args = typeof args;
 
 /**
@@ -80,7 +80,7 @@ const ThemeImporter : Command<Args> = class {
     }
   }
 
-  async execute(args) {
+  async execute(args: ArgsForExecute<Args>) {
     await this.import(args.themeUrl, args.theme, args.useSubmodules);
   }
 

--- a/src/commands/import/themeimporter.ts
+++ b/src/commands/import/themeimporter.ts
@@ -7,7 +7,6 @@ import { getRepoNameFromURL } from '../../utils/gitutils';
 import SystemError from '../../errors/systemerror';
 import UserError from '../../errors/usererror';
 import { isCustomError } from '../../utils/errorutils';
-import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import { CustomCommand } from '../../utils/customcommands/command';
 import { CustomCommandExecuter } from '../../utils/customcommands/commandexecuter';
 import { searchDirectoryIgnoringExtensions } from '../../utils/fileutils';
@@ -16,10 +15,27 @@ import process from 'process';
 import { JamboConfig } from '../../models/JamboConfig';
 import Command from '../../models/commands/command';
 
+const args = {
+  themeUrl: {
+    type: 'string',
+    description: 'url of the theme\'s git repo',
+  },
+  theme: {
+    type:'string',
+    description: '(deprecated: specify the themeUrl instead)'
+      + ' the name of the theme to import',
+  },
+  useSubmodules: {
+    type: 'boolean',
+    description: 'import the theme as a submodule'
+  },
+} as const ;
+type Args = typeof args;
+
 /**
  * ThemeImporter imports a specified theme into the themes directory.
  */
-const ThemeImporter : Command = class {
+const ThemeImporter : Command<Args> = class {
   config: JamboConfig;
   private _themeShadower: ThemeShadower;
   private _postImportHook: 'postimport';
@@ -39,21 +55,7 @@ const ThemeImporter : Command = class {
   }
 
   static args() {
-    return {
-      themeUrl: new ArgumentMetadataImpl({
-        type: 'string',
-        description: 'url of the theme\'s git repo',
-      }),
-      theme: new ArgumentMetadataImpl({
-        type:'string',
-        description: '(deprecated: specify the themeUrl instead)'
-          + ' the name of the theme to import',
-      }),
-      useSubmodules: new ArgumentMetadataImpl({
-        type: 'boolean',
-        description: 'import the theme as a submodule'
-      }),
-    }
+    return args;
   }
 
   static describe() {
@@ -78,7 +80,7 @@ const ThemeImporter : Command = class {
     }
   }
 
-  async execute(args: Record<string, any>) {
+  async execute(args) {
     await this.import(args.themeUrl, args.theme, args.useSubmodules);
   }
 

--- a/src/commands/import/themeimporter.ts
+++ b/src/commands/import/themeimporter.ts
@@ -14,45 +14,37 @@ import { searchDirectoryIgnoringExtensions } from '../../utils/fileutils';
 import fsExtra from 'fs-extra';
 import process from 'process';
 import { JamboConfig } from '../../models/JamboConfig';
+import Command from '../../models/commands/command';
 
 /**
  * ThemeImporter imports a specified theme into the themes directory.
  */
-export default class ThemeImporter {
+const ThemeImporter : Command = class {
   config: JamboConfig;
   _themeShadower: ThemeShadower;
-  _postImportHook: 'postimport'
+  _postImportHook: 'postimport';
+  static alias = 'import';
+  static shortDescription = 'import a theme';
+  static args: Record<string, ArgumentMetadata> = {
+    themeUrl: {
+      type: ArgumentType.STRING,
+      description: 'url of the theme\'s git repo',
+    },
+    theme: {
+      type: ArgumentType.STRING,
+      description: '(deprecated: specify the themeUrl instead)'
+        + ' the name of the theme to import',
+    },
+    useSubmodules: {
+      type: ArgumentType.BOOLEAN,
+      description: 'import the theme as a submodule'
+    }
+  };
 
   constructor(jamboConfig) {
     this.config = jamboConfig;
     this._themeShadower = new ThemeShadower(jamboConfig);
     this._postImportHook = 'postimport';
-  }
-
-  static getAlias() {
-    return 'import';
-  }
-
-  static getShortDescription() {
-    return 'import a theme';
-  }
-
-  static args() {
-    return {
-      themeUrl: new ArgumentMetadata({
-        type: ArgumentType.STRING,
-        description: 'url of the theme\'s git repo',
-      }),
-      theme: new ArgumentMetadata({
-        type: ArgumentType.STRING,
-        description: '(deprecated: specify the themeUrl instead)'
-          + ' the name of the theme to import',
-      }),
-      useSubmodules: new ArgumentMetadata({
-        type: ArgumentType.BOOLEAN,
-        description: 'import the theme as a submodule'
-      }),
-    }
   }
 
   static describe() {
@@ -77,7 +69,7 @@ export default class ThemeImporter {
     }
   }
 
-  async execute(args) {
+  async execute(args: Record<string, any>) {
     await this.import(args.themeUrl, args.theme, args.useSubmodules);
   }
 
@@ -148,3 +140,5 @@ export default class ThemeImporter {
     new CustomCommandExecuter(this.config).execute(customCommand);
   }
 }
+
+export default ThemeImporter;

--- a/src/commands/import/themeimporter.ts
+++ b/src/commands/import/themeimporter.ts
@@ -7,7 +7,7 @@ import { getRepoNameFromURL } from '../../utils/gitutils';
 import SystemError from '../../errors/systemerror';
 import UserError from '../../errors/usererror';
 import { isCustomError } from '../../utils/errorutils';
-import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import { CustomCommand } from '../../utils/customcommands/command';
 import { CustomCommandExecuter } from '../../utils/customcommands/commandexecuter';
 import { searchDirectoryIgnoringExtensions } from '../../utils/fileutils';
@@ -21,8 +21,8 @@ import Command from '../../models/commands/command';
  */
 const ThemeImporter : Command = class {
   config: JamboConfig;
-  _themeShadower: ThemeShadower;
-  _postImportHook: 'postimport';
+  private _themeShadower: ThemeShadower;
+  private _postImportHook: 'postimport';
 
   constructor(jamboConfig) {
     this.config = jamboConfig;
@@ -40,16 +40,16 @@ const ThemeImporter : Command = class {
 
   static args() {
     return {
-      themeUrl: new ArgumentMetadata({
+      themeUrl: new ArgumentMetadataImpl({
         type: 'string',
         description: 'url of the theme\'s git repo',
       }),
-      theme: new ArgumentMetadata({
+      theme: new ArgumentMetadataImpl({
         type:'string',
         description: '(deprecated: specify the themeUrl instead)'
           + ' the name of the theme to import',
       }),
-      useSubmodules: new ArgumentMetadata({
+      useSubmodules: new ArgumentMetadataImpl({
         type: 'boolean',
         description: 'import the theme as a submodule'
       }),

--- a/src/commands/init/initcommand.ts
+++ b/src/commands/init/initcommand.ts
@@ -1,12 +1,29 @@
 import { RepositorySettings, RepositoryScaffolder } from './repositoryscaffolder';
-import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import ThemeManager from '../../utils/thememanager';
-import Command from '../../models/commands/command';
+import Command, { ArgsForExecute } from '../../models/commands/command';
+
+const args = {
+  themeUrl: {
+    type: 'string',
+    description: 'url of a theme\'s git repo to import during the init',
+  },
+  theme: {
+    type: 'string',
+    description: '(deprecated: specify the themeUrl instead)'
+      + ' the name of a theme to import during the init',
+    isRequired: false
+  },
+  useSubmodules: {
+    type: 'boolean', 
+    description: 'if starter theme should be imported as submodule'
+  },
+} as const;
+type Args = typeof args;
 
 /**
  * InitCommand initializes the current directory as a Jambo repository.
  */
-const InitCommand : Command = class {
+const InitCommand : Command<Args> = class {
   static getAlias() {
     return 'init';
   }
@@ -16,22 +33,7 @@ const InitCommand : Command = class {
   }
 
   static args() {
-    return {
-      themeUrl: new ArgumentMetadataImpl({
-        type: 'string',
-        description: 'url of a theme\'s git repo to import during the init',
-      }),
-      theme: new ArgumentMetadataImpl({
-        type: 'string',
-        description: '(deprecated: specify the themeUrl instead)'
-          + ' the name of a theme to import during the init',
-        isRequired: false
-      }),
-      useSubmodules: new ArgumentMetadataImpl({
-        type: 'boolean', 
-        description: 'if starter theme should be imported as submodule'
-      }),
-    }
+    return args;
   }
 
   static describe() {
@@ -56,7 +58,7 @@ const InitCommand : Command = class {
     }
   }
 
-  async execute(args: RepositorySettings) {
+  async execute(args: ArgsForExecute<Args> & RepositorySettings) {
     const repositoryScaffolder = new RepositoryScaffolder();
     await repositoryScaffolder.create(args);
   }

--- a/src/commands/init/initcommand.ts
+++ b/src/commands/init/initcommand.ts
@@ -1,6 +1,6 @@
-import { RepositorySettings, RepositoryScaffolder } from './repositoryscaffolder';
+import { RepositoryScaffolder } from './repositoryscaffolder';
 import ThemeManager from '../../utils/thememanager';
-import Command from '../../models/commands/command';
+import Command, { ArgsForExecute } from '../../models/commands/command';
 
 const args = {
   themeUrl: {
@@ -66,7 +66,7 @@ const InitCommand : Command<Args> = class {
     }
   }
 
-  async execute(args: RepositorySettings) {
+  async execute(args: ArgsForExecute<Args>) {
     const repositoryScaffolder = new RepositoryScaffolder();
     await repositoryScaffolder.create(args);
   }

--- a/src/commands/init/initcommand.ts
+++ b/src/commands/init/initcommand.ts
@@ -1,5 +1,5 @@
 import { RepositorySettings, RepositoryScaffolder } from './repositoryscaffolder';
-import { ArgumentMetadata, ArgumentType } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
 import ThemeManager from '../../utils/thememanager';
 import Command from '../../models/commands/command';
 
@@ -7,24 +7,32 @@ import Command from '../../models/commands/command';
  * InitCommand initializes the current directory as a Jambo repository.
  */
 const InitCommand : Command = class {
-  static alias = 'init';
-  static shortDescription = 'initialize the repository';
-  static args: Record<string, ArgumentMetadata> = {
-    themeUrl: {
-      type: ArgumentType.STRING,
-      description: 'url of a theme\'s git repo to import during the init',
-    },
-    theme: {
-      type: ArgumentType.STRING,
-      description: '(deprecated: specify the themeUrl instead)'
-        + ' the name of a theme to import during the init',
-      isRequired: false
-    },
-    useSubmodules: {
-      type: ArgumentType.BOOLEAN, 
-      description: 'if starter theme should be imported as submodule'
+  static getAlias() {
+    return 'init';
+  }
+
+  static getShortDescription() {
+    return 'initialize the repository';
+  }
+
+  static args() {
+    return {
+      themeUrl: new ArgumentMetadata({
+        type: 'string',
+        description: 'url of a theme\'s git repo to import during the init',
+      }),
+      theme: new ArgumentMetadata({
+        type: 'string',
+        description: '(deprecated: specify the themeUrl instead)'
+          + ' the name of a theme to import during the init',
+        isRequired: false
+      }),
+      useSubmodules: new ArgumentMetadata({
+        type: 'boolean', 
+        description: 'if starter theme should be imported as submodule'
+      }),
     }
-  };
+  }
 
   static describe() {
     const importableThemes = ThemeManager.getKnownThemes();

--- a/src/commands/init/initcommand.ts
+++ b/src/commands/init/initcommand.ts
@@ -1,5 +1,5 @@
 import { RepositorySettings, RepositoryScaffolder } from './repositoryscaffolder';
-import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import ThemeManager from '../../utils/thememanager';
 import Command from '../../models/commands/command';
 
@@ -17,17 +17,17 @@ const InitCommand : Command = class {
 
   static args() {
     return {
-      themeUrl: new ArgumentMetadata({
+      themeUrl: new ArgumentMetadataImpl({
         type: 'string',
         description: 'url of a theme\'s git repo to import during the init',
       }),
-      theme: new ArgumentMetadata({
+      theme: new ArgumentMetadataImpl({
         type: 'string',
         description: '(deprecated: specify the themeUrl instead)'
           + ' the name of a theme to import during the init',
         isRequired: false
       }),
-      useSubmodules: new ArgumentMetadata({
+      useSubmodules: new ArgumentMetadataImpl({
         type: 'boolean', 
         description: 'if starter theme should be imported as submodule'
       }),
@@ -56,10 +56,9 @@ const InitCommand : Command = class {
     }
   }
 
-  async execute(args: Record<string, any>) {
-    const repositorySettings = new RepositorySettings(args);
+  async execute(args: RepositorySettings) {
     const repositoryScaffolder = new RepositoryScaffolder();
-    await repositoryScaffolder.create(repositorySettings);
+    await repositoryScaffolder.create(args);
   }
 }
 

--- a/src/commands/init/initcommand.ts
+++ b/src/commands/init/initcommand.ts
@@ -23,11 +23,12 @@ const args = {
   }
 } as const;
 type Args = typeof args;
+type ExecArgs = ArgsForExecute<Args>;
 
 /**
  * InitCommand initializes the current directory as a Jambo repository.
  */
-const InitCommand : Command<Args> = class {
+const InitCommand : Command<Args, ExecArgs> = class {
   static getAlias() {
     return 'init';
   }

--- a/src/commands/init/initcommand.ts
+++ b/src/commands/init/initcommand.ts
@@ -1,6 +1,6 @@
 import { RepositorySettings, RepositoryScaffolder } from './repositoryscaffolder';
 import ThemeManager from '../../utils/thememanager';
-import Command, { ArgsForExecute } from '../../models/commands/command';
+import Command from '../../models/commands/command';
 
 const args = {
   themeUrl: {
@@ -17,6 +17,10 @@ const args = {
     type: 'boolean', 
     description: 'if starter theme should be imported as submodule'
   },
+  includeTranslations: {
+    type: 'boolean', 
+    description: 'if a translations directory should be included'
+  }
 } as const;
 type Args = typeof args;
 
@@ -53,12 +57,16 @@ const InitCommand : Command<Args> = class {
         useSubmodules: {
           displayName: 'Use Submodules',
           type: 'boolean'
-        }
+        },
+        includeTranslations: {
+          displayName: 'Include Translations',
+          type: 'boolean'
+        },
       }
     }
   }
 
-  async execute(args: ArgsForExecute<Args> & RepositorySettings) {
+  async execute(args: RepositorySettings) {
     const repositoryScaffolder = new RepositoryScaffolder();
     await repositoryScaffolder.create(args);
   }

--- a/src/commands/init/initcommand.ts
+++ b/src/commands/init/initcommand.ts
@@ -1,37 +1,30 @@
 import { RepositorySettings, RepositoryScaffolder } from './repositoryscaffolder';
 import { ArgumentMetadata, ArgumentType } from '../../models/commands/argumentmetadata';
 import ThemeManager from '../../utils/thememanager';
+import Command from '../../models/commands/command';
 
 /**
  * InitCommand initializes the current directory as a Jambo repository.
  */
-export default class InitCommand {
-  static getAlias() {
-    return 'init';
-  }
-
-  static getShortDescription() {
-    return 'initialize the repository';
-  }
-
-  static args() {
-    return {
-      themeUrl: new ArgumentMetadata({
-        type: ArgumentType.STRING,
-        description: 'url of a theme\'s git repo to import during the init',
-      }),
-      theme: new ArgumentMetadata({
-        type: ArgumentType.STRING,
-        description: '(deprecated: specify the themeUrl instead)'
-          + ' the name of a theme to import during the init',
-        isRequired: false
-      }),
-      useSubmodules: new ArgumentMetadata({
-        type: ArgumentType.BOOLEAN, 
-        description: 'if starter theme should be imported as submodule'
-      }),
+const InitCommand : Command = class {
+  static alias = 'init';
+  static shortDescription = 'initialize the repository';
+  static args: Record<string, ArgumentMetadata> = {
+    themeUrl: {
+      type: ArgumentType.STRING,
+      description: 'url of a theme\'s git repo to import during the init',
+    },
+    theme: {
+      type: ArgumentType.STRING,
+      description: '(deprecated: specify the themeUrl instead)'
+        + ' the name of a theme to import during the init',
+      isRequired: false
+    },
+    useSubmodules: {
+      type: ArgumentType.BOOLEAN, 
+      description: 'if starter theme should be imported as submodule'
     }
-  }
+  };
 
   static describe() {
     const importableThemes = ThemeManager.getKnownThemes();
@@ -55,9 +48,11 @@ export default class InitCommand {
     }
   }
 
-  async execute(args) {
+  async execute(args: Record<string, any>) {
     const repositorySettings = new RepositorySettings(args);
     const repositoryScaffolder = new RepositoryScaffolder();
     await repositoryScaffolder.create(repositorySettings);
   }
 }
+
+export default InitCommand;

--- a/src/commands/init/repositoryscaffolder.ts
+++ b/src/commands/init/repositoryscaffolder.ts
@@ -11,34 +11,11 @@ const git = simpleGit();
  * repository. Currently, these settings include an optional themeUrl, theme name, and
  * whether or not the theme should be imported as a submodule.
  */
-export class RepositorySettings {
-  _themeUrl: string
-  _theme: string
-  _useSubmodules: boolean
-  _includeTranslations: boolean
-
-  constructor({ themeUrl, theme, useSubmodules, includeTranslations }: Record<string, any>) {
-    this._themeUrl = themeUrl;
-    this._theme = theme;
-    this._useSubmodules = useSubmodules;
-    this._includeTranslations = includeTranslations;
-  }
-
-  getThemeUrl() {
-    return this._themeUrl;
-  }
-
-  getTheme() {
-    return this._theme;
-  }
-
-  shouldUseSubmodules() {
-    return this._useSubmodules;
-  }
-
-  shouldIncludeTranslations() {
-    return this._includeTranslations;
-  }
+export interface RepositorySettings {
+  themeUrl: string
+  theme: string
+  useSubmodules: boolean
+  includeTranslations: boolean
 }
 
 export class RepositoryScaffolder {
@@ -48,9 +25,9 @@ export class RepositoryScaffolder {
    * Git infrastructure needed for source control. If a theme is specified, that will 
    * also be imported.
    *
-   * @param {RepositoryScaffolder} repositorySettings The settings for the new repository.
+   * @param {RepositorySettings} repositorySettings The settings for the new repository.
    */
-  async create(repositorySettings: any) {
+  async create(repositorySettings: RepositorySettings) {
     try {
       const cwd = process.cwd();
       await git.cwd(cwd);
@@ -58,18 +35,18 @@ export class RepositoryScaffolder {
       fs.writeFileSync('.gitignore', 'public/\nnode_modules/\n');
 
       const includeTranslations = 
-        repositorySettings.shouldIncludeTranslations();
+        repositorySettings.includeTranslations;
       this._createDirectorySkeleton(includeTranslations);
       const jamboConfig = this._createJamboConfig(includeTranslations);
 
-      const themeUrl = repositorySettings.getThemeUrl();
-      const theme = repositorySettings.getTheme();
+      const themeUrl = repositorySettings.themeUrl;
+      const theme = repositorySettings.theme;
       if (themeUrl || theme) {
         const themeImporter = new ThemeImporter(jamboConfig);
         await themeImporter.execute({
           themeUrl,
           theme, 
-          useSubmodules: repositorySettings.shouldUseSubmodules()
+          useSubmodules: repositorySettings.useSubmodules
         });
       }
     } catch (err) {

--- a/src/commands/init/repositoryscaffolder.ts
+++ b/src/commands/init/repositoryscaffolder.ts
@@ -17,7 +17,7 @@ export class RepositorySettings {
   _useSubmodules: boolean
   _includeTranslations: boolean
 
-  constructor({ themeUrl, theme, useSubmodules, includeTranslations }) {
+  constructor({ themeUrl, theme, useSubmodules, includeTranslations }: Record<string, any>) {
     this._themeUrl = themeUrl;
     this._theme = theme;
     this._useSubmodules = useSubmodules;
@@ -66,10 +66,11 @@ export class RepositoryScaffolder {
       const theme = repositorySettings.getTheme();
       if (themeUrl || theme) {
         const themeImporter = new ThemeImporter(jamboConfig);
-        await themeImporter.import(
+        await themeImporter.execute({
           themeUrl,
           theme, 
-          repositorySettings.shouldUseSubmodules());
+          useSubmodules: repositorySettings.shouldUseSubmodules()
+        });
       }
     } catch (err) {
       throw new SystemError(err.message, err.stack);

--- a/src/commands/override/overridecommand.ts
+++ b/src/commands/override/overridecommand.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import fileSystem from 'file-system';
 import { ShadowConfiguration, ThemeShadower } from './themeshadower';
-import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import { JamboConfig } from '../../models/JamboConfig';
 import Command from '../../models/commands/command';
 
@@ -28,7 +28,7 @@ const OverrideCommand : Command = class {
 
   static args() {
     return{
-      path: new ArgumentMetadata({
+      path: new ArgumentMetadataImpl({
         type: 'string',
         description: 'path in the theme to override',
         isRequired: true

--- a/src/commands/override/overridecommand.ts
+++ b/src/commands/override/overridecommand.ts
@@ -13,11 +13,12 @@ const args = {
   }
 } as const;
 type Args = typeof args;
+type ExecArgs = ArgsForExecute<Args>;
 
 /**
  * OverrideCommand overrides a specific file in the theme.
  */
-const OverrideCommand : Command<Args> = class {
+const OverrideCommand : Command<Args, ExecArgs> = class {
   jamboConfig: JamboConfig;
   defaultTheme: string;
 
@@ -75,7 +76,7 @@ const OverrideCommand : Command<Args> = class {
     return themeFiles;
   }
 
-  execute(args: ArgsForExecute<Args>) {
+  execute(args: ExecArgs) {
     const shadowConfiguration = new ShadowConfiguration(
       { ...args, theme: this.defaultTheme });
     const themeShadower = new ThemeShadower(this.jamboConfig);

--- a/src/commands/override/overridecommand.ts
+++ b/src/commands/override/overridecommand.ts
@@ -4,35 +4,27 @@ import fileSystem from 'file-system';
 import { ShadowConfiguration, ThemeShadower } from './themeshadower';
 import { ArgumentMetadata, ArgumentType } from '../../models/commands/argumentmetadata';
 import { JamboConfig } from '../../models/JamboConfig';
+import Command from '../../models/commands/command';
 
 /**
  * OverrideCommand overrides a specific file in the theme.
  */
-class OverrideCommand {
-  jamboConfig: JamboConfig
-  defaultTheme: string
+const OverrideCommand : Command = class {
+  jamboConfig: JamboConfig;
+  defaultTheme: string;
+  static alias = 'override';
+  static shortDescription = 'override a path within the theme';
+  static args: Record<string, ArgumentMetadata> = {
+    path: {
+      type: ArgumentType.STRING,
+      description: 'path in the theme to override',
+      isRequired: true
+    }
+  };
 
   constructor(jamboConfig: JamboConfig = {}) {
     this.jamboConfig = jamboConfig;
     this.defaultTheme = jamboConfig.defaultTheme;
-  }
-
-  static getAlias() {
-    return 'override';
-  }
-
-  static getShortDescription() {
-    return 'override a path within the theme';
-  }
-
-  static args() {
-    return{
-      path: new ArgumentMetadata({
-        type: ArgumentType.STRING,
-        description: 'path in the theme to override',
-        isRequired: true
-      })
-    }
   }
 
   static describe(jamboConfig) {
@@ -72,7 +64,7 @@ class OverrideCommand {
     return themeFiles;
   }
 
-  execute(args) {
+  execute(args: Record<string, any>) {
     const shadowConfiguration = new ShadowConfiguration(
       { ...args, theme: this.defaultTheme });
     const themeShadower = new ThemeShadower(this.jamboConfig);

--- a/src/commands/override/overridecommand.ts
+++ b/src/commands/override/overridecommand.ts
@@ -35,13 +35,7 @@ const OverrideCommand : Command<Args> = class {
   }
 
   static args() {
-    return {
-      path: {
-        type: 'string',
-        description: 'path in the theme to override',
-        isRequired: true
-      }
-    } as const
+    return args;
   }
 
   static describe(jamboConfig) {

--- a/src/commands/override/overridecommand.ts
+++ b/src/commands/override/overridecommand.ts
@@ -2,14 +2,22 @@ import fs from 'fs';
 import path from 'path';
 import fileSystem from 'file-system';
 import { ShadowConfiguration, ThemeShadower } from './themeshadower';
-import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import { JamboConfig } from '../../models/JamboConfig';
-import Command from '../../models/commands/command';
+import Command, { ArgsForExecute } from '../../models/commands/command';
+
+const args = {
+  path: {
+    type: 'string',
+    description: 'path in the theme to override',
+    isRequired: true
+  }
+} as const;
+type Args = typeof args;
 
 /**
  * OverrideCommand overrides a specific file in the theme.
  */
-const OverrideCommand : Command = class {
+const OverrideCommand : Command<Args> = class {
   jamboConfig: JamboConfig;
   defaultTheme: string;
 
@@ -27,13 +35,13 @@ const OverrideCommand : Command = class {
   }
 
   static args() {
-    return{
-      path: new ArgumentMetadataImpl({
+    return {
+      path: {
         type: 'string',
         description: 'path in the theme to override',
         isRequired: true
-      })
-    }
+      }
+    } as const
   }
 
   static describe(jamboConfig) {
@@ -73,7 +81,7 @@ const OverrideCommand : Command = class {
     return themeFiles;
   }
 
-  execute(args: Record<string, any>) {
+  execute(args: ArgsForExecute<Args>) {
     const shadowConfiguration = new ShadowConfiguration(
       { ...args, theme: this.defaultTheme });
     const themeShadower = new ThemeShadower(this.jamboConfig);

--- a/src/commands/override/overridecommand.ts
+++ b/src/commands/override/overridecommand.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import fileSystem from 'file-system';
 import { ShadowConfiguration, ThemeShadower } from './themeshadower';
-import { ArgumentMetadata, ArgumentType } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
 import { JamboConfig } from '../../models/JamboConfig';
 import Command from '../../models/commands/command';
 
@@ -12,19 +12,28 @@ import Command from '../../models/commands/command';
 const OverrideCommand : Command = class {
   jamboConfig: JamboConfig;
   defaultTheme: string;
-  static alias = 'override';
-  static shortDescription = 'override a path within the theme';
-  static args: Record<string, ArgumentMetadata> = {
-    path: {
-      type: ArgumentType.STRING,
-      description: 'path in the theme to override',
-      isRequired: true
-    }
-  };
 
   constructor(jamboConfig: JamboConfig = {}) {
     this.jamboConfig = jamboConfig;
     this.defaultTheme = jamboConfig.defaultTheme;
+  }
+
+  static getAlias() {
+    return 'override';
+  }
+
+  static getShortDescription() {
+    return 'override a path within the theme';
+  }
+
+  static args() {
+    return{
+      path: new ArgumentMetadata({
+        type: 'string',
+        description: 'path in the theme to override',
+        isRequired: true
+      })
+    }
   }
 
   static describe(jamboConfig) {

--- a/src/commands/override/themeshadower.ts
+++ b/src/commands/override/themeshadower.ts
@@ -9,8 +9,8 @@ import { JamboConfig } from '../../models/JamboConfig';
  * indicates which file(s) in the Theme should have local shadows.
  */
 export class ShadowConfiguration {
-  _theme: string
-  _path: string
+  private _theme: string
+  private _path: string
 
   constructor({ theme, path }: any) {
     if (!theme || !path) {

--- a/src/commands/page/add/pagecommand.ts
+++ b/src/commands/page/add/pagecommand.ts
@@ -6,48 +6,39 @@ import UserError from '../../../errors/usererror';
 import { ArgumentMetadata, ArgumentType } from '../../../models/commands/argumentmetadata';
 import { JamboConfig } from '../../../models/JamboConfig';
 import PageScaffolder from './pagescaffolder';
+import Command from '../../../models/commands/command';
 
 /**
  * PageCommand registers a new page with the specified name to be built by Jambo.
  */
-class PageCommand {
-  jamboConfig: JamboConfig
-  defaultTheme: string
-  pageScaffolder: PageScaffolder
+const PageCommand : Command = class {
+  jamboConfig: JamboConfig;
+  defaultTheme: string;
+  pageScaffolder: PageScaffolder;
+  static alias =  'page';
+  static shortDescription = 'add a new page to the site';
+  static args: Record<string, ArgumentMetadata> = {
+    name: {
+      type: ArgumentType.STRING,
+      description: 'name for the new files',
+      isRequired: true
+    },
+    template: {
+      type: ArgumentType.STRING,
+      description: 'template to use within theme',
+      isRequired: false
+    },
+    locales: {
+      type: ArgumentType.ARRAY,
+      description: 'additional locales to generate the page for',
+      isRequired: false
+    }
+  };
 
   constructor(jamboConfig: JamboConfig = {}, pageScaffolder) {
     this.jamboConfig = jamboConfig;
     this.defaultTheme = jamboConfig?.defaultTheme;
     this.pageScaffolder = pageScaffolder;
-  }
-
-  static getAlias() {
-    return 'page';
-  }
-
-  static getShortDescription() {
-    return 'add a new page to the site';
-  }
-
-  static args() {
-    return {
-      name: new ArgumentMetadata({
-        type: ArgumentType.STRING,
-        description: 'name for the new files',
-        isRequired: true
-      }),
-      template: new ArgumentMetadata({
-        type: ArgumentType.STRING,
-        description: 'template to use within theme',
-        isRequired: false
-      }),
-      locales: new ArgumentMetadata({
-        type: ArgumentType.ARRAY,
-        itemType: ArgumentType.STRING,
-        description: 'additional locales to generate the page for',
-        isRequired: false
-      })
-    }
   }
 
   static describe(jamboConfig) {
@@ -127,7 +118,7 @@ class PageCommand {
     return pageLocales;
   }
 
-  execute(args) {
+  execute(args: Record<string, any>) {
     const pageConfiguration = new PageConfiguration(
       { ...args, theme: this.defaultTheme });
     try {

--- a/src/commands/page/add/pagecommand.ts
+++ b/src/commands/page/add/pagecommand.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { parse } from 'comment-json';
 import PageConfiguration from './pageconfiguration';
 import UserError from '../../../errors/usererror';
-import { ArgumentMetadata, ArgumentType } from '../../../models/commands/argumentmetadata';
+import { ArgumentMetadata } from '../../../models/commands/argumentmetadata';
 import { JamboConfig } from '../../../models/JamboConfig';
 import PageScaffolder from './pagescaffolder';
 import Command from '../../../models/commands/command';
@@ -15,30 +15,40 @@ const PageCommand : Command = class {
   jamboConfig: JamboConfig;
   defaultTheme: string;
   pageScaffolder: PageScaffolder;
-  static alias =  'page';
-  static shortDescription = 'add a new page to the site';
-  static args: Record<string, ArgumentMetadata> = {
-    name: {
-      type: ArgumentType.STRING,
-      description: 'name for the new files',
-      isRequired: true
-    },
-    template: {
-      type: ArgumentType.STRING,
-      description: 'template to use within theme',
-      isRequired: false
-    },
-    locales: {
-      type: ArgumentType.ARRAY,
-      description: 'additional locales to generate the page for',
-      isRequired: false
-    }
-  };
 
   constructor(jamboConfig: JamboConfig = {}, pageScaffolder) {
     this.jamboConfig = jamboConfig;
     this.defaultTheme = jamboConfig?.defaultTheme;
     this.pageScaffolder = pageScaffolder;
+  }
+
+  static getAlias() {
+    return 'page';
+  }
+
+  static getShortDescription() {
+    return 'add a new page to the site';
+  }
+
+  static args() {
+    return {
+      name: new ArgumentMetadata({
+        type: 'string',
+        description: 'name for the new files',
+        isRequired: true
+      }),
+      template: new ArgumentMetadata({
+        type: 'string',
+        description: 'template to use within theme',
+        isRequired: false
+      }),
+      locales: new ArgumentMetadata({
+        type: 'array',
+        itemType: 'string',
+        description: 'additional locales to generate the page for',
+        isRequired: false
+      })
+    }
   }
 
   static describe(jamboConfig) {

--- a/src/commands/page/add/pagecommand.ts
+++ b/src/commands/page/add/pagecommand.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 import { parse } from 'comment-json';
-import PageConfiguration from './pageconfiguration';
 import UserError from '../../../errors/usererror';
 import { JamboConfig } from '../../../models/JamboConfig';
 import PageScaffolder from './pagescaffolder';
@@ -130,7 +129,7 @@ const PageCommand : Command<Args> = class {
     return pageLocales;
   }
 
-  execute(args: ArgsForExecute<Args> & PageConfiguration) {
+  execute(args: ArgsForExecute<Args>) {
     const pageConfiguration = { ...args, theme: this.defaultTheme };
     try {
       this.pageScaffolder.create(pageConfiguration);

--- a/src/commands/page/add/pagecommand.ts
+++ b/src/commands/page/add/pagecommand.ts
@@ -25,11 +25,12 @@ const args = {
   }
 } as const;
 type Args = typeof args;
+type ExecArgs = ArgsForExecute<Args>;
 
 /**
  * PageCommand registers a new page with the specified name to be built by Jambo.
  */
-const PageCommand : Command<Args> = class {
+const PageCommand : Command<Args, ExecArgs> = class {
   jamboConfig: JamboConfig;
   defaultTheme: string;
   pageScaffolder: PageScaffolder;
@@ -129,7 +130,7 @@ const PageCommand : Command<Args> = class {
     return pageLocales;
   }
 
-  execute(args: ArgsForExecute<Args>) {
+  execute(args: ExecArgs) {
     const pageConfiguration = { ...args, theme: this.defaultTheme };
     try {
       this.pageScaffolder.create(pageConfiguration);

--- a/src/commands/page/add/pageconfiguration.ts
+++ b/src/commands/page/add/pageconfiguration.ts
@@ -2,40 +2,11 @@
  * PageConfiguration contains all of the configuration information
  * needed to create a new page in a Jambo repository.
  */
-class PageConfiguration {
-  _name: string
-  _layout: string
-  _theme: string
-  _template: string
-  _locales: string[]
-  
-constructor({ name, layout, theme, template, locales }: any) {
-    this._name = name;
-    this._layout = layout;
-    this._theme = theme;
-    this._template = template;
-    this._locales = locales;
-  }
 
-  getName() {
-    return this._name;
-  }
-
-  getLayout() {
-    return this._layout;
-  }
-
-  getTheme() {
-    return this._theme;
-  }
-
-  getTemplate() {
-    return this._template;
-  }
-
-  getLocales() {
-    return this._locales;
-  }
+export default interface PageConfiguration {
+  name: string;
+  layout: string;
+  theme: string;
+  template: string;
+  locales: string[];
 }
-
-export default PageConfiguration;

--- a/src/commands/page/add/pageconfiguration.ts
+++ b/src/commands/page/add/pageconfiguration.ts
@@ -5,7 +5,6 @@
 
 export default interface PageConfiguration {
   name: string;
-  layout: string;
   theme: string;
   template: string;
   locales: string[];

--- a/src/commands/page/add/pagescaffolder.ts
+++ b/src/commands/page/add/pagescaffolder.ts
@@ -1,6 +1,7 @@
 import fs from 'file-system';
 import { parse, stringify, assign } from 'comment-json';
 import { JamboConfig } from '../../../models/JamboConfig';
+import PageConfiguration from './pageconfiguration';
 
 class PageScaffolder {
   config: JamboConfig
@@ -9,12 +10,12 @@ class PageScaffolder {
     this.config = jamboConfig;
   }
 
-  create(pageConfiguration) {
-    const name = pageConfiguration.getName();
-    const theme = pageConfiguration.getTheme();
-    const template = pageConfiguration.getTemplate();
-    const layout = pageConfiguration.getLayout();
-    const locales = pageConfiguration.getLocales();
+  create(pageConfiguration: PageConfiguration) {
+    const name = pageConfiguration.name;
+    const theme = pageConfiguration.theme;
+    const template = pageConfiguration.template;
+    const layout = pageConfiguration.layout;
+    const locales = pageConfiguration.locales;
 
     const htmlFilePath = `${this.config.dirs.pages}/${name}.html.hbs`;
     const configFilePath = `${this.config.dirs.config}/${name}.json`;

--- a/src/commands/page/add/pagescaffolder.ts
+++ b/src/commands/page/add/pagescaffolder.ts
@@ -1,5 +1,5 @@
 import fs from 'file-system';
-import { parse, stringify, assign } from 'comment-json';
+import { parse, stringify } from 'comment-json';
 import { JamboConfig } from '../../../models/JamboConfig';
 import PageConfiguration from './pageconfiguration';
 
@@ -14,21 +14,18 @@ class PageScaffolder {
     const name = pageConfiguration.name;
     const theme = pageConfiguration.theme;
     const template = pageConfiguration.template;
-    const layout = pageConfiguration.layout;
     const locales = pageConfiguration.locales;
 
     const htmlFilePath = `${this.config.dirs.pages}/${name}.html.hbs`;
     const configFilePath = `${this.config.dirs.config}/${name}.json`;
 
-    let configContents = layout ? { layout } : {};
+    let configContents = {};
     if (theme && template) {
       const rootTemplatePath = 
         `${this.config.dirs.themes}/${theme}/templates/${template}`;
       fs.copyFileSync(`${rootTemplatePath}/page.html.hbs`, htmlFilePath);
 
-      configContents = assign(
-        parse(fs.readFileSync(`${rootTemplatePath}/page-config.json`, 'utf8')),
-        configContents);
+      configContents = parse(fs.readFileSync(`${rootTemplatePath}/page-config.json`, 'utf8'));
     } else {
       fs.writeFileSync(htmlFilePath, '');
     }

--- a/src/commands/upgrade/themeupgrader.ts
+++ b/src/commands/upgrade/themeupgrader.ts
@@ -12,6 +12,7 @@ import { searchDirectoryIgnoringExtensions } from '../../utils/fileutils';
 import fsExtra from 'fs-extra';
 import { info } from '../../utils/logger';
 import { JamboConfig } from '../../models/JamboConfig';
+import Command from '../../models/commands/command';
 
 const git = simpleGit();
 
@@ -20,44 +21,35 @@ const git = simpleGit();
  * version. It first detects whether the theme was imported as a submodule or raw files,
  * then handles the upgrade accordingly.
  */
-export default class ThemeUpgrader {
-  jamboConfig: JamboConfig
-  _themesDir: string
-  postUpgradeFileName: 'upgrade'
-
+const ThemeUpgrader : Command = class {
+  jamboConfig: JamboConfig;
+  _themesDir: string;
+  postUpgradeFileName: 'upgrade';
+  static alias = 'upgrade';
+  static shortDescription = 'upgrade the default theme to the latest version';
+  static args: Record<string, ArgumentMetadata> = {
+    disableScript:{
+      type: ArgumentType.BOOLEAN,
+      description: 'disable execution of ./upgrade.js after the upgrade is done',
+      isRequired: false
+    },
+    isLegacy: {
+      type: ArgumentType.BOOLEAN,
+      description: 'whether to pass the --isLegacy flag to ./upgrade.js',
+      isRequired: false
+    },
+    branch: {
+      type: ArgumentType.STRING,
+      description: 'the branch of the theme to upgrade to',
+      isRequired: false,
+      defaultValue: 'master'
+    }
+  };
+  
   constructor(jamboConfig: JamboConfig = {}) {
     this.jamboConfig = jamboConfig;
     this._themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
     this.postUpgradeFileName = 'upgrade';
-  }
-
-  static getAlias() {
-    return 'upgrade';
-  }
-
-  static getShortDescription() {
-    return 'upgrade the default theme to the latest version';
-  }
-
-  static args() {
-    return {
-      disableScript: new ArgumentMetadata({
-        type: ArgumentType.BOOLEAN,
-        description: 'disable execution of ./upgrade.js after the upgrade is done',
-        isRequired: false
-      }),
-      isLegacy: new ArgumentMetadata({
-        type: ArgumentType.BOOLEAN,
-        description: 'whether to pass the --isLegacy flag to ./upgrade.js',
-        isRequired: false
-      }),
-      branch: new ArgumentMetadata({
-        type: ArgumentType.STRING,
-        description: 'the branch of the theme to upgrade to',
-        isRequired: false,
-        defaultValue: 'master'
-      })
-    }
   }
 
   static async describe() {
@@ -81,7 +73,7 @@ export default class ThemeUpgrader {
     }
   }
 
-  async execute(args) {
+  async execute(args: Record<string, any>) {
     await this._upgrade({
       themeName: this.jamboConfig.defaultTheme,
       disableScript: args.disableScript,
@@ -203,3 +195,5 @@ export default class ThemeUpgrader {
       .find(p => p === submodulePath)
   }
 }
+
+export default ThemeUpgrader;

--- a/src/commands/upgrade/themeupgrader.ts
+++ b/src/commands/upgrade/themeupgrader.ts
@@ -33,13 +33,14 @@ const args = {
   }
 } as const;
 type Args = typeof args;
+type ExecArgs = ArgsForExecute<Args>;
 
 /**
  * ThemeUpgrader is responsible for upgrading the current defaultTheme to the latest
  * version. It first detects whether the theme was imported as a submodule or raw files,
  * then handles the upgrade accordingly.
  */
-const ThemeUpgrader : Command<Args> = class {
+const ThemeUpgrader : Command<Args, ExecArgs> = class {
   jamboConfig: JamboConfig;
   private _themesDir: string;
   postUpgradeFileName: 'upgrade';
@@ -83,7 +84,7 @@ const ThemeUpgrader : Command<Args> = class {
     }
   }
 
-  async execute(args: ArgsForExecute<Args>) {
+  async execute(args: ExecArgs) {
     await this._upgrade({
       themeName: this.jamboConfig.defaultTheme,
       disableScript: args.disableScript,

--- a/src/commands/upgrade/themeupgrader.ts
+++ b/src/commands/upgrade/themeupgrader.ts
@@ -4,7 +4,7 @@ import simpleGit from 'simple-git/promise';
 import ThemeManager from '../../utils/thememanager';
 import { CustomCommand } from '../../utils/customcommands/command';
 import { CustomCommandExecuter } from '../../utils/customcommands/commandexecuter';
-import { ArgumentMetadata, ArgumentType } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
 import SystemError from '../../errors/systemerror';
 import UserError from '../../errors/systemerror';
 import { isCustomError } from '../../utils/errorutils';
@@ -25,31 +25,40 @@ const ThemeUpgrader : Command = class {
   jamboConfig: JamboConfig;
   _themesDir: string;
   postUpgradeFileName: 'upgrade';
-  static alias = 'upgrade';
-  static shortDescription = 'upgrade the default theme to the latest version';
-  static args: Record<string, ArgumentMetadata> = {
-    disableScript:{
-      type: ArgumentType.BOOLEAN,
-      description: 'disable execution of ./upgrade.js after the upgrade is done',
-      isRequired: false
-    },
-    isLegacy: {
-      type: ArgumentType.BOOLEAN,
-      description: 'whether to pass the --isLegacy flag to ./upgrade.js',
-      isRequired: false
-    },
-    branch: {
-      type: ArgumentType.STRING,
-      description: 'the branch of the theme to upgrade to',
-      isRequired: false,
-      defaultValue: 'master'
-    }
-  };
-  
+
   constructor(jamboConfig: JamboConfig = {}) {
     this.jamboConfig = jamboConfig;
     this._themesDir = jamboConfig.dirs && jamboConfig.dirs.themes;
     this.postUpgradeFileName = 'upgrade';
+  }
+
+  static getAlias() {
+    return 'upgrade';
+  }
+
+  static getShortDescription() {
+    return 'upgrade the default theme to the latest version';
+  }
+
+  static args() {
+    return {
+      disableScript: new ArgumentMetadata({
+        type: 'boolean',
+        description: 'disable execution of ./upgrade.js after the upgrade is done',
+        isRequired: false
+      }),
+      isLegacy: new ArgumentMetadata({
+        type: 'boolean',
+        description: 'whether to pass the --isLegacy flag to ./upgrade.js',
+        isRequired: false
+      }),
+      branch: new ArgumentMetadata({
+        type: 'string',
+        description: 'the branch of the theme to upgrade to',
+        isRequired: false,
+        defaultValue: 'master'
+      })
+    }
   }
 
   static async describe() {

--- a/src/commands/upgrade/themeupgrader.ts
+++ b/src/commands/upgrade/themeupgrader.ts
@@ -4,7 +4,7 @@ import simpleGit from 'simple-git/promise';
 import ThemeManager from '../../utils/thememanager';
 import { CustomCommand } from '../../utils/customcommands/command';
 import { CustomCommandExecuter } from '../../utils/customcommands/commandexecuter';
-import { ArgumentMetadata } from '../../models/commands/argumentmetadata';
+import { ArgumentMetadataImpl } from '../../models/commands/argumentmetadata';
 import SystemError from '../../errors/systemerror';
 import UserError from '../../errors/systemerror';
 import { isCustomError } from '../../utils/errorutils';
@@ -23,7 +23,7 @@ const git = simpleGit();
  */
 const ThemeUpgrader : Command = class {
   jamboConfig: JamboConfig;
-  _themesDir: string;
+  private _themesDir: string;
   postUpgradeFileName: 'upgrade';
 
   constructor(jamboConfig: JamboConfig = {}) {
@@ -42,17 +42,17 @@ const ThemeUpgrader : Command = class {
 
   static args() {
     return {
-      disableScript: new ArgumentMetadata({
+      disableScript: new ArgumentMetadataImpl({
         type: 'boolean',
         description: 'disable execution of ./upgrade.js after the upgrade is done',
         isRequired: false
       }),
-      isLegacy: new ArgumentMetadata({
+      isLegacy: new ArgumentMetadataImpl({
         type: 'boolean',
         description: 'whether to pass the --isLegacy flag to ./upgrade.js',
         isRequired: false
       }),
-      branch: new ArgumentMetadata({
+      branch: new ArgumentMetadataImpl({
         type: 'string',
         description: 'the branch of the theme to upgrade to',
         isRequired: false,

--- a/src/handlebars/handlebarspreprocessor.ts
+++ b/src/handlebars/handlebarspreprocessor.ts
@@ -8,7 +8,7 @@ import HbsHelperParser from './hbshelperparser';
  * used with Jambo.
  */
 export default class HandlebarsPreprocessor {
-  _invocationTranspiler: InvocationTranspiler
+  private _invocationTranspiler: InvocationTranspiler
 
   constructor(translator) {
     this._invocationTranspiler = new InvocationTranspiler(translator);

--- a/src/handlebars/invocationtranspiler.ts
+++ b/src/handlebars/invocationtranspiler.ts
@@ -8,7 +8,7 @@ import TranslateInvocation from './models/translateinvocation';
  * if possible, or a runtime translation helper if not.
  */
 class InvocationTranspiler {
-  _translator: Translator;
+  private _translator: Translator;
 
   constructor(translator) {
     /**

--- a/src/i18n/extractor/translationextractor.ts
+++ b/src/i18n/extractor/translationextractor.ts
@@ -12,8 +12,8 @@ import { error } from '../../utils/logger';
  * from a set of files and exports them to an output file.
  */
 class TranslationExtractor {
-  _extractor: GettextExtractor;
-  _options: Record<string, any>
+  private _extractor: GettextExtractor;
+  private _options: Record<string, any>
 
   constructor(options?: any) {
     this._options = {

--- a/src/i18n/translationfetchers/localfileparser.ts
+++ b/src/i18n/translationfetchers/localfileparser.ts
@@ -8,8 +8,8 @@ import UserError from '../../errors/usererror';
  * library is used to put the translations in i18next format.
  */
 class LocalFileParser {
-  _translationsDir: string;
-  _options: Record<string, unknown>
+  private _translationsDir: string;
+  private _options: Record<string, unknown>
 
   /**
    * Creates a new instance of {@link LocalFileParser}.

--- a/src/i18n/translator/translator.ts
+++ b/src/i18n/translator/translator.ts
@@ -7,7 +7,7 @@ import escapeRegExp from 'lodash/escapeRegExp';
  * pluralization, and added context.
  */
 class Translator {
-  _i18next: i18n;
+  private _i18next: i18n;
 
   /**
    * Creates a new {@link Translator} that wraps the provided {@link i18next} instance.

--- a/src/models/commands/argumentmetadata.ts
+++ b/src/models/commands/argumentmetadata.ts
@@ -1,12 +1,7 @@
 /**
- * An enum describing the different kinds of argument that are supported.
+ * defines the different kinds of argument that are supported.
  */
-enum ArgumentType {
-  STRING = 'string',
-  NUMBER = 'number',
-  BOOLEAN = 'boolean',
-  ARRAY = 'array'
-}
+type ArgumentType = 'string' | 'number' | 'boolean' | 'array';
 
 /**
  * An interface outlining the metadata for a {@link Command}'s argument. This includes
@@ -14,34 +9,76 @@ enum ArgumentType {
  */
 interface ArgumentMetadata {
   /**
-   * The display name for the argument.
+   * The type of the argument, e.g. STRING, BOOLEAN, etc.
    */
-  describeName?: string,
-  
+  getType(): ArgumentType
+
+  /**
+   * The type of the elements of an array argument.
+   */
+  getItemType(): string
+
   /**
    * The description of the argument.
    */
-  description: string,
-  
+  getDescription(): string
+
   /**
-   * The type of the argument, e.g. string, boolean, etc.
+   * A boolean indicating if the argument is required.
    */
-  type: ArgumentType,
-  
+  isRequired(): boolean
+
   /**
-   * indicate if the argument is required.
+   * Optional, a default value for the argument.
    */
-  isRequired?: boolean,
-  
+  defaultValue(): string|boolean|number
+
   /**
-   * a default value for the argument
+   * The display name for the argument.
    */
-  defaultValue?: string | number | boolean | (string|number|boolean)[]
-  
-  /**
-   * Used for the describe and eventually CLI auto-completion
-   */
-  options?: (string|number|boolean)[]
+  getDisplayName(): string
+}
+
+class ArgumentMetadata implements ArgumentMetadata {
+  _description: string
+  _type: string
+  _displayName: string
+  _itemType: string
+  _isRequired: boolean
+  _defaultValue: unknown
+
+  constructor({displayName, type, itemType, isRequired, defaultValue, description}: any) {
+    this._displayName = displayName;
+    this._type = type;
+    this._itemType = itemType;
+    this._isRequired = isRequired;
+    this._defaultValue = defaultValue;
+    this._description = description;
+  }
+
+  getType() {
+    return this._type;
+  }
+
+  getItemType() {
+    return this._itemType;
+  }
+
+  getDescription() {
+    return this._description
+  }
+
+  isRequired() {
+    return !!this._isRequired;
+  }
+
+  defaultValue() {
+    return this._defaultValue;
+  }
+
+  getDisplayName() {
+    return this._displayName;
+  }
 }
 
 export { ArgumentMetadata, ArgumentType };

--- a/src/models/commands/argumentmetadata.ts
+++ b/src/models/commands/argumentmetadata.ts
@@ -1,5 +1,5 @@
 /**
- * defines the different kinds of argument that are supported.
+ * Defines the different kinds of arguments that are supported.
  */
 export type ArgumentType = 'string' | 'number' | 'boolean' | 'array';
 
@@ -16,7 +16,7 @@ export interface ArgumentMetadata {
   /**
    * The type of the elements of an array argument.
    */
-  itemType?: string
+  itemType?: ArgumentType
 
   /**
    * The description of the argument.

--- a/src/models/commands/argumentmetadata.ts
+++ b/src/models/commands/argumentmetadata.ts
@@ -38,3 +38,8 @@ export interface ArgumentMetadata {
    */
   displayName?: string
 }
+
+/**
+ * Represents a record of argument names to metadata about that argument
+ */
+export type ArgumentMetadataRecord = Record<string, ArgumentMetadata>;

--- a/src/models/commands/argumentmetadata.ts
+++ b/src/models/commands/argumentmetadata.ts
@@ -7,90 +7,34 @@ export type ArgumentType = 'string' | 'number' | 'boolean' | 'array';
  * An interface outlining the metadata for a {@link Command}'s argument. This includes
  * the type of the argument's values, if it is required, and an optional default.
  */
-interface ArgumentMetadata {
+export interface ArgumentMetadata {
   /**
    * The type of the argument, e.g. STRING, BOOLEAN, etc.
    */
-  getType(): ArgumentType
+  type: ArgumentType
 
   /**
    * The type of the elements of an array argument.
    */
-  getItemType(): string
+  itemType?: string
 
   /**
    * The description of the argument.
    */
-  getDescription(): string
+  description: string
 
   /**
    * A boolean indicating if the argument is required.
    */
-  isRequired(): boolean
+  isRequired?: boolean
 
   /**
    * Optional, a default value for the argument.
    */
-  defaultValue(): string|boolean|number
+  defaultValue?: string|boolean|number
 
   /**
    * The display name for the argument.
    */
-  getDisplayName(): string
-
-  /**
-   * Returns an Object with the keys expected by the Jambo describe command
-   */
-  toDescribeFormat(): Record<string, any>
-}
-
-export class ArgumentMetadataImpl implements ArgumentMetadata {
-  private _description: string
-  private _type: ArgumentType
-  private _displayName: string
-  private _itemType: string
-  private _isRequired: boolean
-  private _defaultValue: string|boolean|number
-
-  constructor({displayName, type, itemType, isRequired, defaultValue, description}: any) {
-    this._displayName = displayName;
-    this._type = type;
-    this._itemType = itemType;
-    this._isRequired = isRequired;
-    this._defaultValue = defaultValue;
-    this._description = description;
-  }
-
-  getType() {
-    return this._type;
-  }
-
-  getItemType() {
-    return this._itemType;
-  }
-
-  getDescription() {
-    return this._description
-  }
-
-  isRequired() {
-    return !!this._isRequired;
-  }
-
-  defaultValue() {
-    return this._defaultValue;
-  }
-
-  getDisplayName() {
-    return this._displayName;
-  }
-
-  toDescribeFormat() {
-    return {
-      displayName: this.getDisplayName(),
-      type: this.getType(),
-      required: this.isRequired(),
-      default: this.defaultValue(),
-    };
-  }
+  displayName?: string
 }

--- a/src/models/commands/argumentmetadata.ts
+++ b/src/models/commands/argumentmetadata.ts
@@ -9,7 +9,7 @@ export type ArgumentType = 'string' | 'number' | 'boolean' | 'array';
  */
 export interface ArgumentMetadata {
   /**
-   * The type of the argument, e.g. STRING, BOOLEAN, etc.
+   * The type of the argument, e.g. 'string', 'boolean', etc.
    */
   type: ArgumentType
 

--- a/src/models/commands/argumentmetadata.ts
+++ b/src/models/commands/argumentmetadata.ts
@@ -1,7 +1,7 @@
 /**
  * defines the different kinds of argument that are supported.
  */
-type ArgumentType = 'string' | 'number' | 'boolean' | 'array';
+export type ArgumentType = 'string' | 'number' | 'boolean' | 'array';
 
 /**
  * An interface outlining the metadata for a {@link Command}'s argument. This includes
@@ -37,15 +37,20 @@ interface ArgumentMetadata {
    * The display name for the argument.
    */
   getDisplayName(): string
+
+  /**
+   * Returns an Object with the keys expected by the Jambo describe command
+   */
+  toDescribeFormat(): Record<string, any>
 }
 
-class ArgumentMetadata implements ArgumentMetadata {
-  _description: string
-  _type: string
-  _displayName: string
-  _itemType: string
-  _isRequired: boolean
-  _defaultValue: unknown
+export class ArgumentMetadataImpl implements ArgumentMetadata {
+  private _description: string
+  private _type: ArgumentType
+  private _displayName: string
+  private _itemType: string
+  private _isRequired: boolean
+  private _defaultValue: string|boolean|number
 
   constructor({displayName, type, itemType, isRequired, defaultValue, description}: any) {
     this._displayName = displayName;
@@ -79,6 +84,13 @@ class ArgumentMetadata implements ArgumentMetadata {
   getDisplayName() {
     return this._displayName;
   }
-}
 
-export { ArgumentMetadata, ArgumentType };
+  toDescribeFormat() {
+    return {
+      displayName: this.getDisplayName(),
+      type: this.getType(),
+      required: this.isRequired(),
+      default: this.defaultValue(),
+    };
+  }
+}

--- a/src/models/commands/argumentmetadata.ts
+++ b/src/models/commands/argumentmetadata.ts
@@ -1,89 +1,47 @@
 /**
  * An enum describing the different kinds of argument that are supported.
  */
-const ArgumentType = {
-  STRING: 'string',
-  NUMBER: 'number',
-  BOOLEAN: 'boolean',
-  ARRAY: 'array'
+enum ArgumentType {
+  STRING = 'string',
+  NUMBER = 'number',
+  BOOLEAN = 'boolean',
+  ARRAY = 'array'
 }
-Object.freeze(ArgumentType);
 
 /**
- * A class outlining the metadata for a {@link Command}'s argument. This includes
+ * An interface outlining the metadata for a {@link Command}'s argument. This includes
  * the type of the argument's values, if it is required, and an optional default.
  */
-class ArgumentMetadata {
-  _description: string
-  _type: string
-  _displayName: string
-  _itemType: string
-  _isRequired: boolean
-  _defaultValue: unknown
-
-  constructor({ type, itemType, description, isRequired, defaultValue, displayName }: any) {
-    this._displayName = displayName;
-    this._type = type;
-    this._itemType = itemType;
-    this._isRequired = isRequired;
-    this._defaultValue = defaultValue;
-    this._description = description;
-  }
-
+interface ArgumentMetadata {
   /**
-   * @returns {ArgumentType} The type of the argument, e.g. STRING, BOOLEAN, etc.
+   * The display name for the argument.
    */
-  getType() {
-    return this._type;
-  }
-
+  describeName?: string,
+  
   /**
-   * @returns {ItemType} The type of the elements of an array argument.
+   * The description of the argument.
    */
-  getItemType() {
-    return this._itemType;
-  }
-
+  description: string,
+  
   /**
-   * @returns {string} The description of the argument.
+   * The type of the argument, e.g. string, boolean, etc.
    */
-  getDescription() {
-    return this._description
-  }
-
+  type: ArgumentType,
+  
   /**
-   * @returns {boolean} A boolean indicating if the argument is required.
+   * indicate if the argument is required.
    */
-  isRequired() {
-    return !!this._isRequired;
-  }
-
+  isRequired?: boolean,
+  
   /**
-   * @returns {string|boolean|number} Optional, a default value for the argument.
+   * a default value for the argument
    */
-  defaultValue() {
-    return this._defaultValue;
-  }
-
+  defaultValue?: string | number | boolean | (string|number|boolean)[]
+  
   /**
-   * @returns {string} The display name for the argument.
+   * Used for the describe and eventually CLI auto-completion
    */
-  getDisplayName() {
-    return this._displayName;
-  }
-
-  /**
-   * Returns an Object with the keys expected by the Jambo describe command
-   *
-   * @returns {Object}
-   */
-  toDescribeFormat() {
-    return {
-      displayName: this.getDisplayName(),
-      type: this.getType(),
-      required: this.isRequired(),
-      default: this.defaultValue(),
-    };
-  }
+  options?: (string|number|boolean)[]
 }
+
 export { ArgumentMetadata, ArgumentType };

--- a/src/models/commands/argumentmetadatalegacy.ts
+++ b/src/models/commands/argumentmetadatalegacy.ts
@@ -1,0 +1,41 @@
+/**
+ * defines the different kinds of argument that are supported.
+ */
+ type ArgumentType = 'string' | 'number' | 'boolean' | 'array';
+
+ /**
+  * An interface describing the legacy version of {@link ArgumentMetadata}.
+  */
+ export interface ArgumentMetadataLegacy {
+   /**
+    * The type of the argument, e.g. STRING, BOOLEAN, etc.
+    */
+   getType(): ArgumentType
+ 
+   /**
+    * The type of the elements of an array argument.
+    */
+   getItemType(): string | undefined
+ 
+   /**
+    * The description of the argument.
+    */
+   getDescription(): string
+ 
+   /**
+    * A boolean indicating if the argument is required.
+    */
+   isRequired(): boolean | undefined
+ 
+   /**
+    * Optional, a default value for the argument.
+    */
+   defaultValue(): string | boolean | number | undefined
+ }
+
+ /**
+  * Returns true if the provided metadata object is the legacy model
+  */
+ export function isArgumentMetadataLegacy(metadata: any): metadata is ArgumentMetadataLegacy {
+  return metadata.getType !== undefined;
+ }

--- a/src/models/commands/argumentmetadatalegacy.ts
+++ b/src/models/commands/argumentmetadatalegacy.ts
@@ -8,7 +8,7 @@
   */
  export interface ArgumentMetadataLegacy {
    /**
-    * The type of the argument, e.g. STRING, BOOLEAN, etc.
+    * The type of the argument, e.g. 'string', 'boolean', etc.
     */
    getType(): ArgumentType
  

--- a/src/models/commands/argumentmetadatalegacy.ts
+++ b/src/models/commands/argumentmetadatalegacy.ts
@@ -1,10 +1,11 @@
 /**
- * defines the different kinds of argument that are supported.
+ * Defines the different kinds of arguments that are supported.
  */
  type ArgumentType = 'string' | 'number' | 'boolean' | 'array';
 
  /**
   * An interface describing the legacy version of {@link ArgumentMetadata}.
+  * @deprecated
   */
  export interface ArgumentMetadataLegacy {
    /**
@@ -15,7 +16,7 @@
    /**
     * The type of the elements of an array argument.
     */
-   getItemType(): string | undefined
+   getItemType(): ArgumentType | undefined
  
    /**
     * The description of the argument.

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { JamboConfig } from '../JamboConfig';
-import { ArgumentMetadata } from './argumentmetadata';
+import { ArgumentMetadataImpl } from './argumentmetadata';
 
 /**
  * Command interface that contains non static fields and methods
@@ -37,7 +37,7 @@ export default interface Command {
   /**
    * Descriptions of each argument, keyed by name.
    */
-   args(): Record<string, ArgumentMetadata>;
+   args(): Record<string, ArgumentMetadataImpl>;
 
   /**
    * @param {Object} jamboConfig the config of the jambo repository

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -20,24 +20,24 @@ interface CommandExecutable {
  * Contains non static (CommandExecutable interface) and 
  * static (specified in here) fields and methods.
  */
-interface Command {
+export default interface Command {
   new(...args: any[]):CommandExecutable;
 
   /**
    * The alias for the command.
    */
-  alias: string;
+  getAlias(): string;
   
   /**
    * A short, one sentence description of the command. This
    * description appears as part of the help text in the CLI. 
    */
-  shortDescription : string;
+   getShortDescription() : string;
 
   /**
    * Descriptions of each argument, keyed by name.
    */
-  args: Record<string, ArgumentMetadata>;
+   args(): Record<string, ArgumentMetadata>;
 
   /**
    * @param {Object} jamboConfig the config of the jambo repository
@@ -47,4 +47,3 @@ interface Command {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   describe(jamboConfig: JamboConfig): Promise<any> | any;
 }
-export default Command;

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -1,18 +1,37 @@
-/* eslint-disable @typescript-eslint/no-empty-function */
 import { JamboConfig } from '../JamboConfig';
-import { ArgumentMetadataImpl } from './argumentmetadata';
+import { ArgumentMetadata } from './argumentmetadata';
+
+type toPrim<T = never> = {
+  'string': string
+  'number': number
+  'boolean': boolean
+  'array': T[]
+}
+
+type Metadata = {
+  type: keyof toPrim,
+  itemType?: keyof toPrim
+}
+
+/**
+ * generate a type based on the arguments given to Jambo command
+ */
+export type ArgsForExecute<T extends Record<string, Metadata>> = {
+  [prop in keyof T]: toPrim<toPrim[T[prop]['itemType']]>[T[prop]['type']]
+}
 
 /**
  * Command interface that contains non static fields and methods
- * of a Command instance
+ * of a Command instance. It requires a type T that defines the
+ * arguments pass to execute()
  */
-interface CommandExecutable {
+interface CommandExecutable<T> {
   /**
    * Executes the command with the provided arguments.
    * 
    * @param {Object<string, any>} args The arguments, keyed by name.
    */
-  execute(args: Record<string, any>): any
+  execute(args?: ArgsForExecute<T & Record<string, Metadata>>): any
 }
 
 /**
@@ -20,8 +39,8 @@ interface CommandExecutable {
  * Contains non static (CommandExecutable interface) and 
  * static (specified in here) fields and methods.
  */
-export default interface Command {
-  new(...args: any[]):CommandExecutable;
+export default interface Command<T> {
+  new(...args: any[]):CommandExecutable<T>;
 
   /**
    * The alias for the command.
@@ -37,7 +56,7 @@ export default interface Command {
   /**
    * Descriptions of each argument, keyed by name.
    */
-   args(): Record<string, ArgumentMetadataImpl>;
+   args(): Record<string, ArgumentMetadata>;
 
   /**
    * @param {Object} jamboConfig the config of the jambo repository

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -1,5 +1,6 @@
 import { JamboConfig } from '../JamboConfig';
 import { ArgumentMetadata } from './argumentmetadata';
+import { CommandExecutable } from './commandexecutable';
 
 type toPrim<T = never> = {
   'string': string
@@ -8,30 +9,11 @@ type toPrim<T = never> = {
   'array': T[]
 }
 
-type Metadata = {
-  type: keyof toPrim,
-  itemType?: keyof toPrim
-}
-
 /**
  * generate a type based on the arguments given to Jambo command
  */
-export type ArgsForExecute<T extends Record<string, Metadata>> = {
+export type ArgsForExecute<T extends Record<string, ArgumentMetadata>> = {
   [prop in keyof T]: toPrim<toPrim[T[prop]['itemType']]>[T[prop]['type']]
-}
-
-/**
- * Command interface that contains non static fields and methods
- * of a Command instance. It requires a type T that defines the
- * arguments pass to execute()
- */
-interface CommandExecutable<T> {
-  /**
-   * Executes the command with the provided arguments.
-   * 
-   * @param {Object<string, any>} args The arguments, keyed by name.
-   */
-  execute(args?: ArgsForExecute<T & Record<string, Metadata>>): any
 }
 
 /**
@@ -39,8 +21,8 @@ interface CommandExecutable<T> {
  * Contains non static (CommandExecutable interface) and 
  * static (specified in here) fields and methods.
  */
-export default interface Command<T> {
-  new(...args: any[]):CommandExecutable<T>;
+export default interface Command<T extends Record<string, ArgumentMetadata>> {
+  new(...args: any[]):CommandExecutable<ArgsForExecute<T>>;
 
   /**
    * The alias for the command.
@@ -56,7 +38,7 @@ export default interface Command<T> {
   /**
    * Descriptions of each argument, keyed by name.
    */
-   args(): Record<string, ArgumentMetadata>;
+   args(): T;
 
   /**
    * @param {Object} jamboConfig the config of the jambo repository

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -44,5 +44,5 @@ export default interface Command {
    * @returns {Object} description of the card command, including paths to 
    *                   all available cards
    */
-  describe(jamboConfig: JamboConfig): Promise<any> | any;
+  describe(jamboConfig: JamboConfig): any;
 }

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -44,6 +44,5 @@ export default interface Command {
    * @returns {Object} description of the card command, including paths to 
    *                   all available cards
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   describe(jamboConfig: JamboConfig): Promise<any> | any;
 }

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -3,40 +3,41 @@ import { JamboConfig } from '../JamboConfig';
 import { ArgumentMetadata } from './argumentmetadata';
 
 /**
- * An interface that represents a command in the Jambo CLI. 
+ * Command interface that contains non static fields and methods
+ * of a Command instance
  */
-class Command {
-
-  /**
-   * @returns {string} The alias for the command.
-   */
-  static getAlias(): string { return ''; }
-
-  /**
-   * @returns {string} A short, one sentence description of the command. This
-   *                   description appears as part of the help text in the CLI. 
-   */
-  static getShortDescription(): string {
-    return '';
-  }
-
+interface CommandExecutable {
   /**
    * Executes the command with the provided arguments.
    * 
-   * @param {Object<string, unknown>} args The arguments, keyed by name.
+   * @param {Object<string, any>} args The arguments, keyed by name.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  execute(args: Record<string, unknown>): Record<string, unknown> {
-    return {};
-  }
+  execute(args: Record<string, any>): any
+}
+
+/**
+ * An interface that represents a command in the Jambo CLI. 
+ * Contains non static (CommandExecutable interface) and 
+ * static (specified in here) fields and methods.
+ */
+interface Command {
+  new(...args: any[]):CommandExecutable;
 
   /**
-   * @returns {Object<string, ArgumentMetadata>} Descriptions of each argument,
-   *                                             keyed by name.
+   * The alias for the command.
    */
-  static args(): Record<string, ArgumentMetadata>{
-    return {};
-  }
+  alias: string;
+  
+  /**
+   * A short, one sentence description of the command. This
+   * description appears as part of the help text in the CLI. 
+   */
+  shortDescription : string;
+
+  /**
+   * Descriptions of each argument, keyed by name.
+   */
+  args: Record<string, ArgumentMetadata>;
 
   /**
    * @param {Object} jamboConfig the config of the jambo repository
@@ -44,6 +45,6 @@ class Command {
    *                   all available cards
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static describe(jamboConfig: JamboConfig): Promise<any> | any {}
+  describe(jamboConfig: JamboConfig): Promise<any> | any;
 }
 export default Command;

--- a/src/models/commands/command.ts
+++ b/src/models/commands/command.ts
@@ -1,8 +1,8 @@
 import { JamboConfig } from '../JamboConfig';
-import { ArgumentMetadata } from './argumentmetadata';
-import { CommandExecutable } from './commandexecutable';
+import { ArgumentMetadata, ArgumentMetadataRecord } from './argumentmetadata';
+import { CommandExecutable, ExecArgumentRecord } from './commandexecutable';
 
-type toPrim<T = never> = {
+type valToType<T = never> = {
   'string': string
   'number': number
   'boolean': boolean
@@ -13,7 +13,7 @@ type toPrim<T = never> = {
  * generate a type based on the arguments given to Jambo command
  */
 export type ArgsForExecute<T extends Record<string, ArgumentMetadata>> = {
-  [prop in keyof T]: toPrim<toPrim[T[prop]['itemType']]>[T[prop]['type']]
+  [prop in keyof T]: valToType<valToType[T[prop]['itemType']]>[T[prop]['type']]
 }
 
 /**
@@ -21,8 +21,8 @@ export type ArgsForExecute<T extends Record<string, ArgumentMetadata>> = {
  * Contains non static (CommandExecutable interface) and 
  * static (specified in here) fields and methods.
  */
-export default interface Command<T extends Record<string, ArgumentMetadata>> {
-  new(...args: any[]):CommandExecutable<ArgsForExecute<T>>;
+export default interface Command<T extends ArgumentMetadataRecord, S extends ExecArgumentRecord> {
+  new(...args: any[]):CommandExecutable<S>;
 
   /**
    * The alias for the command.

--- a/src/models/commands/commandexecutable.ts
+++ b/src/models/commands/commandexecutable.ts
@@ -1,9 +1,21 @@
 /**
+ * The primitive types used by execute arguments
+ */
+type Primitive = string | number | boolean;
+
+/**
+ * Represents a record of argument names to their corresponding type
+ */
+ export type ExecArgumentRecord = {
+  [arg: string]: Primitive | Primitive[]
+}
+
+/**
  * Command interface that contains non static fields and methods
  * of a Command instance. It requires a type T that defines the
  * arguments pass to execute()
  */
- export interface CommandExecutable<T> {
+ export interface CommandExecutable<T extends ExecArgumentRecord> {
   /**
    * Executes the command with the provided arguments.
    * 

--- a/src/models/commands/commandexecutable.ts
+++ b/src/models/commands/commandexecutable.ts
@@ -1,0 +1,13 @@
+/**
+ * Command interface that contains non static fields and methods
+ * of a Command instance. It requires a type T that defines the
+ * arguments pass to execute()
+ */
+ export interface CommandExecutable<T> {
+  /**
+   * Executes the command with the provided arguments.
+   * 
+   * @param {T} args The arguments passed to the execute command
+   */
+  execute(args: T): any
+}

--- a/src/models/configurationregistry.ts
+++ b/src/models/configurationregistry.ts
@@ -13,9 +13,9 @@ import { info } from '../utils/logger';
  * This class does not mutate or localize the configuration in any way.
  */
 export default class ConfigurationRegistry {
-  _globalConfig: GlobalConfig
-  _localizationConfig: LocalizationConfig
-  _pageConfigs: PageConfig[]
+  private _globalConfig: GlobalConfig
+  private _localizationConfig: LocalizationConfig
+  private _pageConfigs: PageConfig[]
 
   /**
    * @param {GlobalConfig} globalConfig

--- a/src/models/generateddata.ts
+++ b/src/models/generateddata.ts
@@ -7,8 +7,8 @@ import PageSetsBuilder from '../commands/build/pagesetsbuilder';
  * the {@link LocalizationConfig}, a group of {@link PageSet}s.
  */
 export default class GeneratedData {
-  _localizationConfig: LocalizationConfig
-  _pageSets: PageSet[]
+  private _localizationConfig: LocalizationConfig
+  private _pageSets: PageSet[]
 
   /**
    * @param {LocalizationConfig} localizationConfig

--- a/src/models/localizationconfig.ts
+++ b/src/models/localizationconfig.ts
@@ -7,10 +7,10 @@ import UserError from '../errors/usererror';
  * configuration and URL formatting for each locale.
  */
 export default class LocalizationConfig {
-  _defaultLocale: string
-  _localeToConfig: Record<string, any>
-  _defaultUrlPattern: string
-  _baseLocalePattern: string
+  private _defaultLocale: string
+  private _localeToConfig: Record<string, any>
+  private _defaultUrlPattern: string
+  private _baseLocalePattern: string
 
   /**
    * @param {Object} rawLocalizationConfig

--- a/src/utils/customcommands/command.ts
+++ b/src/utils/customcommands/command.ts
@@ -3,9 +3,9 @@
  * of a built-in Jambo command. These shell commands are supplied by Themes.
  */
 export class CustomCommand {
-    _executable: string
-    _args: string[]
-    _cwd: string
+    private _executable: string
+    private _args: string[]
+    private _cwd: string
 
     constructor({ executable, args, cwd }: any) {
         this._executable = executable;

--- a/src/utils/customcommands/commandexecuter.ts
+++ b/src/utils/customcommands/commandexecuter.ts
@@ -8,7 +8,7 @@ import { JamboConfig } from '../../models/JamboConfig';
  * flags.
  */
 export class CustomCommandExecuter {
-  _jamboFlags: any
+  private _jamboFlags: any
 
   constructor(jamboConfig) {
     this._jamboFlags = this._generateJamboFlags(jamboConfig);

--- a/src/utils/envvarparser.ts
+++ b/src/utils/envvarparser.ts
@@ -5,7 +5,7 @@ import { parse } from 'comment-json';
  * It exposes a method to retrieve unserialized values from this mapping.
  */
 class EnvironmentVariableParser {
-  _envVars: any
+  private _envVars: any
 
   constructor(envVars) {
     this._envVars = envVars;

--- a/src/validation/globalconfigvalidator.ts
+++ b/src/validation/globalconfigvalidator.ts
@@ -5,7 +5,7 @@ import { FileNames } from '../constants';
  * Performs validation on global_config.json
  */
 export default class GlobalConfigValidator {
-  _globalConfig: any
+  private _globalConfig: any
 
   constructor(globalConfig) {
     /**

--- a/src/validation/localeconfigvalidator.ts
+++ b/src/validation/localeconfigvalidator.ts
@@ -6,7 +6,7 @@ import LocalizationConfig from '../models/localizationconfig';
  * Performs validation on locale_config.json
  */
 export default class LocaleConfigValidator {
-  _localizationConfig: LocalizationConfig
+  private _localizationConfig: LocalizationConfig
 
   constructor(localizationConfig) {
     /**

--- a/src/validation/pageconfigsvalidator.ts
+++ b/src/validation/pageconfigsvalidator.ts
@@ -7,8 +7,8 @@ import PageConfig from '../models/pageconfig';
  * Performs validation on page config files
  */
 export default class PageConfigsValidator {
-  _pageConfigs: Record<string, PageConfig>
-  _configuredLocales: string[]
+  private _pageConfigs: Record<string, PageConfig>
+  private _configuredLocales: string[]
 
   constructor(pageConfigs, configuredLocales) {
     /**

--- a/src/validation/rawconfigvalidator.ts
+++ b/src/validation/rawconfigvalidator.ts
@@ -11,7 +11,7 @@ import { canonicalizeLocale } from '../utils/i18nutils';
  * the various page configurations
  */
 export default class RawConfigValidator {
-  _configNameToRawConfig: Record<string, any>
+  private _configNameToRawConfig: Record<string, any>
 
   constructor(configNameToRawConfig) {
     /**

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -55,7 +55,16 @@ class YargsFactory {
       command: commandClass.getAlias(),
       describe: commandClass.getShortDescription(),
       builder: yargs => {
-        Object.entries(commandClass.args()).forEach(([name, metadata]) => {
+        Object.entries(commandClass.args()).forEach(([name, argMetadata]: [string, ArgumentMetadata | any]) => {
+          let metadata = argMetadata;
+          if(metadata.hasOwnProperty('_type')) {
+            metadata = {
+              type: argMetadata.getType(),
+              description: argMetadata.getDescription(),
+              demandOption: argMetadata.isRequired(),
+              default: argMetadata.defaultValue()
+            }
+          }
           if (metadata.type === 'array') {
             this._addListOption(name, metadata, yargs);
           } else {

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -10,6 +10,7 @@ import DescribeCommand from './commands/describe/describecommand';
 import PageCommand from './commands/page/add/pagecommand';
 import BuildCommand from './commands/build/buildcommand';
 import { ArgumentMetadata } from './models/commands/argumentmetadata';
+import { ArgumentMetadataLegacy, isArgumentMetadataLegacy } from './models/commands/argumentmetadatalegacy';
 
 /**
  * Creates the {@link yargs} instance that powers the Jambo CLI.
@@ -55,15 +56,18 @@ class YargsFactory {
       command: commandClass.getAlias(),
       describe: commandClass.getShortDescription(),
       builder: yargs => {
-        Object.entries(commandClass.args()).forEach(([name, argMetadata]: [string, ArgumentMetadata | any]) => {
-          let metadata = argMetadata;
-          if(metadata.hasOwnProperty('_type')) {
+        Object.entries(commandClass.args())
+          .forEach(([name, argMetadata]: [string, ArgumentMetadata | ArgumentMetadataLegacy]) => {
+          let metadata: ArgumentMetadata;
+          if(isArgumentMetadataLegacy(argMetadata)) {
             metadata = {
               type: argMetadata.getType(),
               description: argMetadata.getDescription(),
-              demandOption: argMetadata.isRequired(),
-              default: argMetadata.defaultValue()
+              isRequired: argMetadata.isRequired(),
+              defaultValue: argMetadata.defaultValue()
             }
+          } else {
+            metadata = argMetadata;
           }
           if (metadata.type === 'array') {
             this._addListOption(name, metadata, yargs);

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -99,7 +99,7 @@ class YargsFactory {
    * @param {Class} commandClass the class of the Jambo command
    * @returns {Command} the instantiated Jambo command
    */
-  _createCommandInstance(commandClass) {
+  _createCommandInstance(commandClass: Command) {
     const classAlias = commandClass.alias;
     let commandInstance;
     switch (classAlias) {

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -92,7 +92,7 @@ class YargsFactory {
    * option cannot be added with 'yargs.option'.
    * 
    * @param {string} name The name of the option.
-   * @param {ArgumentMetadataImpl} metadata The option's {@link ArgumentMetadataImpl}.
+   * @param {ArgumentMetadata} metadata The option's {@link ArgumentMetadata}.
    * @param {import('yargs').Argv} yargs The Yargs instance to modify.
    */
   _addListOption(name: string, metadata: ArgumentMetadata, yargs: import('yargs').Argv) {

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -51,7 +51,7 @@ class YargsFactory {
    * @param {Class} commandClass A Jambo {@link Command}'s class.
    * @returns {Object<string, ?>} The {@link yargs} CommandModule for the {@link Command}.
    */
-  _createCommandModule(commandClass: Command<any>): CommandModule {
+  _createCommandModule(commandClass: Command<any, any>): CommandModule {
     return {
       command: commandClass.getAlias(),
       describe: commandClass.getShortDescription(),

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -1,7 +1,7 @@
 import yargs, { CommandModule } from 'yargs';
 import PageScaffolder from './commands/page/add/pagescaffolder';
 import SitesGenerator from './commands/build/sitesgenerator';
-import { ArgumentMetadata } from './models/commands/argumentmetadata';
+import { ArgumentMetadataImpl } from './models/commands/argumentmetadata';
 import { info, error } from './utils/logger';
 import { exitWithError } from './utils/errorutils';
 import CommandRegistry from './commands/commandregistry';
@@ -15,8 +15,8 @@ import BuildCommand from './commands/build/buildcommand';
  * Creates the {@link yargs} instance that powers the Jambo CLI.
  */
 class YargsFactory {
-  _commandRegistry: CommandRegistry
-  _jamboConfig: JamboConfig
+  private _commandRegistry: CommandRegistry
+  private _jamboConfig: JamboConfig
 
   constructor(commandRegistry: CommandRegistry, jamboConfig: JamboConfig) {
     this._commandRegistry = commandRegistry;
@@ -83,10 +83,10 @@ class YargsFactory {
    * option cannot be added with 'yargs.option'.
    * 
    * @param {string} name The name of the option.
-   * @param {ArgumentMetadata} metadata The option's {@link ArgumentMetadata}.
+   * @param {ArgumentMetadataImpl} metadata The option's {@link ArgumentMetadataImpl}.
    * @param {import('yargs').Argv} yargs The Yargs instance to modify.
    */
-  _addListOption(name: string, metadata: ArgumentMetadata, yargs: import('yargs').Argv) {
+  _addListOption(name: string, metadata: ArgumentMetadataImpl, yargs: import('yargs').Argv) {
     yargs.array(name);
     const defaultValue = metadata.defaultValue() || [];
 

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -1,7 +1,6 @@
 import yargs, { CommandModule } from 'yargs';
 import PageScaffolder from './commands/page/add/pagescaffolder';
 import SitesGenerator from './commands/build/sitesgenerator';
-import { ArgumentMetadataImpl } from './models/commands/argumentmetadata';
 import { info, error } from './utils/logger';
 import { exitWithError } from './utils/errorutils';
 import CommandRegistry from './commands/commandregistry';
@@ -10,6 +9,7 @@ import { JamboConfig } from './models/JamboConfig';
 import DescribeCommand from './commands/describe/describecommand';
 import PageCommand from './commands/page/add/pagecommand';
 import BuildCommand from './commands/build/buildcommand';
+import { ArgumentMetadata } from './models/commands/argumentmetadata';
 
 /**
  * Creates the {@link yargs} instance that powers the Jambo CLI.
@@ -50,22 +50,22 @@ class YargsFactory {
    * @param {Class} commandClass A Jambo {@link Command}'s class.
    * @returns {Object<string, ?>} The {@link yargs} CommandModule for the {@link Command}.
    */
-  _createCommandModule(commandClass: Command): CommandModule {
+  _createCommandModule(commandClass: Command<any>): CommandModule {
     return {
       command: commandClass.getAlias(),
       describe: commandClass.getShortDescription(),
       builder: yargs => {
         Object.entries(commandClass.args()).forEach(([name, metadata]) => {
-          if (metadata.getType() === 'array') {
+          if (metadata.type === 'array') {
             this._addListOption(name, metadata, yargs);
           } else {
             yargs.option<string, any>(
               name,
               {
-                type: metadata.getType(),
-                description: metadata.getDescription(),
-                demandOption: metadata.isRequired(),
-                default: metadata.defaultValue()
+                type: metadata.type,
+                description: metadata.description,
+                demandOption: metadata.isRequired,
+                default: metadata.defaultValue
               });
           }
         });
@@ -86,13 +86,13 @@ class YargsFactory {
    * @param {ArgumentMetadataImpl} metadata The option's {@link ArgumentMetadataImpl}.
    * @param {import('yargs').Argv} yargs The Yargs instance to modify.
    */
-  _addListOption(name: string, metadata: ArgumentMetadataImpl, yargs: import('yargs').Argv) {
+  _addListOption(name: string, metadata: ArgumentMetadata, yargs: import('yargs').Argv) {
     yargs.array(name);
-    const defaultValue = metadata.defaultValue() || [];
+    const defaultValue = metadata.defaultValue || [];
 
-    metadata.isRequired() && yargs.demandOption(name);
+    metadata.isRequired && yargs.demandOption(name);
     yargs.default(name, defaultValue);
-    yargs.describe(name, metadata.getDescription());
+    yargs.describe(name, metadata.description);
   }
 
   /**

--- a/tests/acceptance/fixtures/describe/describe-test.json
+++ b/tests/acceptance/fixtures/describe/describe-test.json
@@ -54,11 +54,6 @@
           "describe-template"
         ]
       },
-      "layout": {
-        "displayName": "Page Layout",
-        "type": "singleoption",
-        "options": []
-      },
       "locales": {
         "displayName": "Additional Page Locales",
         "type": "multioption",

--- a/tests/acceptance/fixtures/describe/describe-test.json
+++ b/tests/acceptance/fixtures/describe/describe-test.json
@@ -54,6 +54,11 @@
           "describe-template"
         ]
       },
+      "layout": {
+        "displayName": "Page Layout",
+        "type": "singleoption",
+        "options": []
+      },
       "locales": {
         "displayName": "Additional Page Locales",
         "type": "multioption",

--- a/tests/acceptance/fixtures/describe/describe-test.json
+++ b/tests/acceptance/fixtures/describe/describe-test.json
@@ -13,6 +13,10 @@
           "answers-hitchhiker-theme"
         ]
       },
+      "includeTranslations": {
+        "displayName": "Include Translations",
+        "type": "boolean"
+      },
       "useSubmodules": {
         "displayName": "Use Submodules",
         "type": "boolean"
@@ -70,6 +74,7 @@
         "required": true,
         "options": [
           "commands/addVertical.js",
+          "commands/addVerticalLegacy.js",
           "postimport.js",
           "templates/describe-template/page-config.json",
           "templates/describe-template/page.html.hbs"
@@ -97,6 +102,34 @@
     }
   },
   "vertical": {
+    "displayName": "Add Vertical",
+    "params": {
+      "name": {
+        "displayName": "Page Name",
+        "required": true,
+        "type": "string"
+      },
+      "verticalKey": {
+        "displayName": "Vertical Key",
+        "required": true,
+        "type": "string"
+      },
+      "cardName": {
+        "displayName": "Card Name",
+        "type": "singleoption"
+      },
+      "template": {
+        "displayName": "Page Template",
+        "required": true,
+        "type": "singleoption"
+      },
+      "locales": {
+        "displayName": "Additional Page Locales",
+        "type": "multioption"
+      }
+    }
+  },
+  "verticalLegacy": {
     "displayName": "Add Vertical",
     "params": {
       "name": {

--- a/tests/acceptance/suites/customcommand.js
+++ b/tests/acceptance/suites/customcommand.js
@@ -11,3 +11,14 @@ it('import and execute custom commands', () => runInPlayground(async t => {
     '../fixtures/customcommand/customcommand-test.html', 'utf-8');
   expect(actualPage).toEqualHtml(expectedPage);
 }));
+
+it('import and execute legacy custom commands', () => runInPlayground(async t => {
+  await t.jambo('init');
+  await t.jambo('import --themeUrl ../test-themes/customcommand');
+  await t.jambo(
+      'verticalLegacy --name testvert --verticalKey testkey --template universal-standard');
+  const actualPage = fs.readFileSync('indexLegacy.html', 'utf-8');
+  const expectedPage = fs.readFileSync(
+    '../fixtures/customcommand/customcommand-test.html', 'utf-8');
+  expect(actualPage).toEqualHtml(expectedPage);
+}));

--- a/tests/acceptance/test-themes/customcommand/commands/addVertical.js
+++ b/tests/acceptance/test-themes/customcommand/commands/addVertical.js
@@ -1,5 +1,5 @@
 const {
-  ArgumentMetadata
+  ArgumentMetadataImpl
 } = require('../../../../../src/models/commands/argumentmetadata');
 const fs = require('fs');
 
@@ -27,28 +27,28 @@ module.exports = class VerticalAdder {
   }
 
   /**
-   * @returns {Object<string, ArgumentMetadata>} description of each argument for 
+   * @returns {Object<string, ArgumentMetadataImpl>} description of each argument for 
    *                                             the add vertical command, keyed by name
    */
   static args() {
     return {
-      name: new ArgumentMetadata({
+      name: new ArgumentMetadataImpl({
         itemType: 'string', 
         description: 'name of the vertical\'s page', 
         isRequired: true}),
-      verticalKey: new ArgumentMetadata({
+      verticalKey: new ArgumentMetadataImpl({
         itemType: 'string', 
         description: 'the vertical\'s key', 
         isRequired: true}),
-      cardName: new ArgumentMetadata({
+      cardName: new ArgumentMetadataImpl({
         itemType: 'string', 
         description: 'card to use with vertical', 
         isRequired: false}),
-      template: new ArgumentMetadata({
+      template: new ArgumentMetadataImpl({
         itemType: 'string',
         description: 'page template to use within theme',
         isRequired: true}),
-      locales: new ArgumentMetadata({
+      locales: new ArgumentMetadataImpl({
         type: 'array',
         description: 'additional locales to generate the page for',
         isRequired: false,

--- a/tests/acceptance/test-themes/customcommand/commands/addVertical.js
+++ b/tests/acceptance/test-themes/customcommand/commands/addVertical.js
@@ -1,6 +1,5 @@
 const {
-  ArgumentMetadata,
-  ArgumentType
+  ArgumentMetadata
 } = require('../../../../../src/models/commands/argumentmetadata');
 const fs = require('fs');
 
@@ -34,27 +33,27 @@ module.exports = class VerticalAdder {
   static args() {
     return {
       name: new ArgumentMetadata({
-        itemType: ArgumentType.STRING, 
+        itemType: 'string', 
         description: 'name of the vertical\'s page', 
         isRequired: true}),
       verticalKey: new ArgumentMetadata({
-        itemType: ArgumentType.STRING, 
+        itemType: 'string', 
         description: 'the vertical\'s key', 
         isRequired: true}),
       cardName: new ArgumentMetadata({
-        itemType: ArgumentType.STRING, 
+        itemType: 'string', 
         description: 'card to use with vertical', 
         isRequired: false}),
       template: new ArgumentMetadata({
-        itemType: ArgumentType.STRING,
+        itemType: 'string',
         description: 'page template to use within theme',
         isRequired: true}),
       locales: new ArgumentMetadata({
-        type: ArgumentType.ARRAY,
+        type: 'array',
         description: 'additional locales to generate the page for',
         isRequired: false,
         defaultValue: [],
-        itemType: ArgumentType.STRING})
+        itemType: 'string'})
     };
   }
 

--- a/tests/acceptance/test-themes/customcommand/commands/addVertical.js
+++ b/tests/acceptance/test-themes/customcommand/commands/addVertical.js
@@ -1,6 +1,6 @@
-const {
-  ArgumentMetadataImpl
-} = require('../../../../../src/models/commands/argumentmetadata');
+// const {
+//   ArgumentMetadata
+// } = require('../../../../../src/models/commands/argumentmetadata');
 const fs = require('fs');
 
 /**
@@ -27,33 +27,38 @@ module.exports = class VerticalAdder {
   }
 
   /**
-   * @returns {Object<string, ArgumentMetadataImpl>} description of each argument for 
+   * @returns {Object<string, ArgumentMetadata>} description of each argument for 
    *                                             the add vertical command, keyed by name
    */
   static args() {
     return {
-      name: new ArgumentMetadataImpl({
+      name: {
         itemType: 'string', 
         description: 'name of the vertical\'s page', 
-        isRequired: true}),
-      verticalKey: new ArgumentMetadataImpl({
+        isRequired: true
+      },
+      verticalKey: {
         itemType: 'string', 
         description: 'the vertical\'s key', 
-        isRequired: true}),
-      cardName: new ArgumentMetadataImpl({
+        isRequired: true
+      },
+      cardName: {
         itemType: 'string', 
         description: 'card to use with vertical', 
-        isRequired: false}),
-      template: new ArgumentMetadataImpl({
+        isRequired: false
+      },
+      template: {
         itemType: 'string',
         description: 'page template to use within theme',
-        isRequired: true}),
-      locales: new ArgumentMetadataImpl({
+        isRequired: true
+      },
+      locales: {
         type: 'array',
         description: 'additional locales to generate the page for',
         isRequired: false,
         defaultValue: [],
-        itemType: 'string'})
+        itemType: 'string'
+      }
     };
   }
 

--- a/tests/acceptance/test-themes/customcommand/commands/addVerticalLegacy.js
+++ b/tests/acceptance/test-themes/customcommand/commands/addVerticalLegacy.js
@@ -1,5 +1,35 @@
 const fs = require('fs');
 
+class ArgumentMetadata {
+  constructor({type, description, isRequired, defaultValue, itemType}) {
+    this._type = type;
+    this._description = description;
+    this._isRequired = isRequired;
+    this._defaultValue = defaultValue;
+    this._itemType = itemType;
+  }
+
+  getType() {
+    return this._type;
+  }
+
+  getItemType() {
+    return this._itemType;
+  }
+
+  getDescription() {
+    return this._description
+  }
+
+  isRequired() {
+    return !!this._isRequired;
+  }
+
+  defaultValue() {
+    return this._defaultValue;
+  }
+}
+
 /**
  * VerticalAdder represents the `vertical` custom jambo command. The command adds
  * a new page for the given Vertical and associates a card type with it.
@@ -13,7 +43,7 @@ module.exports = class VerticalAdder {
    * @returns {string} the alias for the add vertical command.
    */
   static getAlias() {
-    return 'vertical';
+    return 'verticalLegacy';
   }
 
   /**
@@ -29,33 +59,28 @@ module.exports = class VerticalAdder {
    */
   static args() {
     return {
-      name: {
+      name: new ArgumentMetadata({
         itemType: 'string', 
         description: 'name of the vertical\'s page', 
-        isRequired: true
-      },
-      verticalKey: {
+        isRequired: true}),
+      verticalKey: new ArgumentMetadata({
         itemType: 'string', 
         description: 'the vertical\'s key', 
-        isRequired: true
-      },
-      cardName: {
+        isRequired: true}),
+      cardName: new ArgumentMetadata({
         itemType: 'string', 
         description: 'card to use with vertical', 
-        isRequired: false
-      },
-      template: {
+        isRequired: false}),
+      template: new ArgumentMetadata({
         itemType: 'string',
         description: 'page template to use within theme',
-        isRequired: true
-      },
-      locales: {
+        isRequired: true}),
+      locales: new ArgumentMetadata({
         type: 'array',
         description: 'additional locales to generate the page for',
         isRequired: false,
         defaultValue: [],
-        itemType: 'string'
-      }
+        itemType: 'string'})
     };
   }
 
@@ -100,6 +125,6 @@ module.exports = class VerticalAdder {
  */
   execute(args) {
     const content = args.name + args.template + args.verticalKey;
-    fs.writeFileSync('index.html', content);
+    fs.writeFileSync('indexLegacy.html', content);
   }
 }


### PR DESCRIPTION
Update built in commands to use new Command interface

- make `ArgumentMetadata` an interface
- change `ArgumentType` to string union type
- change `Command` class to an interface that enforces static and non static fields/methods
  - Typescript doesn't allow static fields/methods to be used in interface. In order to enforce the static properties in interface (show errors to user if a customcommand is not implemented properly), a workaround is implemented. `CommandExecutable` contains all the non static properties and functions. `Command` holds a constructor signature of type `CommandExecutable` and specified fields (e.g alias, args, and shortdescriptions) that will be required to be static when type checked. This approach is similar to what is used in React (Component and ComponentClass)
  - Command will also take in two type arguments to define the return type of jambo command's arg() method and the argument types that get pass in execute()
  - The syntax to follow is: `const SomeCustomCommand : Command<Args, ExecArgs> = class { ... }` where Args is the type of the args object and ExecArgs is the type of the args passed to execute
 - Keeping the static methods instead of switching to static fields to avoid breaking current public interface and needing to handle another legacy import
 - Update other related files such as commandregistry, commandimporter, and yargsfactory to follow the new interface
 - Update RepositorySettings and PageConfiguration from class to interface
 - remove layout option to pagecommand
 
J=SLAP-1492

TEST=compile & auto

see that tests passed