### PR TITLE
improve error message when a page config cannot be parsed

### DIFF
--- a/src/commands/build/sitesgenerator.js
+++ b/src/commands/build/sitesgenerator.js
@@ -21,7 +21,7 @@ const registerCustomHbsHelpers = require('../../handlebars/registercustomhbshelp
 const SystemError = require('../../errors/systemerror');
 const Translator = require('../../i18n/translator/translator');
 const UserError = require('../../errors/usererror');
-const { info } = require('../../utils/logger');
+const { info, error } = require('../../utils/logger');
 
 class SitesGenerator {
   constructor(jamboConfig) {
@@ -59,10 +59,12 @@ class SitesGenerator {
             true
           );
         } catch (err) {
-          if (err instanceof SyntaxError) {
+          if (err instanceof SyntaxError ||
+            err.message && err.message.includes('Invalid regular expression')) {
             throw new UserError(
-              `JSON SyntaxError: could not parse file ${path}`, err.stack);
+              `Could not parse JSON page config at ${path}`, err.stack);
           } else {
+            error('Error parsing JSON page config at', path);
             throw err;
           }
         }


### PR DESCRIPTION
It now always says which file could not be parsed.

J=SLAP-2134
TEST=manual

intentionally make a syntax error in a page config in the theme's test site
see the expected error message