### PR TITLE
feat: add OIDC publishing and CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @yext/watson

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,13 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  id-token: write # Required for OIDC
+
+jobs:
+  publish:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/publish.yml@v1


### PR DESCRIPTION
This PR adds the OIDC-backed publishin workflow we are adding to all Yext Github repos, as well as adding a CODEOWNERS file to make it explicit who owns this repo.

J=WAT-5073
T=manual

ran with dryRun