### PR TITLE
Version 1.12.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jambo",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "description": "A JAMStack implementation using Handlebars",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Fixes
- Fixed an error where upgrading to the latest version of Jambo was incompatible with Node 12 (#335)