### PR TITLE
Use reusable workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,24 +9,11 @@ on:
   pull_request:
 
 jobs:
-  Coveralls:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: git config --global user.email "slapshot@yext.com"
-    - run: git config --global user.name "Jambo run-tests.yml"
-    - run: npx jest --config=jest-coverage.json
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+  call_code_coverage:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/coverage.yml@v1
+    with:
+      test_script: 'git config --global user.email "slapshot@yext.com"
+        && git config --global user.name "Jambo run-tests.yml"
+        && npx jest --config=jest-coverage.json'
+    secrets:
+      caller_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,22 +6,9 @@ name: Run Tests
 on: [push, pull_request]
 
 jobs:
-  tests:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x, 16.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: git config --global user.email "slapshot@yext.com"
-    - run: git config --global user.name "Jambo run-tests.yml"
-    - run: npm run build
-    - run: npm test
+  call_run_tests:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
+    with:
+      build_script: 'git config --global user.email "slapshot@yext.com"
+        && git config --global user.name "Jambo run-tests.yml"
+        && npm run build'

--- a/.github/workflows/sync_develop_and_main.yml
+++ b/.github/workflows/sync_develop_and_main.yml
@@ -1,27 +1,11 @@
-name: create PR from main to develop
+name: Create PR from main to develop
 
 on:
   push:
     branches: [main, master]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
-  createPullRequest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: extract package version
-        id: vars
-        run: |
-          PACKAGE_VERSION="v$(cat ./package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')"
-          echo ::set-output name=tag::${PACKAGE_VERSION}
-      - uses: repo-sync/pull-request@v2
-        with:
-          source_branch: "${{ github.event.repository.default_branch }}"
-          destination_branch: "develop"
-          pr_title: "Merge ${{ github.event.repository.default_branch }} (${{ steps.vars.outputs.tag }}) into develop"
-          pr_body: "Merge ${{ github.event.repository.default_branch }} (${{ steps.vars.outputs.tag }}) into develop"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+  call_sync_develop_and_main:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/sync_develop_and_main.yml@v1
+    secrets:
+      caller_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -3,25 +3,5 @@ name: Check and Update Repo's documenation
 on: pull_request
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [17.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm run build
-    - name: Update Documentation
-      uses: EndBug/add-and-commit@v7
-      with:
-        message: "Automated update to repo's documentation from github action"
-        add: '*.md'
-        push: true
-        default_author: github_actions
+  call_update_docs:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/update_docs.yml@v1


### PR DESCRIPTION
Update the github workflows to use the callable workflows in the `slapshot-reusable-workflows` repo.

J=SLAP-2005
TEST=auto

- See that the `coverage`, `update_docs`, and `run_tests` workflows run on this PR as expected.
- Test on another branch (`dev/test-reusable-workflows`) and see that docs are updated when needed.
- Fork the repo and commit to master. See that the `sync_develop_and_main` workflow creates a PR as expected.