### PR TITLE
Allow custom translation for default locale

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -322,8 +322,7 @@ class SitesGenerator {
       const translationFileName = 
         localizationConfig.getTranslationFile(locale) || `${locale}.po`;
       const translationFilePath = path.join(translationsDir, translationFileName);
-      const isDefaultLocale = (locale === localizationConfig.getDefaultLocale());
-      if (!isDefaultLocale && fs.existsSync(translationFilePath)) {
+      if (fs.existsSync(translationFilePath)) {
         const localeTranslations = await localFileParser
           .fetch(locale, translationFileName);
         translations[locale] = { translation: localeTranslations };


### PR DESCRIPTION
- fix bug for use case where a default locale specify custom translation file (e.g. 'ja_JP' use 'ja.po' file)

J=TECHOPS-2099