### PR TITLE
add i18next specific locale formatting to support chinese

### DIFF
--- a/src/utils/i18nutils.ts
+++ b/src/utils/i18nutils.ts
@@ -1,12 +1,11 @@
 import UserError from '../errors/usererror';
 
+type ParsedLocale = { language: string, modifier?: string, region?: string };
+
 /**
  * Normalizes a locale code
- *
- * @param {string} localeCode
- * @returns {string}
  */
-export function canonicalizeLocale(localeCode: string) {
+export function canonicalizeLocale(localeCode: string): string {
   if (!localeCode) {
     return;
   }
@@ -17,11 +16,8 @@ export function canonicalizeLocale(localeCode: string) {
 /**
  * Parses a locale code into its constituent parts.
  * Performs case formatting on the result.
- *
- * @param {string} localeCode
- * @returns { language: string, modifier?: string, region?: string }
  */
-export function parseLocale(localeCode) {
+export function parseLocale(localeCode: string): ParsedLocale {
   const localeCodeSections = localeCode.replace(/-/g, '_').split('_');
   const language = localeCodeSections[0].toLowerCase();
   const parseModifierAndRegion = () => {
@@ -69,12 +65,11 @@ export function parseLocale(localeCode) {
 /**
  * Formats a locale code given its constituent parts.
  *
- * @param {string} language zh in zh-Hans_CH
- * @param {string?} modifier Hans in zh-Hans_CH
- * @param {string?} region CH in zh-Hans_CH
- * @returns
+ * @param language zh in zh-Hans_CH
+ * @param modifier Hans in zh-Hans_CH
+ * @param region CH in zh-Hans_CH
  */
-function formatLocale(language, modifier, region) {
+function formatLocale(language: string, modifier?: string, region?: string): string {
   let result = language.toLowerCase();
   if (modifier) {
     result += '-' + modifier;

--- a/tests/i18n/translator/translator.js
+++ b/tests/i18n/translator/translator.js
@@ -254,3 +254,23 @@ describe('translations with multiple plural forms (Lithuanian)', () => {
     expect(translation).toEqual(expectedResult);
   });
 });
+
+describe('formats chinese locales and resources in i18next style instead of jambo style', () => {
+  const jamboStyleLocale = 'zh-Hant_TW';
+  const translations = {
+    [jamboStyleLocale]: {
+      translation: {
+        chinese: '中文',
+        rockOneFly: '石一飛'
+      }
+    }
+  };
+  let translator;
+  beforeAll(async () => {
+    translator = await Translator.create(jamboStyleLocale, [], translations);
+  });
+  it('can translate to chinese', () => {
+    expect(translator.translate('chinese')).toEqual('中文');
+    expect(translator.translate('rockOneFly')).toEqual('石一飛');
+  });
+});


### PR DESCRIPTION
Prior to this, certain kinds of chinese locales would not be translated properly.
i18next will silently refuse to translate for you if your locale has any underscores in it.

J=TECHOPS-2885
TEST=manual,auto

tested I can do zh-Hant_TW translations in the theme