### PR TITLE
unify describe with args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3884,6 +3884,12 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.172",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@babel/preset-typescript": "^7.15.0",
     "@handlebars/parser": "^2.1.0",
     "@types/jest": "^27.0.1",
+    "@types/lodash": "^4.14.172",
     "@types/yargs": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "^4.31.0",
     "@typescript-eslint/parser": "^4.31.0",

--- a/src/buildJamboCLI.ts
+++ b/src/buildJamboCLI.ts
@@ -1,4 +1,4 @@
-import fs from 'file-system';
+import fs from 'fs';
 import path from 'path';
 import { parseJamboConfig } from './utils/jamboconfigutils';
 import CommandRegistry from './commands/commandregistry';

--- a/src/commands/LegacyAdapter.ts
+++ b/src/commands/LegacyAdapter.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import Command from '../models/commands/command';
+import Command from '../models/commands/Command';
 import { ArgumentMetadataImpl, ConcreteArgumentMetadata } from '../models/commands/concreteargumentmetadata';
 import { LegacyArgumentMetadata } from '../models/commands/LegacyArgumentMetadata';
 import { warn } from '../utils/logger';

--- a/src/commands/adaptCommandWithLegacyArgs.ts
+++ b/src/commands/adaptCommandWithLegacyArgs.ts
@@ -1,6 +1,6 @@
 import UserError from '../errors/usererror';
 import { ArgumentMetadata } from '../models/commands/ArgumentMetadata';
-import Command from '../models/commands/command';
+import Command from '../models/commands/Command';
 import { CommandExecutable } from '../models/commands/commandexecutable';
 import {
   ConcreteArgumentMetadata,

--- a/src/commands/adaptLegacyCommand.ts
+++ b/src/commands/adaptLegacyCommand.ts
@@ -1,4 +1,4 @@
-import Command from '../models/commands/command';
+import Command from '../models/commands/Command';
 import { LegacyArgumentMetadata } from '../models/commands/LegacyArgumentMetadata';
 import { JamboConfig } from '../models/JamboConfig';
 import { CommandClassWithLegacyArguments } from './adaptCommandWithLegacyArgs';
@@ -12,7 +12,7 @@ export type LegacyCommand = (jamboConfig: JamboConfig) => {
   getAlias: () => string
   getShortDescription: () => string
   args: () => Record<string, LegacyArgumentMetadata>
-  describe: () => void
+  describe: () => any
   execute: (params: any) => void
 }
 

--- a/src/commands/build/buildcommand.ts
+++ b/src/commands/build/buildcommand.ts
@@ -1,7 +1,7 @@
 import UserError from '../../errors/usererror';
 import { isCustomError } from '../../utils/errorutils';
 import SitesGenerator from './sitesgenerator';
-import Command from '../../models/commands/command';
+import Command from '../../models/commands/Command';
 import { StringArrayMetadata } from '../../models/commands/concreteargumentmetadata';
 
 const args = {
@@ -15,7 +15,7 @@ const args = {
  * BuildCommand builds all pages in the Jambo repo and places them in the
  * public directory.
  */
-const BuildCommand : Command<typeof args> = class {
+const BuildCommand: Command<typeof args> = class {
   sitesGenerator: SitesGenerator;
 
   constructor(sitesGenerator) {
@@ -40,7 +40,7 @@ const BuildCommand : Command<typeof args> = class {
     }
   }
 
-  async execute(args: { jsonEnvVars: string[] }): Promise<any> {
+  async execute(args: { jsonEnvVars: string[] }): Promise<void> {
     try {
       await this.sitesGenerator.generate(args.jsonEnvVars);
     } catch (err) {

--- a/src/commands/build/buildcommand.ts
+++ b/src/commands/build/buildcommand.ts
@@ -3,6 +3,7 @@ import { isCustomError } from '../../utils/errorutils';
 import SitesGenerator from './sitesgenerator';
 import Command from '../../models/commands/Command';
 import { StringArrayMetadata } from '../../models/commands/concreteargumentmetadata';
+import DescribeDefinition from '../../models/commands/DescribeDefinition';
 
 const args = {
   jsonEnvVars: new StringArrayMetadata({
@@ -34,7 +35,7 @@ const BuildCommand: Command<typeof args> = class {
     return args;
   }
 
-  static describe() {
+  static describe(): DescribeDefinition<typeof args> {
     return {
       displayName: 'Build Pages'
     }

--- a/src/commands/commandregistry.ts
+++ b/src/commands/commandregistry.ts
@@ -6,7 +6,7 @@ import DescribeCommand from '../commands/describe/describecommand';
 import JamboTranslationExtractor from './extract-translations/jambotranslationextractor';
 import ThemeImporter from './import/themeimporter';
 import ThemeUpgrader from './upgrade/themeupgrader';
-import Command from '../models/commands/command';
+import Command from '../models/commands/Command';
 
 /**
  * A registry that maintains the built-in and custom commands for the Jambo CLI.

--- a/src/commands/describe/DescribeOutput.ts
+++ b/src/commands/describe/DescribeOutput.ts
@@ -1,0 +1,16 @@
+/**
+ * DescribeOutput provides static type checking for a {@link Command}'s describe(),
+ * and ensures that the return value matches the same shape as the {@link Command}'s args.
+ */
+export default interface DescribeOutput{
+  displayName: string
+  params?: Record<string, DescribeParam>
+}
+
+export interface DescribeParam {
+  displayName: string
+  type: 'string' | 'number' | 'boolean' | 'singleoption' | 'filesystem' | 'multioption'
+  required?: boolean
+  default?: string | number | boolean | string[] | number[] | boolean[]
+  options: string[] | number[] | boolean[]
+}

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -51,7 +51,7 @@ const DescribeCommand: Command<any> = class {
     const descriptions = {};
     const commands = this.getCommands();
     const describePromises = commands.map(command => {
-      const recordDescription = (value: DescribeDefinition<ArgumentMetadataRecord>) => {
+      const recordDescription = (value: DescribeDefinition) => {
         descriptions[command.getAlias()] = this.calculateDescribeOutput(command.args(), value);
       }
       const describeValue = command.describe(this._jamboConfig);
@@ -71,7 +71,7 @@ const DescribeCommand: Command<any> = class {
 
   private calculateDescribeOutput(
     args: ArgumentMetadataRecord,
-    describeDefinition: DescribeDefinition<ArgumentMetadataRecord>
+    describeDefinition: DescribeDefinition
   ): DescribeOutput {
     if (!describeDefinition.params) {
       return {
@@ -96,12 +96,10 @@ const DescribeCommand: Command<any> = class {
 }
 
 function isPromise(
-  describeValue: DescribeDefinition<ArgumentMetadataRecord> | Promise<DescribeDefinition<ArgumentMetadataRecord>>
-): describeValue is Promise<DescribeDefinition<ArgumentMetadataRecord>> {
-  if (!('then' in describeValue)) {
-    return false;
-  }
-  return typeof describeValue.then === 'function';
+  describeValue: DescribeDefinition | Promise<DescribeDefinition>
+): describeValue is Promise<DescribeDefinition> {
+  return ('then' in describeValue)
+    && typeof describeValue.then === 'function';
 }
 
 export default DescribeCommand;

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -1,13 +1,16 @@
-import Command from '../../models/commands/command';
+import Command from '../../models/commands/Command';
+import { ArgumentMetadataRecord } from '../../models/commands/concreteargumentmetadata';
+import DescribeDefinition from '../../models/commands/DescribeDefinition';
 import { JamboConfig } from '../../models/JamboConfig';
+import DescribeOutput from './DescribeOutput';
 
 /**
  * DescribeCommand outputs JSON that describes all registered Jambo commands
  * and their possible arguments.
  */
-const DescribeCommand : Command<any> = class {
+const DescribeCommand: Command<any> = class {
   private _jamboConfig: JamboConfig
-  getCommands: () => Command<any>[]
+  getCommands: () => Command<ArgumentMetadataRecord>[]
 
   constructor(jamboConfig, getCommands) {
     /**
@@ -33,35 +36,72 @@ const DescribeCommand : Command<any> = class {
    * The describe command filters its own describe out of the jambo describe output.
    */
   static describe() {
-    return {};
+    return null;
   }
 
   async execute() {
-    const descriptions = await this._getCommandDescriptions();
+    const descriptions = await this.getCommandDescriptions();
     console.log(JSON.stringify(descriptions, null, 2));
   }
 
   /**
    * Returns the descriptions of all registered Commands
    */
-  _getCommandDescriptions() {
+  private getCommandDescriptions() {
     const descriptions = {};
-    const describePromises = this.getCommands().map(
-      command => {
-        const describeValue = command.describe(this._jamboConfig);
-        if (describeValue.then && typeof describeValue.then === 'function') {
-          return describeValue.then(
-            (value) => { descriptions[command.getAlias()] = value; }
-          );
-        } else {
-          if (command.getAlias() !== 'describe') {
-            descriptions[command.getAlias()] = describeValue;
-          }
-        }
+    const commands = this.getCommands();
+    const describePromises = commands.map(command => {
+      const recordDescription = (value: DescribeDefinition<ArgumentMetadataRecord>) => {
+        descriptions[command.getAlias()] = this.calculateDescribeOutput(command.args(), value);
       }
-    );
+      const describeValue = command.describe(this._jamboConfig);
+      if (!describeValue) {
+        return;
+      }
+      if (isPromise(describeValue)) {
+        return describeValue.then(value => {
+          value && recordDescription(value);
+        });
+      } else {
+        recordDescription(describeValue);
+      }
+    });
     return Promise.all(describePromises).then(() => descriptions);
   }
+
+  private calculateDescribeOutput(
+    args: ArgumentMetadataRecord,
+    describeDefinition: DescribeDefinition<ArgumentMetadataRecord>
+  ): DescribeOutput {
+    if (!describeDefinition.params) {
+      return {
+        displayName: describeDefinition.displayName
+      };
+    }
+    const mergedParams = {};
+    for (const [argName, describeParam] of Object.entries(describeDefinition.params)) {
+      const concreteMetadata = args[argName];
+      mergedParams[argName] = {
+        required: concreteMetadata.isRequired,
+        default: concreteMetadata.defaultValue,
+        type: concreteMetadata.type,
+        ...describeParam
+      }
+    }
+    return {
+      displayName: describeDefinition.displayName,
+      params: mergedParams
+    };
+  }
+}
+
+function isPromise(
+  describeValue: DescribeDefinition<ArgumentMetadataRecord> | Promise<DescribeDefinition<ArgumentMetadataRecord>>
+): describeValue is Promise<DescribeDefinition<ArgumentMetadataRecord>> {
+  if (!('then' in describeValue)) {
+    return false;
+  }
+  return typeof describeValue.then === 'function';
 }
 
 export default DescribeCommand;

--- a/src/commands/extract-translations/jambotranslationextractor.ts
+++ b/src/commands/extract-translations/jambotranslationextractor.ts
@@ -5,6 +5,7 @@ import { readGitignorePaths } from '../../utils/gitutils';
 import { JamboConfig } from '../../models/JamboConfig';
 import Command from '../../models/commands/Command';
 import { StringArrayMetadata, StringMetadata } from '../../models/commands/concreteargumentmetadata';
+import DescribeDefinition from '../../models/commands/DescribeDefinition';
 
 const args = {
   globs: new StringArrayMetadata({
@@ -43,7 +44,7 @@ const JamboTranslationExtractor: Command<typeof args> = class {
     return args;
   }
 
-  static describe() {
+  static describe(): DescribeDefinition<typeof args> {
     return {
       displayName: 'Extract Translations',
       params: {

--- a/src/commands/extract-translations/jambotranslationextractor.ts
+++ b/src/commands/extract-translations/jambotranslationextractor.ts
@@ -3,18 +3,16 @@ import { info } from '../../utils/logger';
 import DefaultTranslationGlobber from './defaulttranslationglobber';
 import { readGitignorePaths } from '../../utils/gitutils';
 import { JamboConfig } from '../../models/JamboConfig';
-import Command from '../../models/commands/command';
+import Command from '../../models/commands/Command';
 import { StringArrayMetadata, StringMetadata } from '../../models/commands/concreteargumentmetadata';
 
 const args = {
   globs: new StringArrayMetadata({
-    displayName: 'Globs to Scan',
     description:
       'specify globs to scan for translations, instead of using the defaults',
     isRequired: false
   }),
   output: new StringMetadata({
-    displayName: 'Output Path',
     description: 'the output path to extract the .pot file to',
     isRequired: false,
     defaultValue: 'messages.pot'
@@ -48,16 +46,14 @@ const JamboTranslationExtractor: Command<typeof args> = class {
   static describe() {
     return {
       displayName: 'Extract Translations',
-      params: Object.keys(args).reduce((params, alias) => {
-        params[alias] = {
-          displayName: args[alias].displayName,
-          type: args[alias].type,
-          required: args[alias].isRequired,
-          default: args[alias].defaultValue,
-
+      params: {
+        globs: {
+          displayName: 'Globs to Scan',
+        },
+        output: {
+          displayName: 'Output Path',
         }
-        return params;
-      }, {})
+      }
     };
   }
 

--- a/src/commands/import/themeimporter.ts
+++ b/src/commands/import/themeimporter.ts
@@ -12,7 +12,7 @@ import { searchDirectoryIgnoringExtensions } from '../../utils/fileutils';
 import fsExtra from 'fs-extra';
 import process from 'process';
 import { JamboConfig } from '../../models/JamboConfig';
-import Command from '../../models/commands/command';
+import Command from '../../models/commands/Command';
 import { BooleanMetadata, StringMetadata } from '../../models/commands/concreteargumentmetadata';
 
 const args = {
@@ -30,7 +30,7 @@ const args = {
 /**
  * ThemeImporter imports a specified theme into the themes directory.
  */
-const ThemeImporter : Command<typeof args> = class {
+const ThemeImporter: Command<typeof args> = class {
   config: JamboConfig;
   private _postImportHook: 'postimport';
 
@@ -58,7 +58,6 @@ const ThemeImporter : Command<typeof args> = class {
       params: {
         themeUrl: {
           displayName: 'URL',
-          type: 'string',
         },
         theme: {
           displayName: 'Theme',
@@ -67,10 +66,9 @@ const ThemeImporter : Command<typeof args> = class {
         },
         useSubmodules: {
           displayName: 'Use Submodules',
-          type: 'boolean'
         }
       }
-    }
+    } as const;
   }
 
   async execute(args: {

--- a/src/commands/import/themeimporter.ts
+++ b/src/commands/import/themeimporter.ts
@@ -14,6 +14,7 @@ import process from 'process';
 import { JamboConfig } from '../../models/JamboConfig';
 import Command from '../../models/commands/Command';
 import { BooleanMetadata, StringMetadata } from '../../models/commands/concreteargumentmetadata';
+import DescribeDefinition from '../../models/commands/DescribeDefinition';
 
 const args = {
   themeUrl: new StringMetadata({
@@ -51,7 +52,7 @@ const ThemeImporter: Command<typeof args> = class {
     return args;
   }
 
-  static describe() {
+  static describe(): DescribeDefinition<typeof args> {
     const importableThemes = ThemeManager.getKnownThemes();
     return {
       displayName: 'Import Theme',
@@ -68,7 +69,7 @@ const ThemeImporter: Command<typeof args> = class {
           displayName: 'Use Submodules',
         }
       }
-    } as const;
+    };
   }
 
   async execute(args: {

--- a/src/commands/init/initcommand.ts
+++ b/src/commands/init/initcommand.ts
@@ -2,6 +2,7 @@ import { RepositoryScaffolder, RepositorySettings } from './repositoryscaffolder
 import ThemeManager from '../../utils/thememanager';
 import Command from '../../models/commands/Command';
 import { BooleanMetadata, StringMetadata } from '../../models/commands/concreteargumentmetadata';
+import DescribeDefinition from '../../models/commands/DescribeDefinition';
 
 const args = {
   themeUrl: new StringMetadata({
@@ -36,7 +37,7 @@ const InitCommand: Command<typeof args> = class {
     return args;
   }
 
-  static describe() {
+  static describe(): DescribeDefinition<typeof args> {
     const importableThemes = ThemeManager.getKnownThemes();
     return {
       displayName: 'Initialize Jambo',
@@ -56,7 +57,7 @@ const InitCommand: Command<typeof args> = class {
           displayName: 'Include Translations'
         }
       }
-    } as const;
+    };
   }
 
   async execute(args: RepositorySettings) {

--- a/src/commands/init/initcommand.ts
+++ b/src/commands/init/initcommand.ts
@@ -1,6 +1,6 @@
 import { RepositoryScaffolder, RepositorySettings } from './repositoryscaffolder';
 import ThemeManager from '../../utils/thememanager';
-import Command from '../../models/commands/command';
+import Command from '../../models/commands/Command';
 import { BooleanMetadata, StringMetadata } from '../../models/commands/concreteargumentmetadata';
 
 const args = {
@@ -42,8 +42,7 @@ const InitCommand: Command<typeof args> = class {
       displayName: 'Initialize Jambo',
       params: {
         themeUrl: {
-          displayName: 'URL',
-          type: 'string',
+          displayName: 'URL'
         },
         theme: {
           displayName: 'Theme',
@@ -51,15 +50,13 @@ const InitCommand: Command<typeof args> = class {
           options: importableThemes
         },
         useSubmodules: {
-          displayName: 'Use Submodules',
-          type: 'boolean'
+          displayName: 'Use Submodules'
         },
         includeTranslations: {
-          displayName: 'Include Translations',
-          type: 'boolean'
-        },
+          displayName: 'Include Translations'
+        }
       }
-    }
+    } as const;
   }
 
   async execute(args: RepositorySettings) {

--- a/src/commands/override/overridecommand.ts
+++ b/src/commands/override/overridecommand.ts
@@ -5,6 +5,7 @@ import { ShadowConfiguration, ThemeShadower } from './themeshadower';
 import { JamboConfig } from '../../models/JamboConfig';
 import Command from '../../models/commands/Command';
 import { StringMetadata } from '../../models/commands/concreteargumentmetadata';
+import DescribeDefinition from '../../models/commands/DescribeDefinition';
 
 const args = {
   path: new StringMetadata({
@@ -37,7 +38,7 @@ const OverrideCommand: Command<typeof args> = class {
     return args;
   }
 
-  static describe(jamboConfig) {
+  static describe(jamboConfig): DescribeDefinition<typeof args> {
     const themeFiles = this._getThemeFiles(jamboConfig);
     return {
       displayName: 'Override Theme',
@@ -48,7 +49,7 @@ const OverrideCommand: Command<typeof args> = class {
           options: themeFiles
         }
       }
-    } as const;
+    };
   }
 
   /**

--- a/src/commands/override/overridecommand.ts
+++ b/src/commands/override/overridecommand.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import fileSystem from 'file-system';
 import { ShadowConfiguration, ThemeShadower } from './themeshadower';
 import { JamboConfig } from '../../models/JamboConfig';
-import Command from '../../models/commands/command';
+import Command from '../../models/commands/Command';
 import { StringMetadata } from '../../models/commands/concreteargumentmetadata';
 
 const args = {
@@ -45,11 +45,10 @@ const OverrideCommand: Command<typeof args> = class {
         path: {
           displayName: 'Path to Override',
           type: 'filesystem',
-          required: true,
           options: themeFiles
         }
       }
-    }
+    } as const;
   }
 
   /**

--- a/src/commands/page/add/pagecommand.ts
+++ b/src/commands/page/add/pagecommand.ts
@@ -5,7 +5,7 @@ import UserError from '../../../errors/usererror';
 import { JamboConfig } from '../../../models/JamboConfig';
 import PageScaffolder from './pagescaffolder';
 import { StringArrayMetadata, StringMetadata } from '../../../models/commands/concreteargumentmetadata';
-import Command from '../../../models/commands/command';
+import Command from '../../../models/commands/Command';
 import PageConfiguration from './pageconfiguration';
 
 const args = {
@@ -56,9 +56,7 @@ const PageCommand: Command<typeof args> = class {
       displayName: 'Add Page',
       params: {
         name: {
-          displayName: 'Page Name',
-          type: 'string',
-          required: true
+          displayName: 'Page Name'
         },
         template: {
           displayName: 'Page Template',
@@ -70,8 +68,8 @@ const PageCommand: Command<typeof args> = class {
           type: 'multioption',
           options: pageLocales
         }
-      }
-    }
+      } as const
+    };
   }
 
   /**

--- a/src/commands/page/add/pagecommand.ts
+++ b/src/commands/page/add/pagecommand.ts
@@ -7,6 +7,7 @@ import PageScaffolder from './pagescaffolder';
 import { StringArrayMetadata, StringMetadata } from '../../../models/commands/concreteargumentmetadata';
 import Command from '../../../models/commands/Command';
 import PageConfiguration from './pageconfiguration';
+import DescribeDefinition from '../../../models/commands/DescribeDefinition';
 
 const args = {
   name: new StringMetadata({
@@ -49,14 +50,14 @@ const PageCommand: Command<typeof args> = class {
     return args;
   }
 
-  static describe(jamboConfig) {
+  static describe(jamboConfig): DescribeDefinition<typeof args> {
     const pageTemplates = this._getPageTemplates(jamboConfig);
     const pageLocales = this._getAdditionalPageLocales(jamboConfig);
     return {
       displayName: 'Add Page',
       params: {
         name: {
-          displayName: 'Page Name'
+          displayName: 'Page Name',
         },
         template: {
           displayName: 'Page Template',
@@ -68,7 +69,7 @@ const PageCommand: Command<typeof args> = class {
           type: 'multioption',
           options: pageLocales
         }
-      } as const
+      }
     };
   }
 

--- a/src/commands/upgrade/themeupgrader.ts
+++ b/src/commands/upgrade/themeupgrader.ts
@@ -13,6 +13,7 @@ import { info } from '../../utils/logger';
 import { JamboConfig } from '../../models/JamboConfig';
 import Command from '../../models/commands/Command';
 import { BooleanMetadata, StringMetadata } from '../../models/commands/concreteargumentmetadata';
+import DescribeDefinition from '../../models/commands/DescribeDefinition';
 
 const git = simpleGit();
 const args = {
@@ -59,7 +60,7 @@ const ThemeUpgrader: Command<typeof args> = class {
     return args;
   }
 
-  static describe() {
+  static describe(): DescribeDefinition<typeof args> {
     return {
       displayName: 'Upgrade Theme',
       params: {

--- a/src/commands/upgrade/themeupgrader.ts
+++ b/src/commands/upgrade/themeupgrader.ts
@@ -11,7 +11,7 @@ import { searchDirectoryIgnoringExtensions } from '../../utils/fileutils';
 import fsExtra from 'fs-extra';
 import { info } from '../../utils/logger';
 import { JamboConfig } from '../../models/JamboConfig';
-import Command from '../../models/commands/command';
+import Command from '../../models/commands/Command';
 import { BooleanMetadata, StringMetadata } from '../../models/commands/concreteargumentmetadata';
 
 const git = simpleGit();
@@ -36,7 +36,7 @@ const args = {
  * version. It first detects whether the theme was imported as a submodule or raw files,
  * then handles the upgrade accordingly.
  */
-const ThemeUpgrader : Command<typeof args> = class {
+const ThemeUpgrader: Command<typeof args> = class {
   jamboConfig: JamboConfig;
   private _themesDir: string;
   postUpgradeFileName: 'upgrade';
@@ -59,22 +59,18 @@ const ThemeUpgrader : Command<typeof args> = class {
     return args;
   }
 
-  static async describe() {
+  static describe() {
     return {
       displayName: 'Upgrade Theme',
       params: {
         isLegacy: {
           displayName: 'Is Legacy Upgrade',
-          type: 'boolean'
         },
         disableScript: {
           displayName: 'Disable Upgrade Script',
-          type: 'boolean'
         },
         branch: {
-          displayName: 'Branch of theme to upgrade to',
-          type: 'string',
-          default: 'master'
+          displayName: 'Branch of theme to upgrade to'
         }
       }
     }

--- a/src/models/commands/ArgumentMetadata.ts
+++ b/src/models/commands/ArgumentMetadata.ts
@@ -19,9 +19,4 @@ export interface ArgumentMetadata<T extends ArgumentType> {
    * Optional, a default value for the argument.
    */
   defaultValue?: T
-
-  /**
-   * The display name for the argument.
-   */
-  displayName?: string
 }

--- a/src/models/commands/Command.ts
+++ b/src/models/commands/Command.ts
@@ -32,5 +32,5 @@ export default interface Command<T extends ArgumentMetadataRecord> {
    * @returns {Object} description of the card command, including paths to
    *                   all available cards. returning null causes no description to be output.
    */
-  describe(jamboConfig: JamboConfig): null | DescribeDefinition<T>;
+  describe(jamboConfig: JamboConfig): null | DescribeDefinition<T> | Promise<DescribeDefinition<T>>;
 }

--- a/src/models/commands/Command.ts
+++ b/src/models/commands/Command.ts
@@ -1,7 +1,7 @@
 import { JamboConfig } from '../JamboConfig';
 import { ArgumentMetadataRecord } from './concreteargumentmetadata';
 import { CommandExecutable } from './commandexecutable';
-
+import DescribeDefinition from './DescribeDefinition';
 
 /**
  * An interface that represents a command in the Jambo CLI.
@@ -30,7 +30,7 @@ export default interface Command<T extends ArgumentMetadataRecord> {
   /**
    * @param {Object} jamboConfig the config of the jambo repository
    * @returns {Object} description of the card command, including paths to
-   *                   all available cards
+   *                   all available cards. returning null causes no description to be output.
    */
-  describe(jamboConfig: JamboConfig): any;
+  describe(jamboConfig: JamboConfig): null | DescribeDefinition<T>;
 }

--- a/src/models/commands/DescribeDefinition.ts
+++ b/src/models/commands/DescribeDefinition.ts
@@ -29,16 +29,30 @@ export type DescribeDefinitionParam<T extends ConcreteArgumentMetadata> =
   T extends NumberMetadata ? DescribeParamForPrimitive<'number'> :
   never;
 
-interface DescribeParamForPrimitive<T extends 'string' | 'number' | 'boolean'> {
+type DeprecatedDescribeParamTypes = 'string' | 'number' | 'boolean'
+
+type DescribeParamForPrimitive<T extends 'string' | 'number' | 'boolean'> = {
   displayName: string
   options?: StringToPrimitiveType<T>[]
-  type?: 'singleoption' | 'filesystem'
+  /**
+   * @note 'string', 'number', and 'boolean' are deprecated
+   * These types can be automatically inferred from Command.args()
+   **/
+  type?: 'singleoption' | 'filesystem' | DeprecatedDescribeParamTypes
+  /** @deprecated - specify in Command.args() instead */
+  required?: boolean,
+  /** @deprecated - specify in Command.args() instead */
+  default?: StringToPrimitiveType<T>
 }
 
 interface DescribeParamForArray<T extends 'string' | 'number' | 'boolean'> {
   displayName: string
   options?: StringToPrimitiveType<T>[]
   type?: 'multioption'
+  /** @deprecated - specify in Command.args() instead */
+  required?: boolean,
+  /** @deprecated - specify in Command.args() instead */
+  default?: StringToPrimitiveType<T>[]
 }
 
 type StringToPrimitiveType<T extends 'string' | 'number' | 'boolean'> = {

--- a/src/models/commands/DescribeDefinition.ts
+++ b/src/models/commands/DescribeDefinition.ts
@@ -1,0 +1,48 @@
+import {
+  ArgumentMetadataRecord,
+  StringArrayMetadata,
+  BooleanArrayMetadata,
+  NumberArrayMetadata,
+  ConcreteArgumentMetadata,
+  StringMetadata,
+  BooleanMetadata,
+  NumberMetadata
+} from './concreteargumentmetadata';
+
+/**
+ * DescribeOutput provides static type checking for a {@link Command}'s describe(),
+ * and ensures that the return value matches the same shape as the {@link Command}'s args.
+ */
+export default interface DescribeDefinition<T extends ArgumentMetadataRecord> {
+  displayName: string
+  params?: {
+    [arg in keyof T]: DescribeDefinitionParam<T[arg]>
+  }
+}
+
+export type DescribeDefinitionParam<T extends ConcreteArgumentMetadata> =
+  T extends StringArrayMetadata ? DescribeParamForArray<'string'> :
+  T extends BooleanArrayMetadata ? DescribeParamForArray<'boolean'> :
+  T extends NumberArrayMetadata ? DescribeParamForArray<'number'> :
+  T extends StringMetadata ? DescribeParamForPrimitive<'string'> :
+  T extends BooleanMetadata ? DescribeParamForPrimitive<'boolean'> :
+  T extends NumberMetadata ? DescribeParamForPrimitive<'number'> :
+  never;
+
+interface DescribeParamForPrimitive<T extends 'string' | 'number' | 'boolean'> {
+  displayName: string
+  options?: StringToPrimitiveType<T>[]
+  type?: 'singleoption' | 'filesystem'
+}
+
+interface DescribeParamForArray<T extends 'string' | 'number' | 'boolean'> {
+  displayName: string
+  options?: StringToPrimitiveType<T>[]
+  type?: 'multioption'
+}
+
+type StringToPrimitiveType<T extends 'string' | 'number' | 'boolean'> = {
+  string: string,
+  number: number,
+  boolean: boolean
+}[T]

--- a/src/models/commands/DescribeDefinition.ts
+++ b/src/models/commands/DescribeDefinition.ts
@@ -13,7 +13,7 @@ import {
  * DescribeOutput provides static type checking for a {@link Command}'s describe(),
  * and ensures that the return value matches the same shape as the {@link Command}'s args.
  */
-export default interface DescribeDefinition<T extends ArgumentMetadataRecord> {
+export default interface DescribeDefinition<T extends ArgumentMetadataRecord = ArgumentMetadataRecord> {
   displayName: string
   params?: {
     [arg in keyof T]: DescribeDefinitionParam<T[arg]>
@@ -21,19 +21,19 @@ export default interface DescribeDefinition<T extends ArgumentMetadataRecord> {
 }
 
 export type DescribeDefinitionParam<T extends ConcreteArgumentMetadata> =
-  T extends StringArrayMetadata ? DescribeParamForArray<'string'> :
-  T extends BooleanArrayMetadata ? DescribeParamForArray<'boolean'> :
-  T extends NumberArrayMetadata ? DescribeParamForArray<'number'> :
-  T extends StringMetadata ? DescribeParamForPrimitive<'string'> :
-  T extends BooleanMetadata ? DescribeParamForPrimitive<'boolean'> :
-  T extends NumberMetadata ? DescribeParamForPrimitive<'number'> :
+  T extends StringArrayMetadata ? DescribeParamForArray<string> :
+  T extends BooleanArrayMetadata ? DescribeParamForArray<boolean> :
+  T extends NumberArrayMetadata ? DescribeParamForArray<number> :
+  T extends StringMetadata ? DescribeParamForPrimitive<string> :
+  T extends BooleanMetadata ? DescribeParamForPrimitive<boolean> :
+  T extends NumberMetadata ? DescribeParamForPrimitive<number> :
   never;
 
 type DeprecatedDescribeParamTypes = 'string' | 'number' | 'boolean'
 
-type DescribeParamForPrimitive<T extends 'string' | 'number' | 'boolean'> = {
+type DescribeParamForPrimitive<T extends string | number | boolean> = {
   displayName: string
-  options?: StringToPrimitiveType<T>[]
+  options?: T[]
   /**
    * @note 'string', 'number', and 'boolean' are deprecated
    * These types can be automatically inferred from Command.args()
@@ -42,21 +42,15 @@ type DescribeParamForPrimitive<T extends 'string' | 'number' | 'boolean'> = {
   /** @deprecated - specify in Command.args() instead */
   required?: boolean,
   /** @deprecated - specify in Command.args() instead */
-  default?: StringToPrimitiveType<T>
+  default?: T
 }
 
-interface DescribeParamForArray<T extends 'string' | 'number' | 'boolean'> {
+interface DescribeParamForArray<T extends string | number | boolean> {
   displayName: string
-  options?: StringToPrimitiveType<T>[]
+  options?: T[]
   type?: 'multioption'
   /** @deprecated - specify in Command.args() instead */
   required?: boolean,
   /** @deprecated - specify in Command.args() instead */
-  default?: StringToPrimitiveType<T>[]
+  default?: T[]
 }
-
-type StringToPrimitiveType<T extends 'string' | 'number' | 'boolean'> = {
-  string: string,
-  number: number,
-  boolean: boolean
-}[T]

--- a/src/models/commands/commandexecutable.ts
+++ b/src/models/commands/commandexecutable.ts
@@ -10,13 +10,13 @@ import {
 
 type ExecArgs<T extends ArgumentMetadataRecord> = {
   [arg in keyof T]:
-  T[arg] extends StringMetadata ? string :
-  T[arg] extends StringArrayMetadata ? string[] :
-  T[arg] extends BooleanMetadata ? boolean :
-  T[arg] extends BooleanArrayMetadata ? boolean[] :
-  T[arg] extends NumberMetadata ? number :
-  T[arg] extends NumberArrayMetadata ? number[] :
-  never;
+    T[arg] extends StringMetadata ? string :
+    T[arg] extends StringArrayMetadata ? string[] :
+    T[arg] extends BooleanMetadata ? boolean :
+    T[arg] extends BooleanArrayMetadata ? boolean[] :
+    T[arg] extends NumberMetadata ? number :
+    T[arg] extends NumberArrayMetadata ? number[] :
+    never;
 }
 
 /**

--- a/src/yargsfactory.ts
+++ b/src/yargsfactory.ts
@@ -4,7 +4,7 @@ import SitesGenerator from './commands/build/sitesgenerator';
 import { info, error } from './utils/logger';
 import { exitWithError } from './utils/errorutils';
 import CommandRegistry from './commands/commandregistry';
-import Command from './models/commands/command';
+import Command from './models/commands/Command';
 import { JamboConfig } from './models/JamboConfig';
 import DescribeCommand from './commands/describe/describecommand';
 import PageCommand from './commands/page/add/pagecommand';

--- a/tests/acceptance/fixtures/describe/describe-test.json
+++ b/tests/acceptance/fixtures/describe/describe-test.json
@@ -3,23 +3,24 @@
     "displayName": "Initialize Jambo",
     "params": {
       "themeUrl": {
-        "displayName": "URL",
-        "type": "string"
+        "type": "string",
+        "displayName": "URL"
       },
       "theme": {
-        "displayName": "Theme",
+        "required": false,
         "type": "singleoption",
+        "displayName": "Theme",
         "options": [
           "answers-hitchhiker-theme"
         ]
       },
-      "includeTranslations": {
-        "displayName": "Include Translations",
-        "type": "boolean"
-      },
       "useSubmodules": {
-        "displayName": "Use Submodules",
-        "type": "boolean"
+        "type": "boolean",
+        "displayName": "Use Submodules"
+      },
+      "includeTranslations": {
+        "type": "boolean",
+        "displayName": "Include Translations"
       }
     }
   },
@@ -27,19 +28,19 @@
     "displayName": "Import Theme",
     "params": {
       "themeUrl": {
-        "displayName": "URL",
-        "type": "string"
+        "type": "string",
+        "displayName": "URL"
       },
       "theme": {
-        "displayName": "Theme",
         "type": "singleoption",
+        "displayName": "Theme",
         "options": [
           "answers-hitchhiker-theme"
         ]
       },
       "useSubmodules": {
-        "displayName": "Use Submodules",
-        "type": "boolean"
+        "type": "boolean",
+        "displayName": "Use Submodules"
       }
     }
   },
@@ -47,20 +48,22 @@
     "displayName": "Add Page",
     "params": {
       "name": {
-        "displayName": "Page Name",
+        "required": true,
         "type": "string",
-        "required": true
+        "displayName": "Page Name"
       },
       "template": {
-        "displayName": "Page Template",
+        "required": false,
         "type": "singleoption",
+        "displayName": "Page Template",
         "options": [
           "describe-template"
         ]
       },
       "locales": {
-        "displayName": "Additional Page Locales",
+        "required": false,
         "type": "multioption",
+        "displayName": "Additional Page Locales",
         "options": []
       }
     }
@@ -69,9 +72,9 @@
     "displayName": "Override Theme",
     "params": {
       "path": {
-        "displayName": "Path to Override",
-        "type": "filesystem",
         "required": true,
+        "type": "filesystem",
+        "displayName": "Path to Override",
         "options": [
           "commands/addVertical.js",
           "commands/addVerticalLegacyArgs.js",
@@ -85,19 +88,40 @@
   "build": {
     "displayName": "Build Pages"
   },
+  "upgrade": {
+    "displayName": "Upgrade Theme",
+    "params": {
+      "isLegacy": {
+        "required": false,
+        "type": "boolean",
+        "displayName": "Is Legacy Upgrade"
+      },
+      "disableScript": {
+        "required": false,
+        "type": "boolean",
+        "displayName": "Disable Upgrade Script"
+      },
+      "branch": {
+        "required": false,
+        "default": "master",
+        "type": "string",
+        "displayName": "Branch of theme to upgrade to"
+      }
+    }
+  },
   "extract-translations": {
     "displayName": "Extract Translations",
     "params": {
       "globs": {
-        "displayName": "Globs to Scan",
         "required": false,
-        "type": "array"
+        "type": "array",
+        "displayName": "Globs to Scan"
       },
       "output": {
-        "displayName": "Output Path",
-        "type": "string",
         "required": false,
-        "default": "messages.pot"
+        "default": "messages.pot",
+        "type": "string",
+        "displayName": "Output Path"
       }
     }
   },
@@ -105,27 +129,30 @@
     "displayName": "Add Vertical",
     "params": {
       "name": {
-        "displayName": "Page Name",
         "required": true,
-        "type": "string"
+        "type": "string",
+        "displayName": "Page Name"
       },
       "verticalKey": {
-        "displayName": "Vertical Key",
         "required": true,
-        "type": "string"
+        "type": "string",
+        "displayName": "Vertical Key"
       },
       "cardName": {
-        "displayName": "Card Name",
-        "type": "singleoption"
+        "required": false,
+        "type": "singleoption",
+        "displayName": "Card Name"
       },
       "template": {
-        "displayName": "Page Template",
         "required": true,
-        "type": "singleoption"
+        "type": "singleoption",
+        "displayName": "Page Template"
       },
       "locales": {
-        "displayName": "Additional Page Locales",
-        "type": "multioption"
+        "required": false,
+        "default": [],
+        "type": "multioption",
+        "displayName": "Additional Page Locales"
       }
     }
   },
@@ -133,45 +160,30 @@
     "displayName": "Add Vertical",
     "params": {
       "name": {
-        "displayName": "Page Name",
         "required": true,
-        "type": "string"
+        "type": "string",
+        "displayName": "Page Name"
       },
       "verticalKey": {
-        "displayName": "Vertical Key",
         "required": true,
-        "type": "string"
+        "type": "string",
+        "displayName": "Vertical Key"
       },
       "cardName": {
-        "displayName": "Card Name",
-        "type": "singleoption"
+        "required": false,
+        "type": "singleoption",
+        "displayName": "Card Name"
       },
       "template": {
-        "displayName": "Page Template",
         "required": true,
-        "type": "singleoption"
+        "type": "singleoption",
+        "displayName": "Page Template"
       },
       "locales": {
-        "displayName": "Additional Page Locales",
-        "type": "multioption"
-      }
-    }
-  },
-  "upgrade": {
-    "displayName": "Upgrade Theme",
-    "params": {
-      "isLegacy": {
-        "displayName": "Is Legacy Upgrade",
-        "type": "boolean"
-      },
-      "disableScript": {
-        "displayName": "Disable Upgrade Script",
-        "type": "boolean"
-      },
-      "branch": {
-        "displayName": "Branch of theme to upgrade to",
-        "type": "string",
-        "default": "master"
+        "required": false,
+        "default": [],
+        "type": "multioption",
+        "displayName": "Additional Page Locales"
       }
     }
   }

--- a/tests/acceptance/test-themes/customcommand/commands/addVertical.js
+++ b/tests/acceptance/test-themes/customcommand/commands/addVertical.js
@@ -62,14 +62,10 @@ module.exports = class VerticalAdder {
       displayName: 'Add Vertical',
       params: {
         name: {
-          displayName: 'Page Name',
-          required: true,
-          type: 'string'
+          displayName: 'Page Name'
         },
         verticalKey: {
-          displayName: 'Vertical Key',
-          required: true,
-          type: 'string',
+          displayName: 'Vertical Key'
         },
         cardName: {
           displayName: 'Card Name',
@@ -77,7 +73,6 @@ module.exports = class VerticalAdder {
         },
         template: {
           displayName: 'Page Template',
-          required: true,
           type: 'singleoption'
         },
         locales: {

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -1,8 +1,19 @@
 import DescribeCommand from '../../../src/commands/describe/describecommand';
+import { BooleanMetadata, StringMetadata } from '../../../src/models/commands/concreteargumentmetadata';
 
 const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 const mockJamboConfig = {};
 const mockInitCommand = {
+  args() {
+    return {
+      theme: new StringMetadata({
+        description: 'the theme'
+      }),
+      useSubmodules: new BooleanMetadata({
+        description: 'use submodules'
+      })
+    }
+  },
   getAlias() {
     return 'init';
   },
@@ -17,7 +28,6 @@ const mockInitCommand = {
         },
         useSubmodules: {
           displayName: 'Use Submodules',
-          type: 'boolean'
         }
       }
     }

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -2,48 +2,44 @@ import DescribeCommand from '../../../src/commands/describe/describecommand';
 import { BooleanMetadata, StringMetadata } from '../../../src/models/commands/concreteargumentmetadata';
 
 const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-const mockJamboConfig = {};
-const mockInitCommand = {
-  args() {
-    return {
-      theme: new StringMetadata({
-        description: 'the theme'
-      }),
-      useSubmodules: new BooleanMetadata({
-        description: 'use submodules'
-      })
-    }
-  },
-  getAlias() {
-    return 'init';
-  },
-  describe() {
-    return {
-      displayName: 'Initialize Jambo',
-      params: {
-        theme: {
-          displayName: 'Theme',
-          type: 'singleoption',
-          options: ['answers-hitchhiker-theme']
-        },
-        useSubmodules: {
-          displayName: 'Use Submodules',
+
+describe('DescribeCommand can describe a simple command', () => {
+  const mockInitCommand = {
+    args() {
+      return {
+        theme: new StringMetadata({
+          description: 'the theme',
+          isRequired: true
+        }),
+        useSubmodules: new BooleanMetadata({
+          description: 'use submodules'
+        })
+      }
+    },
+    getAlias() {
+      return 'init';
+    },
+    describe() {
+      return {
+        displayName: 'Initialize Jambo',
+        params: {
+          theme: {
+            displayName: 'Theme',
+            type: 'singleoption',
+            options: ['answers-hitchhiker-theme']
+          },
+          useSubmodules: {
+            displayName: 'Use Submodules',
+          }
         }
       }
     }
   }
-}
-
-describe('DescribeCommand works correctly', () => {
   let descriptions;
   beforeAll(async () => {
-    await new DescribeCommand(
-      mockJamboConfig,
-      () => [
-        mockInitCommand,
-      ],
-    ).execute();
+    await new DescribeCommand({}, () => [ mockInitCommand ]).execute();
     descriptions = JSON.parse(consoleSpy.mock.calls[0][0]);
+    consoleSpy.mockClear();
   })
 
   it('describes all provided commands and nothing more', () => {
@@ -60,6 +56,7 @@ describe('DescribeCommand works correctly', () => {
       params: {
         theme: {
           displayName: 'Theme',
+          required: true,
           type: 'singleoption',
           options: ['answers-hitchhiker-theme']
         },
@@ -71,3 +68,48 @@ describe('DescribeCommand works correctly', () => {
     });
   });
 });
+
+it('deprecated params in a command\'s DescribeDefinition ' +
+'take precedence over params inferred from that command\'s args()', async () => {
+  const mockCommand = {
+    args() {
+      return {
+        myParam: new StringMetadata({
+          description: 'the theme',
+          isRequired: false,
+          defaultValue: 'dont show me in describe'
+        })
+      }
+    },
+    getAlias() { return 'mocked'; },
+    describe() {
+      return {
+        displayName: 'lol mocked',
+        params: {
+          myParam: {
+            displayName: 'MY PARAM',
+            required: false,
+            default: 82,
+            type: 'number'
+          },
+        }
+      }
+    }
+  }
+
+  await new DescribeCommand({}, () => [ mockCommand ]).execute();
+  const descriptions = JSON.parse(consoleSpy.mock.calls[0][0]);
+  consoleSpy.mockClear();
+
+  expect(descriptions.mocked).toEqual({
+    displayName: 'lol mocked',
+    params: {
+      myParam: {
+        displayName: 'MY PARAM',
+        required: false,
+        default: 82,
+        type: 'number',
+      }
+    }
+  });
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "allowJs": true,
     "declaration": true,
     "declarationMap": true,
-    "lib": ["es2019"]
+    "lib": ["es2019"],
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
This commit updates describecommand to combine information from args
with the return value of describe (a DescribeDefinition) to produce
an instance of DescribeOutput, which is the full output to be used
by UI like sitesgitstorm.

J=SLAP-1493
TEST=manual,auto

test that all jambo card, page, vertical, and build commands work in SGS
test that I can run custom commands locally