### PR TITLE
add types for file-system dependency

### DIFF
--- a/src/commands/build/pagewriter.ts
+++ b/src/commands/build/pagewriter.ts
@@ -1,4 +1,4 @@
-import fs from 'file-system';
+import fs from 'fs';
 import hbs from 'handlebars';
 import path from 'path';
 import PageSet from '../../models/pageset';

--- a/src/commands/build/sitesgenerator.ts
+++ b/src/commands/build/sitesgenerator.ts
@@ -1,4 +1,5 @@
-import fs from 'file-system';
+import fileSystem from 'file-system';
+import fs from 'fs';
 import hbs from 'handlebars';
 import path from 'path';
 import { parse } from 'comment-json';
@@ -51,7 +52,7 @@ class SitesGenerator {
 
     info('Reading config files');
     const configNameToRawConfig = {};
-    fs.recurseSync(config.dirs.config, (path, relative, filename) => {
+    fileSystem.recurseSync(config.dirs.config, (path, relative, filename) => {
       if (isValidFile(filename)) {
         const configName = stripExtension(relative);
         try {
@@ -75,7 +76,7 @@ class SitesGenerator {
     const hasLocalizationConfig = configRegistry.getLocalizationConfig().hasConfig();
 
     const pageTemplates = [];
-    fs.recurseSync(config.dirs.pages, (path, _relative, filename) => {
+    fileSystem.recurseSync(config.dirs.pages, (path, _relative, filename) => {
       if (isValidFile(filename)) {
         const fileContents = fs.readFileSync(path).toString();
         pageTemplates.push(new PageTemplate({
@@ -253,7 +254,7 @@ class SitesGenerator {
   _containsPreservedFiles(directory: string, preservedFiles: Array<any>) {
     let hasPreservedFile = false;
     if (preservedFiles) {
-      fs.recurseSync(directory, (path) => {
+      fileSystem.recurseSync(directory, (path) => {
         if (this._isPreserved(path, preservedFiles)) {
           hasPreservedFile = true;
         }
@@ -275,7 +276,7 @@ class SitesGenerator {
    */
   _createStaticOutput(staticDirs: Array<any>, outputDir: string) {
     for (const staticDir of staticDirs) {
-      fs.recurseSync(staticDir, (path, relative) => {
+      fileSystem.recurseSync(staticDir, (path, relative) => {
         if (fs.lstatSync(path).isFile()) {
           fs.copyFileSync(path, `${outputDir}/static/${relative}`);
         }

--- a/src/commands/build/templatedatavalidator.ts
+++ b/src/commands/build/templatedatavalidator.ts
@@ -1,4 +1,4 @@
-import fs from 'file-system';
+import fs from 'fs';
 import UserError from '../../errors/usererror';
 import { info } from '../../utils/logger';
 
@@ -8,7 +8,7 @@ import { info } from '../../utils/logger';
  */
 export default class TemplateDataValidator {
   private _templateDataValidationHook: string
-  private _hasHook: string
+  private _hasHook: boolean
 
   constructor(templateDataValidationHook) {
     /**

--- a/src/commands/init/repositoryscaffolder.ts
+++ b/src/commands/init/repositoryscaffolder.ts
@@ -1,5 +1,5 @@
 import ThemeImporter from '../import/themeimporter';
-import fs from 'file-system';
+import fs from 'fs';
 import process from 'process';
 import simpleGit from 'simple-git/promise';
 import SystemError from '../../errors/systemerror';

--- a/src/commands/override/themeshadower.ts
+++ b/src/commands/override/themeshadower.ts
@@ -1,4 +1,5 @@
-import fs from 'file-system';
+import fs from 'fs';
+import fileSystem from 'file-system';
 import { addToPartials } from '../../utils/jamboconfigutils';
 import UserError from '../../errors/usererror';
 import { JamboConfig } from '../../models/JamboConfig';
@@ -70,7 +71,7 @@ export class ThemeShadower {
     if (fs.lstatSync(fullPathInThemes).isFile()) {
       fs.copyFileSync(fullPathInThemes, localShadowPath);
     } else if (fs.lstatSync(fullPathInThemes).isDirectory()) {
-      fs.recurseSync(fullPathInThemes, (path, relative) => {
+      fileSystem.recurseSync(fullPathInThemes, (path, relative) => {
         if (fs.lstatSync(path).isFile()) {
           fs.copyFileSync(path, `${localShadowPath}/${relative}`);
         } else {

--- a/src/commands/page/add/pagescaffolder.ts
+++ b/src/commands/page/add/pagescaffolder.ts
@@ -1,4 +1,4 @@
-import fs from 'file-system';
+import fs from 'fs';
 import { parse, stringify } from 'comment-json';
 import { JamboConfig } from '../../../models/JamboConfig';
 import PageConfiguration from './pageconfiguration';

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module 'file-system' {
+  type RecurseSyncCallback = (filePath: string, relativePath: string, filename: string) => void;
+  export function recurseSync(directoryPath: string, callback: RecurseSyncCallback): string;
+}

--- a/src/models/JamboConfig.ts
+++ b/src/models/JamboConfig.ts
@@ -8,8 +8,8 @@ export interface JamboConfig {
     themes: string
     config: string
     output: string
+    pages: string
     partials: string[]
-    pages?: string
     preservedFiles?: string[]
     translations?: string
   }

--- a/src/models/JamboConfig.ts
+++ b/src/models/JamboConfig.ts
@@ -8,8 +8,8 @@ export interface JamboConfig {
     themes: string
     config: string
     output: string
-    pages: string
     partials: string[]
+    pages?: string
     preservedFiles?: string[]
     translations?: string
   }

--- a/src/models/partialsregistry.ts
+++ b/src/models/partialsregistry.ts
@@ -1,4 +1,5 @@
-import fs from 'file-system';
+import fs from 'fs';
+import fileSystem from 'file-system';
 import { isValidFile, isValidPartialPath } from '../utils/fileutils';
 import Partial from './partial';
 
@@ -58,7 +59,7 @@ export default class PartialsRegistry {
     const partials = [];
     const pathExists = fs.existsSync(partialsPath);
     if (pathExists && !fs.lstatSync(partialsPath).isFile()) {
-      fs.recurseSync(partialsPath, (path, relative, filename) => {
+      fileSystem.recurseSync(partialsPath, (path, relative, filename) => {
         if (isValidFile(filename) && isValidPartialPath(path)) {
           const partialPath = useFullyQualifiedName
             ? path

--- a/src/utils/jamboconfigutils.ts
+++ b/src/utils/jamboconfigutils.ts
@@ -1,4 +1,4 @@
-import fs from 'file-system';
+import fs from 'fs';
 import path from 'path';
 import mergeOptions from 'merge-options';
 import { parse, stringify } from 'comment-json';


### PR DESCRIPTION
file-system has not been updated in 5 years, and does not have
typescript types.
This commit adds some custom types for it, and refactors code to use
vanilla fs where possible, i.e. everything that is not recurseSync
because that was all we were using file-system for. One type check error was found
this way.
Added a github workflow to automatically update api-extract/documenter on pull requests. 

J=SLAP-1599
TEST=none