### PR TITLE
Pin gettext-extractor to avoid a breaking change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4000,9 +4000,9 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "requires": {
         "@types/minimatch": "*",
         "@types/node": "*"
@@ -4135,9 +4135,9 @@
       }
     },
     "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "@types/node": {
       "version": "14.0.14",
@@ -5874,9 +5874,9 @@
       }
     },
     "gettext-extractor": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.5.3.tgz",
-      "integrity": "sha512-9EgJ+hmbtAbATdMIvCj4WnrkeDWH6fv1z+IJJ1XCxdcUMGx6JQdVVFTdzJkSyIHh4td53ngoB5EQbavbKJU9Og==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.6.2.tgz",
+      "integrity": "sha512-EzDL4re46WHR9XHCSsTtrTgd5FCPMtUkK3WpU69dhbYqcWKBFE5h2Sx6EXWjJ3KQLsMxQ/NcoAfg1pz6TqrRjA==",
       "requires": {
         "@types/glob": "5 - 7",
         "@types/parse5": "^5",
@@ -9440,9 +9440,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg=="
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "comment-json": "^3.0.2",
     "file-system": "^2.2.2",
     "fs-extra": "^8.1.0",
-    "gettext-extractor": "^3.5.2",
+    "gettext-extractor": "~3.6.2",
     "glob-to-regexp": "^0.4.1",
     "globby": "^11.0.1",
     "handlebars": "^4.7.8",


### PR DESCRIPTION
This PR pins `gettext-extractor` to a minor version (v3.6) prior to [v3.7.1](https://github.com/lukasgeiter/gettext-extractor/releases/tag/v3.7.1) that was released with a change that breaks Jambo upgrades performed with Node 12 and npm 6. This change adds support for TS v5 and removes support for older TS versions. When upgrading Jambo via the code editor, the version of `gettext-extractor` was being updated to the latest version, which would in turn upgrade to the latest version of TS (v5.4.5) in the acceptable range (4-5). But, v5.4.5 of TS requires Node 14 or higher, causing an error when using `engine-strict=true` in the `.npmrc`. Also, because the code editor by default uses Node 12 and npm 6, we can't use `overrides` in the package.json to pin the transitive TS dep to v4, which was released in npm 8.

J=WAT-4073
TEST=manual

Tried locally pointing the Theme to my local Jambo repo and saw that install was successful with `engine-strict=true`, when it gives the same error reported in the Slack thread when trying to force install an older version of Jambo.