### PR TITLE
Warn when translation file is not found

### DIFF
--- a/src/commands/build/sitesgenerator.ts
+++ b/src/commands/build/sitesgenerator.ts
@@ -321,22 +321,19 @@ class SitesGenerator {
     const translations = {};
 
     for (const locale of locales) {
-      let translationFileName = `${locale}.po`;
-      let translationFilePath = path.join(translationsDir, translationFileName);
-
-      const customTranslationFileName = localizationConfig.getTranslationFile(locale);
-      if (customTranslationFileName) {
-        translationFileName = customTranslationFileName;
-        translationFilePath = path.join(translationsDir, translationFileName);
-        if (!fs.existsSync(translationFilePath)) {
-          warn(`Failed to find custom translation file for '${locale}' at '${translationFilePath}'`);
-        }
+      const translationFileName =
+        localizationConfig.getTranslationFile(locale) || `${locale}.po`;
+      const translationFilePath = path.join(translationsDir, translationFileName);
+      if (!fs.existsSync(translationFilePath)) {
+        warn(`Failed to find custom translation file for '${locale}' at '${translationFilePath}'`);
       }
-      const isDefaultLocale = (locale === localizationConfig.getDefaultLocale());
-      if (!isDefaultLocale && fs.existsSync(translationFilePath)) {
-        const localeTranslations = await localFileParser
-          .fetch(locale, translationFileName);
-        translations[locale] = { translation: localeTranslations };
+      else {
+        const isDefaultLocale = (locale === localizationConfig.getDefaultLocale());
+        if (!isDefaultLocale) {
+          const localeTranslations = await localFileParser
+            .fetch(locale, translationFileName);
+          translations[locale] = { translation: localeTranslations };
+        }
       }
     }
 
@@ -364,6 +361,9 @@ class SitesGenerator {
         const localeTranslations = await localFileParser
           .fetch(locale, translationFileName);
         translations[locale] = { translation: localeTranslations };
+      }
+      else {
+        warn(`Failed to find theme translation file for '${locale}' at '${translationFilePath}'`);
       }
     }
 

--- a/src/commands/build/sitesgenerator.ts
+++ b/src/commands/build/sitesgenerator.ts
@@ -20,7 +20,7 @@ import registerCustomHbsHelpers from '../../handlebars/registercustomhbshelpers'
 import SystemError from '../../errors/systemerror';
 import Translator from '../../i18n/translator/translator';
 import UserError from '../../errors/usererror';
-import { info } from '../../utils/logger';
+import { info, warn } from '../../utils/logger';
 import { JamboConfig } from '../../models/JamboConfig';
 
 class SitesGenerator {
@@ -321,9 +321,17 @@ class SitesGenerator {
     const translations = {};
 
     for (const locale of locales) {
-      const translationFileName =
-        localizationConfig.getTranslationFile(locale) || `${locale}.po`;
-      const translationFilePath = path.join(translationsDir, translationFileName);
+      let translationFileName = `${locale}.po`;
+      let translationFilePath = path.join(translationsDir, translationFileName);
+
+      const customTranslationFileName = localizationConfig.getTranslationFile(locale);
+      if (customTranslationFileName) {
+        translationFileName = customTranslationFileName;
+        translationFilePath = path.join(translationsDir, translationFileName);
+        if (!fs.existsSync(translationFilePath)) {
+          warn(`Failed to find custom translation file for '${locale}' at '${translationFilePath}'`);
+        }
+      }
       const isDefaultLocale = (locale === localizationConfig.getDefaultLocale());
       if (!isDefaultLocale && fs.existsSync(translationFilePath)) {
         const localeTranslations = await localFileParser

--- a/tests/commands/build/sitesgenerator.js
+++ b/tests/commands/build/sitesgenerator.js
@@ -1,0 +1,73 @@
+import SitesGenerator from '../../../src/commands/build/sitesgenerator'
+import LocalizationConfig from '../../../src/models/localizationconfig';
+import path from 'path';
+import log from 'npmlog';
+
+const warnSpy = jest.spyOn(log, 'warn').mockImplementation();
+
+describe('_extractCustomTranslations gives warning if file not found', () => {
+  const jamboConfig = {
+    dirs: {
+      themes: '../../',
+      config: 'config',
+      output: 'public',
+      pages: 'pages',
+      partials: [
+        'script/on-ready.js',
+        'cards',
+        'directanswercards'
+      ],
+      preservedFiles: [
+        'public/iframe_test.html',
+        'public/overlay.html'
+      ],
+      translations: path.resolve(
+        __dirname, '../../fixtures/translations/')
+    },
+    defaultTheme: 'answers-hitchhiker-theme'
+  };
+
+  const config = new LocalizationConfig({
+    default: 'en',
+    localeConfig: {
+      en: {
+        // "fallback": [""], // allows you to specify locale fallbacks for this locale
+        // "translationFile": "<filepath>.po", // the filepath for the translation file
+        experienceKey: 'testkey' //  the unique key of your search configuration for this locale
+      },
+      fr: {
+        // "fallback": [""], // allows you to specify locale fallbacks for this locale
+        translationFile: 'fr-FR.po', // the filepath for the translation file
+        experienceKey: 'testkey-fr' //  the unique key of your search configuration for this locale
+      },
+      es: {
+        // fallback: ["fr"], // allows you to specify locale fallbacks for this locale
+        translationFile: 'dummyFile.po', // the filepath for the translation file
+        experienceKey: 'testkey-es' //  the unique key of your search configuration for this locale
+      }
+    },
+    urlFormat: {
+      baseLocale: '{locale}/{pageName}.{pageExt}',
+      default: '{pageName}.{pageExt}'
+    }
+  });
+
+  const sg = new SitesGenerator(jamboConfig);
+
+  beforeAll(() => {
+    warnSpy.mockClear();
+  });
+
+  it('warns when translationFile specified in locale_config is not found', async () => {
+    const translations = await sg._extractCustomTranslations(['en', 'es'], config);
+    expect(log.warn).toHaveBeenLastCalledWith('',
+      `Failed to find custom translation file for 'es' at '${path.join(jamboConfig.dirs.translations, 'dummyFile.po')}'`
+    );
+    expect(translations).toEqual({});
+  });
+
+  it ('finds translationFile specified in locale_config', async () => {
+    const translations = await sg._extractCustomTranslations(['en', 'fr'], config);
+    expect(translations['fr']).toBeDefined();
+  });
+});

--- a/tests/commands/build/sitesgenerator.js
+++ b/tests/commands/build/sitesgenerator.js
@@ -37,14 +37,24 @@ describe('_extractCustomTranslations gives warning if file not found', () => {
       },
       fr: {
         // "fallback": [""], // allows you to specify locale fallbacks for this locale
-        translationFile: 'fr-FR.po', // the filepath for the translation file
+        // "translationFile": "<filepath>.po", // the filepath for the translation file
         experienceKey: 'testkey-fr' //  the unique key of your search configuration for this locale
       },
       es: {
         // fallback: ["fr"], // allows you to specify locale fallbacks for this locale
         translationFile: 'dummyFile.po', // the filepath for the translation file
         experienceKey: 'testkey-es' //  the unique key of your search configuration for this locale
-      }
+      },
+      jp: {
+        // "fallback": [""], // allows you to specify locale fallbacks for this locale
+        // "translationFile": "<filepath>.po", // the filepath for the translation file
+        experienceKey: 'testkey-jp' //  the unique key of your search configuration for this locale
+      },
+      lt: {
+        // "fallback": [""], // allows you to specify locale fallbacks for this locale
+        translationFile: 'lt-LT.po', // the filepath for the translation file
+        experienceKey: 'testkey-lt' //  the unique key of your search configuration for this locale
+      },
     },
     urlFormat: {
       baseLocale: '{locale}/{pageName}.{pageExt}',
@@ -54,7 +64,7 @@ describe('_extractCustomTranslations gives warning if file not found', () => {
 
   const sg = new SitesGenerator(jamboConfig);
 
-  beforeAll(() => {
+  beforeEach(() => {
     warnSpy.mockClear();
   });
 
@@ -67,8 +77,63 @@ describe('_extractCustomTranslations gives warning if file not found', () => {
     expect(translations).toEqual({});
   });
 
+  it('warns when default translationFile is not found', async () => {
+    const translations = await sg._extractCustomTranslations(['jp'], config);
+    const translationFilePath = path.join(jamboConfig.dirs.translations, 'jp.po');
+    expect(log.warn).toHaveBeenLastCalledWith('',
+      `Failed to find custom translation file for 'jp' at '${translationFilePath}'`
+    );
+    expect(translations).toEqual({});
+  });
+
   it ('finds translationFile specified in locale_config', async () => {
+    const translations = await sg._extractCustomTranslations(['lt'], config);
+    expect(translations['lt']).toBeDefined();
+  });
+
+  it ('finds default translationFile', async () => {
     const translations = await sg._extractCustomTranslations(['en', 'fr'], config);
+    expect(translations['fr']).toBeDefined();
+  });
+});
+
+
+describe('_extractThemeTranslations gives warning if file not found', () => {
+  const jamboConfig = {
+    dirs: {
+      themes: path.resolve(
+        __dirname, '../../'),
+      config: 'config',
+      output: 'public',
+      pages: 'pages',
+      partials: [
+        'script/on-ready.js',
+        'cards',
+        'directanswercards'
+      ],
+      preservedFiles: [
+        'public/iframe_test.html',
+        'public/overlay.html'
+      ]
+    },
+    defaultTheme: 'fixtures'
+  };
+
+  const sg = new SitesGenerator(jamboConfig);
+
+  beforeEach(() => {
+    warnSpy.mockClear();
+  });
+
+  it('warns when theme translationFile is not found', async () => {
+    const translations = await sg._extractThemeTranslations(['en', 'es', 'fr']);
+    const themeTranslationsDir =
+      `${jamboConfig.dirs.themes}/${jamboConfig.defaultTheme}/translations`;
+    const translationFilePath = path.join(themeTranslationsDir, 'es.po');
+    expect(log.warn).toHaveBeenLastCalledWith('',
+      `Failed to find theme translation file for 'es' at '${translationFilePath}'`
+    );
+    expect(translations['es']).toBeUndefined();
     expect(translations['fr']).toBeDefined();
   });
 });

--- a/tests/commands/build/sitesgenerator.js
+++ b/tests/commands/build/sitesgenerator.js
@@ -60,8 +60,9 @@ describe('_extractCustomTranslations gives warning if file not found', () => {
 
   it('warns when translationFile specified in locale_config is not found', async () => {
     const translations = await sg._extractCustomTranslations(['en', 'es'], config);
+    const translationFilePath = path.join(jamboConfig.dirs.translations, 'dummyFile.po');
     expect(log.warn).toHaveBeenLastCalledWith('',
-      `Failed to find custom translation file for 'es' at '${path.join(jamboConfig.dirs.translations, 'dummyFile.po')}'`
+      `Failed to find custom translation file for 'es' at '${translationFilePath}'`
     );
     expect(translations).toEqual({});
   });


### PR DESCRIPTION
Log a warning during build when a custom or theme translation file is not found.

J=SLAP-1453
TEST=auto

Add jest tests and see that they pass successfully. Also build test-site with a non-existent translation file specified and see warning logged.