### PR TITLE
Make describe optional

### DIFF
--- a/docs/jambo.command.describe.md
+++ b/docs/jambo.command.describe.md
@@ -9,7 +9,7 @@ Describes the command.
 <b>Signature:</b>
 
 ```typescript
-describe(jamboConfig: JamboConfig): null | DescribeMetadata<T> | Promise<DescribeMetadata<T>>;
+describe?(jamboConfig: JamboConfig): null | DescribeMetadata<T> | Promise<DescribeMetadata<T>>;
 ```
 
 ## Parameters

--- a/docs/jambo.command.md
+++ b/docs/jambo.command.md
@@ -18,7 +18,7 @@ export default interface Command<T extends ArgumentMetadataRecord>
 |  --- | --- |
 |  [(new)(args)](./jambo.command._new_.md) |  |
 |  [args()](./jambo.command.args.md) | Descriptions of each argument, keyed by name. |
-|  [describe(jamboConfig)](./jambo.command.describe.md) | Describes the command. |
+|  [describe(jamboConfig)?](./jambo.command.describe.md) | <i>(Optional)</i> Describes the command. |
 |  [getAlias()](./jambo.command.getalias.md) | The alias for the command. |
 |  [getShortDescription()](./jambo.command.getshortdescription.md) | A short, one sentence description of the command. This description appears as part of the help text in the CLI. |
 

--- a/etc/jambo.api.md
+++ b/etc/jambo.api.md
@@ -48,7 +48,7 @@ export interface Command<T extends ArgumentMetadataRecord> {
     // (undocumented)
     new (...args: any[]): CommandExecutable<T>;
     args(): T;
-    describe(jamboConfig: JamboConfig): null | DescribeMetadata<T> | Promise<DescribeMetadata<T>>;
+    describe?(jamboConfig: JamboConfig): null | DescribeMetadata<T> | Promise<DescribeMetadata<T>>;
     getAlias(): string;
     getShortDescription(): string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2641,7 +2641,7 @@
     },
     "@babel/plugin-transform-object-assign": {
       "version": "7.12.1",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.12.1.tgz",
       "integrity": "sha512-geUHn4XwHznRAFiuROTy0Hr7bKbpijJCmr1Svt/VNGhpxmp0OrdxURNpWbOAf94nUbL+xj6gbxRVPHWIbRpRoA==",
       "dev": true,
       "requires": {
@@ -7996,7 +7996,7 @@
     },
     "shell-quote": {
       "version": "1.7.2",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
@@ -8742,7 +8742,7 @@
         "commander": "^2.7.1",
         "lodash.get": "^4.0.0",
         "lodash.isequal": "^4.0.0",
-        "validator": "^8.0.0"
+        "validator": "13.6.0"
       },
       "dependencies": {
         "commander": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8742,7 +8742,7 @@
         "commander": "^2.7.1",
         "lodash.get": "^4.0.0",
         "lodash.isequal": "^4.0.0",
-        "validator": "13.6.0"
+        "validator": "^8.0.0"
       },
       "dependencies": {
         "commander": {

--- a/package.json
+++ b/package.json
@@ -3,13 +3,12 @@
   "version": "1.12.0",
   "description": "A JAMStack implementation using Handlebars",
   "main": "./lib/exports.js",
-  "types": "dist/jambo.d.ts",
+  "types": "./lib/cli.d.ts",
   "files": [
     "lib"
   ],
   "scripts": {
     "test": "eslint . && jest",
-    "tsc": "tsc",
     "build": "tsc && npm run api-extractor && npm run generate-docs",
     "build-ci": "tsc && npm run api-extractor-ci && npm run generate-docs",
     "api-extractor": "api-extractor run --local --verbose",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "1.12.0",
   "description": "A JAMStack implementation using Handlebars",
   "main": "./lib/exports.js",
-  "types": "./lib/cli.d.ts",
+  "types": "dist/jambo.d.ts",
   "files": [
     "lib"
   ],
   "scripts": {
     "test": "eslint . && jest",
+    "tsc": "tsc",
     "build": "tsc && npm run api-extractor && npm run generate-docs",
     "build-ci": "tsc && npm run api-extractor-ci && npm run generate-docs",
     "api-extractor": "api-extractor run --local --verbose",

--- a/src/commands/LegacyAdapter.ts
+++ b/src/commands/LegacyAdapter.ts
@@ -63,7 +63,7 @@ function isValidCustomCommand(commandClass) {
 
     const staticMethods = getMethods(commandClass);
     const expectedStaticMethods =
-      ['getAlias', 'getShortDescription', 'args', 'describe'];
+      ['getAlias', 'getShortDescription', 'args'];
 
     const instanceMethods = getMethods(commandClass.prototype);
     const expectedInstanceMethods = ['execute'];

--- a/src/commands/adaptCommandWithLegacyArgs.ts
+++ b/src/commands/adaptCommandWithLegacyArgs.ts
@@ -53,7 +53,7 @@ export default function adaptCommandWithLegacyArgs(
       return commandToWrap.getShortDescription();
     }
     static describe(jamboConfig: JamboConfig) {
-      return commandToWrap.describe?.(jamboConfig);
+      return commandToWrap.describe?.(jamboConfig) ?? null;
     }
 
     execute(args: any) {

--- a/src/commands/adaptCommandWithLegacyArgs.ts
+++ b/src/commands/adaptCommandWithLegacyArgs.ts
@@ -53,10 +53,7 @@ export default function adaptCommandWithLegacyArgs(
       return commandToWrap.getShortDescription();
     }
     static describe(jamboConfig: JamboConfig) {
-      if (!commandToWrap.describe) {
-        return null;
-      }
-      return commandToWrap.describe(jamboConfig);
+      return commandToWrap.describe?.(jamboConfig);
     }
 
     execute(args: any) {

--- a/src/commands/adaptCommandWithLegacyArgs.ts
+++ b/src/commands/adaptCommandWithLegacyArgs.ts
@@ -53,6 +53,9 @@ export default function adaptCommandWithLegacyArgs(
       return commandToWrap.getShortDescription();
     }
     static describe(jamboConfig: JamboConfig) {
+      if (!commandToWrap.describe) {
+        return null;
+      }
       return commandToWrap.describe(jamboConfig);
     }
 

--- a/src/commands/adaptLegacyCommand.ts
+++ b/src/commands/adaptLegacyCommand.ts
@@ -44,7 +44,7 @@ export default function adaptLegacyCommand(commandCreator: LegacyCommand): Comma
     }
 
     static describe(jamboConfig) {
-      return commandCreator(jamboConfig).describe?.();
+      return commandCreator(jamboConfig).describe?.() ?? null;
     }
 
     execute(args: any) {

--- a/src/commands/adaptLegacyCommand.ts
+++ b/src/commands/adaptLegacyCommand.ts
@@ -12,7 +12,7 @@ export type LegacyCommand = (jamboConfig: JamboConfig) => {
   getAlias: () => string
   getShortDescription: () => string
   args: () => Record<string, LegacyArgumentMetadata>
-  describe: () => any
+  describe?: () => any
   execute: (params: any) => void
 }
 
@@ -44,7 +44,7 @@ export default function adaptLegacyCommand(commandCreator: LegacyCommand): Comma
     }
 
     static describe(jamboConfig) {
-      return commandCreator(jamboConfig).describe();
+      return commandCreator(jamboConfig).describe?.();
     }
 
     execute(args: any) {

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -54,7 +54,7 @@ const DescribeCommand: Command<any> = class {
       const recordDescription = (value: DescribeMetadata) => {
         descriptions[command.getAlias()] = this.calculateDescribeOutput(command.args(), value);
       }
-      const describeValue = command.describe && command.describe(this._jamboConfig);
+      const describeValue = command.describe?.(this._jamboConfig);
       if (!describeValue) {
         return;
       }

--- a/src/commands/describe/describecommand.ts
+++ b/src/commands/describe/describecommand.ts
@@ -54,7 +54,7 @@ const DescribeCommand: Command<any> = class {
       const recordDescription = (value: DescribeMetadata) => {
         descriptions[command.getAlias()] = this.calculateDescribeOutput(command.args(), value);
       }
-      const describeValue = command.describe(this._jamboConfig);
+      const describeValue = command.describe && command.describe(this._jamboConfig);
       if (!describeValue) {
         return;
       }

--- a/src/models/commands/Command.ts
+++ b/src/models/commands/Command.ts
@@ -36,5 +36,5 @@ export default interface Command<T extends ArgumentMetadataRecord> {
    * @returns description of the card command, including paths to
    *          all available cards. returning null causes no description to be output.
    */
-  describe(jamboConfig: JamboConfig): null | DescribeMetadata<T> | Promise<DescribeMetadata<T>>;
+  describe?(jamboConfig: JamboConfig): null | DescribeMetadata<T> | Promise<DescribeMetadata<T>>;
 }

--- a/tests/commands/adaptCommandWithLegacyArgs.ts
+++ b/tests/commands/adaptCommandWithLegacyArgs.ts
@@ -31,6 +31,6 @@ describe('can adapt a command with static methods that uses legacy argument meta
   it('importing a legacy command without a describe function works', () => {
     const commandNoDescribe: CommandClassWithLegacyArguments = TestCommandWithLegacyArgsNoDescribe;
     const adaptedCommandNoDescribe = adaptCommandWithLegacyArgs(commandNoDescribe);
-    expect(adaptedCommandNoDescribe.describe({})).toBeUndefined();
+    expect(adaptedCommandNoDescribe.describe({})).toBeNull();
   });
 });

--- a/tests/commands/adaptCommandWithLegacyArgs.ts
+++ b/tests/commands/adaptCommandWithLegacyArgs.ts
@@ -3,6 +3,7 @@ import adaptCommandWithLegacyArgs, {
 } from '../../src/commands/adaptCommandWithLegacyArgs';
 import { StringArrayMetadata, StringMetadata } from '../../src/models/commands/concreteargumentmetadata';
 import TestCommandWithLegacyArgs from '../fixtures/customcommands/TestCommandWithLegacyArgs';
+import TestCommandWithLegacyArgsNoDescribe from '../fixtures/customcommands/TestLegacyCommandWithLegacyArgsNoDescribe';
 
 describe('can adapt a command with static methods that uses legacy argument metadata', () => {
   const command: CommandClassWithLegacyArguments = TestCommandWithLegacyArgs;
@@ -25,5 +26,11 @@ describe('can adapt a command with static methods that uses legacy argument meta
     const instance = new adaptedCommand({});
     expect(typeof instance.execute).toEqual('function');
     instance.execute({});
+  });
+
+  it('importing a legacy command without a describe function works', () => {
+    const commandNoDescribe: CommandClassWithLegacyArguments = TestCommandWithLegacyArgsNoDescribe;
+    const adaptedCommandNoDescribe = adaptCommandWithLegacyArgs(commandNoDescribe);
+    expect(adaptedCommandNoDescribe.describe({})).toBeUndefined();
   });
 });

--- a/tests/commands/adaptLegacyCommand.ts
+++ b/tests/commands/adaptLegacyCommand.ts
@@ -30,6 +30,6 @@ describe('can adapt legacy commands', () => {
   it('importing a legacy command without a describe function works', () => {
     const legacyCommandNoDescribe: LegacyCommand = TestLegacyCommandNoDescribe;
     const adaptedCommandNoDescribe = adaptLegacyCommand(legacyCommandNoDescribe) as CommandClassWithLegacyArguments;
-    expect(adaptedCommandNoDescribe.describe({})).toBeUndefined();
+    expect(adaptedCommandNoDescribe.describe({})).toBeNull();
   });
 });

--- a/tests/commands/adaptLegacyCommand.ts
+++ b/tests/commands/adaptLegacyCommand.ts
@@ -1,6 +1,7 @@
 import { CommandClassWithLegacyArguments } from '../../src/commands/adaptCommandWithLegacyArgs';
 import adaptLegacyCommand, { LegacyCommand } from '../../src/commands/adaptLegacyCommand';
 import TestLegacyCommand from '../fixtures/customcommands/TestLegacyCommand';
+import TestLegacyCommandNoDescribe from '../fixtures/customcommands/TestLegacyCommandNoDescribe';
 
 describe('can adapt legacy commands', () => {
   const legacyCommand: LegacyCommand = TestLegacyCommand;
@@ -24,5 +25,11 @@ describe('can adapt legacy commands', () => {
     const instance = new adaptedCommand({});
     expect(typeof instance.execute).toEqual('function');
     instance.execute({});
+  });
+
+  it('importing a legacy command without a describe function works', () => {
+    const legacyCommandNoDescribe: LegacyCommand = TestLegacyCommandNoDescribe;
+    const adaptedCommandNoDescribe = adaptLegacyCommand(legacyCommandNoDescribe) as CommandClassWithLegacyArguments;
+    expect(adaptedCommandNoDescribe.describe({})).toBeUndefined();
   });
 });

--- a/tests/commands/describe/describecommand.js
+++ b/tests/commands/describe/describecommand.js
@@ -113,3 +113,24 @@ it('deprecated params in a command\'s DescribeMetadata ' +
     }
   });
 })
+
+it('when a describe function is not included, it returns undefined', async () => {
+  const mockCommand = {
+    args() {
+      return {
+        myParam: new StringMetadata({
+          description: 'the theme',
+          isRequired: false,
+          defaultValue: 'dont show me in describe'
+        })
+      }
+    },
+    getAlias() { return 'mocked'; }
+  }
+
+  await new DescribeCommand({}, () => [ mockCommand ]).execute();
+  const descriptions = JSON.parse(consoleSpy.mock.calls[0][0]);
+  consoleSpy.mockClear();
+
+  expect(descriptions.mocked).toBeUndefined();
+})

--- a/tests/fixtures/customcommands/TestLegacyCommandNoDescribe.js
+++ b/tests/fixtures/customcommands/TestLegacyCommandNoDescribe.js
@@ -1,0 +1,32 @@
+const { LegacyArgumentMetadata, LegacyArgumentType } = require('./LegacyArgumentMetadata');
+
+/**
+ * An LegacyCommand implementation for unit tests which does not contain describe
+ * This is an example of our VERY FIRST version of custom commands, before updating all methods but
+ * execute into static methods.
+ */
+class LegacyCommandClass {
+  constructor(jamboConfig) {
+    this.config = jamboConfig;
+  }
+
+  getAlias() {
+    return 'TestLegacyCommand'
+  }
+
+  getShortDescription() {
+    return 'a legacy command for unit tests';
+  }
+
+  args() {
+    return {
+      stringParam: new LegacyArgumentMetadata(LegacyArgumentType.STRING, 'some string param', true),
+      arrayOfStrings: new LegacyArgumentMetadata(
+        LegacyArgumentType.ARRAY, 'an array of strings param', false, [], LegacyArgumentType.STRING)
+    }
+  }
+
+  execute() {}
+}
+
+module.exports = jamboConfig => new LegacyCommandClass(jamboConfig);

--- a/tests/fixtures/customcommands/TestLegacyCommandWithLegacyArgsNoDescribe.js
+++ b/tests/fixtures/customcommands/TestLegacyCommandWithLegacyArgsNoDescribe.js
@@ -1,0 +1,31 @@
+const { LegacyArgumentMetadata, LegacyArgumentType } = require('./LegacyArgumentMetadata');
+
+/**
+ * An LegacyCommand implementation for unit tests without a describe method.
+ * This is an example of our second version of custom commands. This version updated the
+ * Command interface to have static methods for all methods except execute, but
+ * still uses ArgumentMetadata with getters.
+ */
+module.exports = class CommandClass {
+  constructor(jamboConfig) {
+    this.config = jamboConfig;
+  }
+
+  static getAlias() {
+    return 'TestCommandWithLegacyArgs'
+  }
+
+  static getShortDescription() {
+    return 'a command with legacy args';
+  }
+
+  static args() {
+    return {
+      stringParam: new LegacyArgumentMetadata(LegacyArgumentType.STRING, 'some string param', true),
+      arrayOfStrings: new LegacyArgumentMetadata(
+        LegacyArgumentType.ARRAY, 'an array of strings param', false, [], LegacyArgumentType.STRING)
+    }
+  }
+
+  execute() {}
+}


### PR DESCRIPTION
Make describe optional including for the legacy command interfaces

J=SLAP-1598
TEST=manual, auto

Use the theme test site and comment out the describe method. See that the command no longer shows up in the describe output. Test that when describe is not included, the command still works. 

Add unit test coverage